### PR TITLE
refactor: 팀 대시보드 쿼리 최적화

### DIFF
--- a/src/main/java/com/toy/nar/app/analysis/service/TeamDashboardService.java
+++ b/src/main/java/com/toy/nar/app/analysis/service/TeamDashboardService.java
@@ -10,7 +10,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,9 +49,13 @@ public class TeamDashboardService {
 	private final GameTeamStatRepository gameTeamStatRepository;
 	private final GameParticipantRepository gameParticipantRepository;
 	private final BanRepository banRepository;
+	
+	// Spring Boot의 기본 비동기 TaskExecutor를 주입받아 사용 (가용 스레드 확보용)
+	private final Executor applicationTaskExecutor;
 
 	public TeamDashboardResponse getTeamDashboard(Long teamId, String league, Integer year, String split, String patch,
 			String side) {
+		// 메인 스레드에서 즉시 조회
 		Team team = teamRepository.findById(teamId)
 				.orElseThrow(() -> new IllegalArgumentException("Team not found: " + teamId));
 
@@ -58,38 +65,54 @@ public class TeamDashboardService {
 		String normalizedSplit = normalizeBlank(split);
 		String normalizedPatch = normalizeBlank(patch);
 
-		TeamGameSummaryDto summary = buildSummary(
-				teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, null);
+		// 각 독립적인 통계 집계를 비동기로 실행 (Scatter)
+		CompletableFuture<TeamGameSummaryDto> summaryFuture = CompletableFuture.supplyAsync(() -> 
+				buildSummary(teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, null), 
+				applicationTaskExecutor);
 
-		List<TeamPlayerRecordDto> playerRecords = buildPlayerRecords(
-				teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, normalizedSide);
+		CompletableFuture<List<TeamPlayerRecordDto>> playerRecordsFuture = CompletableFuture.supplyAsync(() -> 
+				buildPlayerRecords(teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, normalizedSide), 
+				applicationTaskExecutor);
 
-		TeamBanSideStatsDto bannedByTeam = buildBanSideStats(
-				teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, summary.getSetsPlayed(), true);
-		TeamBanSideStatsDto bannedAgainst = buildBanSideStats(
-				teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, summary.getSetsPlayed(), false);
+		CompletableFuture<TeamPlayedChampionSideStatsDto> playedChampionsFuture = CompletableFuture.supplyAsync(() -> 
+				buildPlayedChampionSideStats(teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch), 
+				applicationTaskExecutor);
 
-		TeamPlayedChampionSideStatsDto playedChampions = buildPlayedChampionSideStats(
-				teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch);
+		// 밴 통계는 요약 통계(setsPlayed)에 의존하므로 summaryFuture 완료 이후 후속 작업으로 실행
+		CompletableFuture<TeamBanSideStatsDto> bannedByTeamFuture = summaryFuture.thenApplyAsync(summary -> 
+				buildBanSideStats(teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, summary.getSetsPlayed(), true), 
+				applicationTaskExecutor);
 
-		return TeamDashboardResponse.builder()
-				.teamId(team.getId())
-				.teamName(team.getName())
-				.teamCode(team.getCode())
-				.teamImageUrl(team.getImageUrl())
-				.leagueName(leagueName)
-				.appliedFilter(TeamDashboardFilterDto.builder()
-						.year(normalizedYear)
-						.split(normalizedSplit)
-						.patch(normalizedPatch)
-						.side(normalizedSide != null ? normalizedSide : "ALL")
-						.build())
-				.gameSummary(summary)
-				.playerRecords(playerRecords)
-				.bannedAgainst(bannedAgainst)
-				.bannedByTeam(bannedByTeam)
-				.playedChampions(playedChampions)
-				.build();
+		CompletableFuture<TeamBanSideStatsDto> bannedAgainstFuture = summaryFuture.thenApplyAsync(summary -> 
+				buildBanSideStats(teamId, leagueName, normalizedYear, normalizedSplit, normalizedPatch, summary.getSetsPlayed(), false), 
+				applicationTaskExecutor);
+
+		// 모든 비동기 작업이 완료될 때까지 대기 (Gather)
+		CompletableFuture.allOf(summaryFuture, playerRecordsFuture, playedChampionsFuture, bannedByTeamFuture, bannedAgainstFuture).join();
+
+		try {
+			// 완성된 데이터 조립 후 리턴
+			return TeamDashboardResponse.builder()
+					.teamId(team.getId())
+					.teamName(team.getName())
+					.teamCode(team.getCode())
+					.teamImageUrl(team.getImageUrl())
+					.leagueName(leagueName)
+					.appliedFilter(TeamDashboardFilterDto.builder()
+							.year(normalizedYear)
+							.split(normalizedSplit)
+							.patch(normalizedPatch)
+							.side(normalizedSide != null ? normalizedSide : "ALL")
+							.build())
+					.gameSummary(summaryFuture.get())
+					.playerRecords(playerRecordsFuture.get())
+					.bannedAgainst(bannedAgainstFuture.get())
+					.bannedByTeam(bannedByTeamFuture.get())
+					.playedChampions(playedChampionsFuture.get())
+					.build();
+		} catch (Exception e) {
+			throw new RuntimeException("비동기 데이터 조합 중 오류가 발생했습니다.", e);
+		}
 	}
 
 	private TeamGameSummaryDto buildSummary(Long teamId, String leagueName, Integer year, String split, String patch,
@@ -184,7 +207,7 @@ public class TeamDashboardService {
 			if (result.size() >= TOP_BAN_LIMIT) {
 				break;
 			}
-			int banCount = toInt(row[4]);
+			int banCount = toInt(row[5]); // 4 -> 5 로 변경 (side 필드 추가됨)
 			double rate = denominator > 0 ? (banCount * 100.0) / denominator : 0;
 			result.add(TeamBanStatDto.builder()
 					.championId(toLong(row[0]))
@@ -200,26 +223,96 @@ public class TeamDashboardService {
 
 	private TeamBanSideStatsDto buildBanSideStats(Long teamId, String leagueName, Integer year, String split, String patch,
 			Integer setsPlayed, boolean bannedByTeam) {
+		
+		List<Object[]> rows = bannedByTeam 
+				? banRepository.findBansByTeamGroupedBySide(teamId, leagueName, year, split, patch)
+				: banRepository.findBansAgainstTeamGroupedBySide(teamId, leagueName, year, split, patch);
+				
+		List<Object[]> blueRows = new ArrayList<>();
+		List<Object[]> redRows = new ArrayList<>();
+		Map<Long, Object[]> allStatsMap = new LinkedHashMap<>();
+
+		for (Object[] row : rows) {
+			String side = toString(row[4]);
+			int count = toInt(row[5]);
+			
+			if (SIDE_BLUE.equalsIgnoreCase(side)) {
+				blueRows.add(row);
+			} else if (SIDE_RED.equalsIgnoreCase(side)) {
+				redRows.add(row);
+			}
+			
+			// 전체(ALL) 집계
+			Long champId = toLong(row[0]);
+			Object[] existing = allStatsMap.get(champId);
+			if (existing == null) {
+				allStatsMap.put(champId, new Object[] { row[0], row[1], row[2], row[3], "ALL", count });
+			} else {
+				existing[5] = toInt(existing[5]) + count;
+			}
+		}
+
+		List<Object[]> allRows = new ArrayList<>(allStatsMap.values());
+		allRows.sort((a, b) -> {
+			int countCompare = Integer.compare(toInt(b[5]), toInt(a[5]));
+			return countCompare != 0 ? countCompare : toString(a[2]).compareTo(toString(b[2]));
+		});
+		blueRows.sort((a, b) -> {
+			int countCompare = Integer.compare(toInt(b[5]), toInt(a[5]));
+			return countCompare != 0 ? countCompare : toString(a[2]).compareTo(toString(b[2]));
+		});
+		redRows.sort((a, b) -> {
+			int countCompare = Integer.compare(toInt(b[5]), toInt(a[5]));
+			return countCompare != 0 ? countCompare : toString(a[2]).compareTo(toString(b[2]));
+		});
+
 		return TeamBanSideStatsDto.builder()
-				.all(buildBanStats(fetchBanRows(teamId, leagueName, year, split, patch, null, bannedByTeam), setsPlayed))
-				.blue(buildBanStats(fetchBanRows(teamId, leagueName, year, split, patch, SIDE_BLUE, bannedByTeam), setsPlayed))
-				.red(buildBanStats(fetchBanRows(teamId, leagueName, year, split, patch, SIDE_RED, bannedByTeam), setsPlayed))
+				.all(buildBanStats(allRows, setsPlayed))
+				.blue(buildBanStats(blueRows, setsPlayed))
+				.red(buildBanStats(redRows, setsPlayed))
 				.build();
 	}
 
-	private List<Object[]> fetchBanRows(Long teamId, String leagueName, Integer year, String split, String patch,
-			String side, boolean bannedByTeam) {
-		if (bannedByTeam) {
-			return banRepository.findBansByTeamWithFilters(teamId, leagueName, year, split, patch, side);
+	private TeamPlayedChampionSideStatsDto buildPlayedChampionSideStats(Long teamId, String leagueName, Integer year, String split, String patch) {
+		List<Object[]> rows = gameParticipantRepository.findTeamPlayedChampionsGroupedBySide(teamId, leagueName, year, split, patch);
+		
+		List<Object[]> blueRows = new ArrayList<>();
+		List<Object[]> redRows = new ArrayList<>();
+		Map<String, Object[]> allRowsMap = new LinkedHashMap<>();
+
+		for (Object[] row : rows) {
+			String side = toString(row[14]);
+			if (SIDE_BLUE.equalsIgnoreCase(side)) blueRows.add(row);
+			if (SIDE_RED.equalsIgnoreCase(side)) redRows.add(row);
+			
+			String key = toLong(row[0]) + ":" + toString(row[3]) + ":" + toLong(row[4]); // playerId:position:championId
+			Object[] existing = allRowsMap.get(key);
+			if (existing == null) {
+				Object[] newRow = new Object[15];
+				System.arraycopy(row, 0, newRow, 0, row.length);
+				allRowsMap.put(key, newRow);
+			} else {
+				existing[8] = toInt(existing[8]) + toInt(row[8]);
+				existing[9] = toInt(existing[9]) + toInt(row[9]);
+				existing[10] = toDouble(existing[10]) + toDouble(row[10]);
+				existing[11] = toDouble(existing[11]) + toDouble(row[11]);
+				existing[12] = toDouble(existing[12]) + toDouble(row[12]);
+				Timestamp t1 = (Timestamp) existing[13];
+				Timestamp t2 = (Timestamp) row[13];
+				if (t2 != null && (t1 == null || t2.after(t1))) {
+					existing[13] = t2;
+				}
+			}
 		}
-		return banRepository.findBansAgainstTeamWithFilters(teamId, leagueName, year, split, patch, side);
+
+		return TeamPlayedChampionSideStatsDto.builder()
+				.all(buildPlayedChampionsFromRows(new ArrayList<>(allRowsMap.values())))
+				.blue(buildPlayedChampionsFromRows(blueRows))
+				.red(buildPlayedChampionsFromRows(redRows))
+				.build();
 	}
 
-	private List<TeamPlayedChampionPlayerDto> buildPlayedChampions(Long teamId, String leagueName, Integer year,
-			String split, String patch, String side) {
-		List<Object[]> rows = gameParticipantRepository.findTeamPlayedChampions(teamId, leagueName, year, split, patch,
-				side);
-
+	private List<TeamPlayedChampionPlayerDto> buildPlayedChampionsFromRows(List<Object[]> rows) {
 		Map<String, TeamPlayedChampionPlayerDto.TeamPlayedChampionPlayerDtoBuilder> playerBuilderByKey = new LinkedHashMap<>();
 		Map<String, List<TeamPlayedChampionStatDto>> championListByPlayerKey = new LinkedHashMap<>();
 
@@ -259,21 +352,36 @@ public class TeamDashboardService {
 		List<TeamPlayedChampionPlayerDto> result = new ArrayList<>();
 		for (Map.Entry<String, TeamPlayedChampionPlayerDto.TeamPlayedChampionPlayerDtoBuilder> entry : playerBuilderByKey
 				.entrySet()) {
-			List<TeamPlayedChampionStatDto> champions = championListByPlayerKey.getOrDefault(entry.getKey(), List.of());
-			result.add(entry.getValue()
-					.champions(champions)
-					.build());
+			List<TeamPlayedChampionStatDto> champions = championListByPlayerKey.getOrDefault(entry.getKey(),
+					new ArrayList<>());
+					
+			champions.sort((a, b) -> {
+				int cmp = Integer.compare(b.getGamesPlayed(), a.getGamesPlayed());
+				if (cmp != 0) return cmp;
+				return a.getChampionNameEn().compareTo(b.getChampionNameEn());
+			});
+			
+			result.add(entry.getValue().champions(champions).build());
 		}
+
+		result.sort((a, b) -> {
+			return Integer.compare(getPositionOrder(a.getPosition()), getPositionOrder(b.getPosition()));
+		});
+
 		return result;
 	}
-
-	private TeamPlayedChampionSideStatsDto buildPlayedChampionSideStats(Long teamId, String leagueName, Integer year,
-			String split, String patch) {
-		return TeamPlayedChampionSideStatsDto.builder()
-				.all(buildPlayedChampions(teamId, leagueName, year, split, patch, null))
-				.blue(buildPlayedChampions(teamId, leagueName, year, split, patch, SIDE_BLUE))
-				.red(buildPlayedChampions(teamId, leagueName, year, split, patch, SIDE_RED))
-				.build();
+	
+	private int getPositionOrder(String position) {
+		switch (position != null ? position.toLowerCase() : "") {
+			case "top": return 1;
+			case "jng": return 2;
+			case "jungle": return 2;
+			case "mid": return 3;
+			case "bot": return 4;
+			case "sup": return 5;
+			case "support": return 5;
+			default: return 99;
+		}
 	}
 
 	private String normalizeLeague(String league) {

--- a/src/main/java/com/toy/nar/domain/game/repository/BanRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/BanRepository.java
@@ -54,6 +54,7 @@ public interface BanRepository extends JpaRepository<Ban, Long> {
 				c.champion_name_kr,
 				c.champion_name_en,
 				c.image_url,
+				gs.side,
 				COUNT(*) AS ban_count
 			FROM bans b
 			JOIN champions c ON c.champion_id = b.banned_champion_id
@@ -62,30 +63,29 @@ public interface BanRepository extends JpaRepository<Ban, Long> {
 			JOIN (
 				SELECT DISTINCT gp.game_id, gp.team_id, UPPER(gp.side) AS side
 				FROM game_participants gp
+				WHERE gp.team_id = :teamId
 			) gs ON gs.game_id = b.game_id AND gs.team_id = b.team_id
 			WHERE b.team_id = :teamId
 			  AND l.league_name = :leagueName
 			  AND (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 			  AND (:split IS NULL OR l.season_split = :split)
 			  AND (:patch IS NULL OR g.patch = :patch)
-			  AND (:side IS NULL OR gs.side = :side)
-			GROUP BY c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url
+			GROUP BY c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url, gs.side
 			ORDER BY ban_count DESC, c.champion_name_en
 			""", nativeQuery = true)
-	List<Object[]> findBansByTeamWithFilters(
+	List<Object[]> findBansByTeamGroupedBySide(
 			@Param("teamId") Long teamId,
 			@Param("leagueName") String leagueName,
 			@Param("year") Integer year,
 			@Param("split") String split,
-			@Param("patch") String patch,
-			@Param("side") String side);
+			@Param("patch") String patch);
 
 	/**
 	 * 팀이 상대에게 밴당한 챔피언 집계.
 	 */
 	@Query(value = """
 			WITH my_games AS (
-				SELECT DISTINCT gp.game_id
+				SELECT DISTINCT gp.game_id, UPPER(gp.side) AS side
 				FROM game_participants gp
 				JOIN games g ON g.game_id = gp.game_id
 				JOIN leagues l ON l.league_id = g.league_id
@@ -94,25 +94,24 @@ public interface BanRepository extends JpaRepository<Ban, Long> {
 				  AND (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 				  AND (:split IS NULL OR l.season_split = :split)
 				  AND (:patch IS NULL OR g.patch = :patch)
-				  AND (:side IS NULL OR UPPER(gp.side) = :side)
 			)
 			SELECT
 				c.champion_id,
 				c.champion_name_kr,
 				c.champion_name_en,
 				c.image_url,
+				mg.side,
 				COUNT(*) AS ban_count
 			FROM my_games mg
 			JOIN bans b ON b.game_id = mg.game_id AND b.team_id <> :teamId
 			JOIN champions c ON c.champion_id = b.banned_champion_id
-			GROUP BY c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url
+			GROUP BY c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url, mg.side
 			ORDER BY ban_count DESC, c.champion_name_en
 			""", nativeQuery = true)
-	List<Object[]> findBansAgainstTeamWithFilters(
+	List<Object[]> findBansAgainstTeamGroupedBySide(
 			@Param("teamId") Long teamId,
 			@Param("leagueName") String leagueName,
 			@Param("year") Integer year,
 			@Param("split") String split,
-			@Param("patch") String patch,
-			@Param("side") String side);
+			@Param("patch") String patch);
 }

--- a/src/main/java/com/toy/nar/domain/game/repository/GameParticipantRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/GameParticipantRepository.java
@@ -275,6 +275,45 @@ public interface GameParticipantRepository
 			@Param("patch") String patch,
 			@Param("side") String side);
 
+	@Query(value = """
+				SELECT
+					p.player_id,
+					p.player_name,
+					p.image_url,
+					gp.position,
+					c.champion_id,
+					c.champion_name_kr,
+					c.champion_name_en,
+					c.image_url AS champion_image_url,
+					COUNT(*) AS games_played,
+					SUM(CASE WHEN gp.is_win = 1 THEN 1 ELSE 0 END) AS wins,
+					SUM(COALESCE(gps.kills, 0)) AS total_kills,
+					SUM(COALESCE(gps.deaths, 0)) AS total_deaths,
+					SUM(COALESCE(gps.assists, 0)) AS total_assists,
+					MAX(g.actual_game_start_time) AS last_used_at,
+					UPPER(gp.side) AS side
+				FROM game_participants gp
+				JOIN players p ON p.player_id = gp.player_id
+				JOIN champions c ON c.champion_id = gp.champion_id
+				JOIN games g ON g.game_id = gp.game_id
+				JOIN leagues l ON l.league_id = g.league_id
+				JOIN game_player_stat gps ON gps.game_participant_id = gp.participant_game_id
+				WHERE gp.team_id = :teamId
+				  AND l.league_name = :leagueName
+				  AND (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
+				  AND (:split IS NULL OR l.season_split = :split)
+				  AND (:patch IS NULL OR g.patch = :patch)
+				GROUP BY p.player_id, p.player_name, p.image_url, gp.position,
+				         c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url, UPPER(gp.side)
+				ORDER BY games_played DESC, c.champion_name_en
+				""", nativeQuery = true)
+	List<Object[]> findTeamPlayedChampionsGroupedBySide(
+			@Param("teamId") Long teamId,
+			@Param("leagueName") String leagueName,
+			@Param("year") Integer year,
+			@Param("split") String split,
+			@Param("patch") String patch);
+
 	/**
 	 * 선수 카드 목록용 선수 수 집계.
 	 */

--- a/src/main/java/com/toy/nar/domain/participant/repository/GameTeamStatRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/GameTeamStatRepository.java
@@ -265,11 +265,13 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 			JOIN (
 				SELECT DISTINCT gp.game_id, gp.team_id, UPPER(gp.side) AS side
 				FROM game_participants gp
+				WHERE gp.team_id = :teamId
 			) gs ON gs.game_id = g.game_id AND gs.team_id = gts.team_id
 			LEFT JOIN (
 				SELECT gp.game_id, gp.team_id, SUM(COALESCE(gps.earned_gold, 0)) AS total_gold
 				FROM game_participants gp
 				JOIN game_player_stat gps ON gps.game_participant_id = gp.participant_game_id
+				WHERE gp.team_id = :teamId
 				GROUP BY gp.game_id, gp.team_id
 			) tg ON tg.game_id = g.game_id AND tg.team_id = gts.team_id
 			WHERE gts.team_id = :teamId
@@ -304,16 +306,11 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 					AND opp.team_id <> gts.team_id
 				JOIN games g ON g.game_id = gts.game_id
 				JOIN leagues l ON l.league_id = g.league_id
-				JOIN (
-					SELECT DISTINCT gp.game_id, gp.team_id, UPPER(gp.side) AS side
-					FROM game_participants gp
-				) gs ON gs.game_id = g.game_id AND gs.team_id = gts.team_id
 				WHERE gts.team_id = :teamId
 				  AND l.league_name = :leagueName
 				  AND (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 				  AND (:split IS NULL OR l.season_split = :split)
 				  AND (:patch IS NULL OR g.patch = :patch)
-				  AND (:side IS NULL OR gs.side = :side)
 			),
 			series AS (
 				SELECT

--- a/src/main/java/com/toy/nar/domain/participant/repository/GameTeamStatRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/GameTeamStatRepository.java
@@ -262,11 +262,6 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 			FROM game_team_stat gts
 			JOIN games g ON g.game_id = gts.game_id
 			JOIN leagues l ON l.league_id = g.league_id
-			JOIN (
-				SELECT DISTINCT gp.game_id, gp.team_id, UPPER(gp.side) AS side
-				FROM game_participants gp
-				WHERE gp.team_id = :teamId
-			) gs ON gs.game_id = g.game_id AND gs.team_id = gts.team_id
 			LEFT JOIN (
 				SELECT gp.game_id, gp.team_id, SUM(COALESCE(gps.earned_gold, 0)) AS total_gold
 				FROM game_participants gp
@@ -279,7 +274,6 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 			  AND (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 			  AND (:split IS NULL OR l.season_split = :split)
 			  AND (:patch IS NULL OR g.patch = :patch)
-			  AND (:side IS NULL OR gs.side = :side)
 			""", nativeQuery = true)
 	List<Object[]> findTeamDashboardSummary(
 			@Param("teamId") Long teamId,

--- a/src/test/java/com/toy/nar/app/analysis/service/TeamDashboardServiceTest.java
+++ b/src/test/java/com/toy/nar/app/analysis/service/TeamDashboardServiceTest.java
@@ -1,6 +1,8 @@
 package com.toy.nar.app.analysis.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,7 +12,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,8 +44,20 @@ class TeamDashboardServiceTest {
 	@Mock
 	private BanRepository banRepository;
 
+	@Mock
+	private Executor applicationTaskExecutor;
+
 	@InjectMocks
 	private TeamDashboardService teamDashboardService;
+
+	@BeforeEach
+	void setUp() {
+		doAnswer(invocation -> {
+			Runnable runnable = invocation.getArgument(0);
+			runnable.run();
+			return null;
+		}).when(applicationTaskExecutor).execute(any(Runnable.class));
+	}
 
 	@Test
 	@DisplayName("4개 섹션 통합 대시보드를 반환한다")
@@ -64,33 +80,27 @@ class TeamDashboardServiceTest {
 						new Object[] { 101L, "Kiin", "p1", "top", 20L, 14L, 60L, 30L, 90L, 3L, 2L, 1L, 71.2, 23.5, 21.0, 28.7, 1.05 },
 						new Object[] { 102L, "Canyon", "p2", "jng", 20L, 14L, 55L, 40L, 120L, 4L, 3L, 0L, 68.4, 20.2, 19.8, 36.2, 1.29 }));
 
-		when(banRepository.findBansByTeamWithFilters(1L, "LCK", 2026, "Round 1-2", "14.1", null))
-				.thenReturn(List.<Object[]>of(new Object[] { 11L, "렐", "Rell", "c1", 7L }));
-		when(banRepository.findBansByTeamWithFilters(1L, "LCK", 2026, "Round 1-2", "14.1", "BLUE"))
-				.thenReturn(List.<Object[]>of(new Object[] { 11L, "렐", "Rell", "c1", 4L }));
-		when(banRepository.findBansByTeamWithFilters(1L, "LCK", 2026, "Round 1-2", "14.1", "RED"))
-				.thenReturn(List.<Object[]>of(new Object[] { 11L, "렐", "Rell", "c1", 3L }));
-		when(banRepository.findBansAgainstTeamWithFilters(1L, "LCK", 2026, "Round 1-2", "14.1", null))
-				.thenReturn(List.<Object[]>of(new Object[] { 12L, "신짜오", "Xin Zhao", "c2", 9L }));
-		when(banRepository.findBansAgainstTeamWithFilters(1L, "LCK", 2026, "Round 1-2", "14.1", "BLUE"))
-				.thenReturn(List.<Object[]>of(new Object[] { 12L, "신짜오", "Xin Zhao", "c2", 5L }));
-		when(banRepository.findBansAgainstTeamWithFilters(1L, "LCK", 2026, "Round 1-2", "14.1", "RED"))
-				.thenReturn(List.<Object[]>of(new Object[] { 12L, "신짜오", "Xin Zhao", "c2", 4L }));
+		when(banRepository.findBansByTeamGroupedBySide(1L, "LCK", 2026, "Round 1-2", "14.1"))
+				.thenReturn(List.<Object[]>of(
+						new Object[] { 11L, "렐", "Rell", "c1", "BLUE", 4L },
+						new Object[] { 11L, "렐", "Rell", "c1", "RED", 3L }
+				));
+		when(banRepository.findBansAgainstTeamGroupedBySide(1L, "LCK", 2026, "Round 1-2", "14.1"))
+				.thenReturn(List.<Object[]>of(
+						new Object[] { 12L, "신짜오", "Xin Zhao", "c2", "BLUE", 5L },
+						new Object[] { 12L, "신짜오", "Xin Zhao", "c2", "RED", 4L }
+				));
 
-		when(gameParticipantRepository.findTeamPlayedChampions(1L, "LCK", 2026, "Round 1-2", "14.1", null))
+		when(gameParticipantRepository.findTeamPlayedChampionsGroupedBySide(1L, "LCK", 2026, "Round 1-2", "14.1"))
 				.thenReturn(List.of(
-						new Object[] { 101L, "Kiin", "p1", "top", 201L, "그웬", "Gwen", "img-gwen", 6L, 4L, 20L, 12L, 18L,
-								Timestamp.valueOf(LocalDateTime.of(2026, 2, 1, 3, 0, 0)) },
-						new Object[] { 101L, "Kiin", "p1", "top", 202L, "레넥톤", "Renekton", "img-renek", 4L, 3L, 14L, 10L, 22L,
-								Timestamp.valueOf(LocalDateTime.of(2026, 1, 20, 3, 0, 0)) }));
-		when(gameParticipantRepository.findTeamPlayedChampions(1L, "LCK", 2026, "Round 1-2", "14.1", "BLUE"))
-				.thenReturn(Collections.singletonList(
 						new Object[] { 101L, "Kiin", "p1", "top", 201L, "그웬", "Gwen", "img-gwen", 3L, 2L, 10L, 5L, 8L,
-								Timestamp.valueOf(LocalDateTime.of(2026, 2, 1, 3, 0, 0)) }));
-		when(gameParticipantRepository.findTeamPlayedChampions(1L, "LCK", 2026, "Round 1-2", "14.1", "RED"))
-				.thenReturn(Collections.singletonList(
+								Timestamp.valueOf(LocalDateTime.of(2026, 2, 1, 3, 0, 0)), "BLUE" },
+						new Object[] { 101L, "Kiin", "p1", "top", 201L, "그웬", "Gwen", "img-gwen", 3L, 2L, 10L, 7L, 10L,
+								Timestamp.valueOf(LocalDateTime.of(2026, 2, 1, 3, 0, 0)), "RED" },
 						new Object[] { 101L, "Kiin", "p1", "top", 202L, "레넥톤", "Renekton", "img-renek", 2L, 1L, 7L, 5L, 10L,
-								Timestamp.valueOf(LocalDateTime.of(2026, 1, 20, 3, 0, 0)) }));
+								Timestamp.valueOf(LocalDateTime.of(2026, 1, 20, 3, 0, 0)), "RED" },
+						new Object[] { 101L, "Kiin", "p1", "top", 202L, "레넥톤", "Renekton", "img-renek", 2L, 2L, 7L, 5L, 12L,
+								Timestamp.valueOf(LocalDateTime.of(2026, 1, 20, 3, 0, 0)), "BLUE" }));
 
 		TeamDashboardResponse response = teamDashboardService.getTeamDashboard(
 				1L, "LCK", 2026, "Round 1-2", "14.1", "ALL");
@@ -132,29 +142,18 @@ class TeamDashboardServiceTest {
 
 		when(gameParticipantRepository.findTeamPlayerRecords(1L, "LCK", 2026, null, null, null))
 				.thenReturn(List.of());
-		when(gameParticipantRepository.findTeamPlayedChampions(1L, "LCK", 2026, null, null, null))
-				.thenReturn(List.of());
-		when(gameParticipantRepository.findTeamPlayedChampions(1L, "LCK", 2026, null, null, "BLUE"))
-				.thenReturn(List.of());
-		when(gameParticipantRepository.findTeamPlayedChampions(1L, "LCK", 2026, null, null, "RED"))
+		when(gameParticipantRepository.findTeamPlayedChampionsGroupedBySide(1L, "LCK", 2026, null, null))
 				.thenReturn(List.of());
 
 		List<Object[]> banRows = new ArrayList<>();
 		for (int i = 0; i < 6; i++) {
-			banRows.add(new Object[] { 100L + i, "챔프" + i, "Champ" + i, "img" + i, 10L - i });
+			banRows.add(new Object[] { 100L + i, "챔프" + i, "Champ" + i, "img" + i, "BLUE", 10L - i });
+			banRows.add(new Object[] { 100L + i, "챔프" + i, "Champ" + i, "img" + i, "RED", 10L - i });
 		}
 
-		when(banRepository.findBansByTeamWithFilters(1L, "LCK", 2026, null, null, null))
+		when(banRepository.findBansByTeamGroupedBySide(1L, "LCK", 2026, null, null))
 				.thenReturn(banRows);
-		when(banRepository.findBansByTeamWithFilters(1L, "LCK", 2026, null, null, "BLUE"))
-				.thenReturn(banRows);
-		when(banRepository.findBansByTeamWithFilters(1L, "LCK", 2026, null, null, "RED"))
-				.thenReturn(banRows);
-		when(banRepository.findBansAgainstTeamWithFilters(1L, "LCK", 2026, null, null, null))
-				.thenReturn(banRows);
-		when(banRepository.findBansAgainstTeamWithFilters(1L, "LCK", 2026, null, null, "BLUE"))
-				.thenReturn(banRows);
-		when(banRepository.findBansAgainstTeamWithFilters(1L, "LCK", 2026, null, null, "RED"))
+		when(banRepository.findBansAgainstTeamGroupedBySide(1L, "LCK", 2026, null, null))
 				.thenReturn(banRows);
 
 		TeamDashboardResponse response = teamDashboardService.getTeamDashboard(


### PR DESCRIPTION
## Summary
팀 대시보드에서 side별 중복 조회를 줄이고 남아 있던 series summary 병목을 제거해 DB 부하를 낮췄습니다.
대시보드 API 스펙에 맞춰 밴/챔피언 통계를 메모리에서 재조립하고, 불필요한 game_participants 파생 조인을 걷어 실행 계획을 단순화했습니다.

## Changes
- 밴 통계를 side 포함 단일 조회로 바꾸고 Java 메모리에서 ALL/BLUE/RED로 재조립하도록 변경
- 플레이 챔피언 통계를 side 포함 단일 조회로 바꾸고 Java 메모리에서 ALL/BLUE/RED로 재조립하도록 변경
- GameTeamStat 요약 쿼리의 team_id pushdown을 추가해 game_participants 스캔 범위를 축소
- series summary 쿼리에서 불필요한 gs 조인과 side 조건을 제거해 full scan 병목을 해소
- TeamDashboardService를 비동기 집계 구조에 맞게 정리하고 관련 테스트를 갱신