### PR TITLE
feat: 팀 분석 필터 통일 및 radar 골드 점수화

### DIFF
--- a/src/main/java/com/toy/nar/api/v3/TeamController.java
+++ b/src/main/java/com/toy/nar/api/v3/TeamController.java
@@ -42,30 +42,40 @@ public class TeamController {
     @GetMapping("/{teamId}/radar")
     public ResponseEntity<TeamRadarResponse> getTeamRadarStats(
             @Parameter(description = "팀 ID") @PathVariable Long teamId,
-            @Parameter(description = "연도 (기본값: 2026)", example = "2026") @RequestParam(defaultValue = "2026") int year) {
+            @Parameter(description = "리그명 (기본값: LCK)", example = "LCK") @RequestParam(defaultValue = "LCK") String league,
+            @Parameter(description = "연도 (기본값: 2026)", example = "2026") @RequestParam(defaultValue = "2026") Integer year,
+            @Parameter(description = "스플릿 (예: Round 1-2)") @RequestParam(required = false) String split,
+            @Parameter(description = "패치 (예: 14.1)") @RequestParam(required = false) String patch,
+            @Parameter(description = "진영 필터 (ALL, BLUE, RED)", example = "ALL") @RequestParam(defaultValue = "ALL") String side) {
 
-        TeamRadarResponse response = teamRadarService.getTeamRadarStats(teamId, year);
+        TeamRadarResponse response = teamRadarService.getTeamRadarStats(teamId, league, year, split, patch, side);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "팀 지표 스캐터 차트", description = "리그/연도 기준으로 팀별 승률(y축)과 평균 지표(x축: ALL, KILLS, GOLD, OBJECTIVES) 데이터를 반환합니다.")
     @GetMapping("/scatter")
     public ResponseEntity<TeamScatterResponse> getTeamScatterStats(
-            @Parameter(description = "연도 (기본값: 2026)", example = "2026") @RequestParam(defaultValue = "2026") int year,
+            @Parameter(description = "연도 (기본값: 2026)", example = "2026") @RequestParam(defaultValue = "2026") Integer year,
             @Parameter(description = "리그명 (기본값: LCK)", example = "LCK") @RequestParam(defaultValue = "LCK") String league,
+            @Parameter(description = "스플릿 (예: Round 1-2)") @RequestParam(required = false) String split,
+            @Parameter(description = "패치 (예: 14.1)") @RequestParam(required = false) String patch,
+            @Parameter(description = "진영 필터 (ALL, BLUE, RED)", example = "ALL") @RequestParam(defaultValue = "ALL") String side,
             @Parameter(description = "x축 지표 (ALL, KILLS, GOLD, OBJECTIVES)", example = "ALL") @RequestParam(defaultValue = "ALL") String metric) {
 
-        TeamScatterResponse response = teamScatterService.getTeamScatterStats(league, year, metric);
+        TeamScatterResponse response = teamScatterService.getTeamScatterStats(league, year, split, patch, side, metric);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "팀 경기 데이터 상세", description = "팀 승률 기준 내림차순으로 매치/세트 전적과 킬/골드/오브젝트/퍼스트 오브젝트 지표를 반환합니다.")
     @GetMapping("/detail-stats")
     public ResponseEntity<TeamDetailStatsResponse> getTeamDetailStats(
-            @Parameter(description = "연도 (기본값: 2026)", example = "2026") @RequestParam(defaultValue = "2026") int year,
-            @Parameter(description = "리그명 (기본값: LCK)", example = "LCK") @RequestParam(defaultValue = "LCK") String league) {
+            @Parameter(description = "연도 (기본값: 2026)", example = "2026") @RequestParam(defaultValue = "2026") Integer year,
+            @Parameter(description = "리그명 (기본값: LCK)", example = "LCK") @RequestParam(defaultValue = "LCK") String league,
+            @Parameter(description = "스플릿 (예: Round 1-2)") @RequestParam(required = false) String split,
+            @Parameter(description = "패치 (예: 14.1)") @RequestParam(required = false) String patch,
+            @Parameter(description = "진영 필터 (ALL, BLUE, RED)", example = "ALL") @RequestParam(defaultValue = "ALL") String side) {
 
-        TeamDetailStatsResponse response = teamDetailStatsService.getTeamDetailStats(league, year);
+        TeamDetailStatsResponse response = teamDetailStatsService.getTeamDetailStats(league, year, split, patch, side);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/toy/nar/app/analysis/dto/TeamRadarStatsDto.java
+++ b/src/main/java/com/toy/nar/app/analysis/dto/TeamRadarStatsDto.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * 팀 레이더 차트 지표 DTO (21개 지표)
+ * 팀 레이더 차트 지표 DTO
  * 
  * 2026 시즌 기준: 아타칸 미적용
  */
@@ -25,12 +25,20 @@ public class TeamRadarStatsDto {
     // === 시간대별 골드차 (팀 합산 평균) ===
     /** 10@GD - 10분 골드차 평균 */
     private Double goldDiffAt10;
+    /** 10@GD score - 레이더 렌더링용 0~100 정규화 점수 */
+    private Double goldDiffAt10Score;
     /** 15@GD - 15분 골드차 평균 */
     private Double goldDiffAt15;
+    /** 15@GD score - 레이더 렌더링용 0~100 정규화 점수 */
+    private Double goldDiffAt15Score;
     /** 20@GD - 20분 골드차 평균 */
     private Double goldDiffAt20;
+    /** 20@GD score - 레이더 렌더링용 0~100 정규화 점수 */
+    private Double goldDiffAt20Score;
     /** 25@GD - 25분 골드차 평균 */
     private Double goldDiffAt25;
+    /** 25@GD score - 레이더 렌더링용 0~100 정규화 점수 */
+    private Double goldDiffAt25Score;
     /** GSPD - Gold Slope Percent Difference (시간당 골드 기울기 차이) */
     private Double gspd;
 

--- a/src/main/java/com/toy/nar/app/analysis/service/TeamAnalysisFilter.java
+++ b/src/main/java/com/toy/nar/app/analysis/service/TeamAnalysisFilter.java
@@ -1,0 +1,41 @@
+package com.toy.nar.app.analysis.service;
+
+import java.util.Locale;
+
+record TeamAnalysisFilter(
+		String leagueName,
+		Integer year,
+		String split,
+		String patch,
+		String side) {
+
+	static TeamAnalysisFilter from(String league, Integer year, String split, String patch, String side) {
+		return new TeamAnalysisFilter(
+				normalizeLeague(league),
+				year != null ? year : 2026,
+				normalizeBlank(split),
+				normalizeBlank(patch),
+				normalizeSide(side));
+	}
+
+	private static String normalizeLeague(String league) {
+		if (league == null || league.isBlank()) {
+			return "LCK";
+		}
+		return league.trim().toUpperCase(Locale.ROOT);
+	}
+
+	private static String normalizeSide(String side) {
+		if (side == null || side.isBlank() || "ALL".equalsIgnoreCase(side)) {
+			return null;
+		}
+		return side.trim().toUpperCase(Locale.ROOT);
+	}
+
+	private static String normalizeBlank(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value.trim();
+	}
+}

--- a/src/main/java/com/toy/nar/app/analysis/service/TeamDetailStatsService.java
+++ b/src/main/java/com/toy/nar/app/analysis/service/TeamDetailStatsService.java
@@ -2,7 +2,6 @@ package com.toy.nar.app.analysis.service;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -22,16 +21,32 @@ public class TeamDetailStatsService {
 
 	private final GameTeamStatRepository gameTeamStatRepository;
 
-	public TeamDetailStatsResponse getTeamDetailStats(String league, int year) {
-		String leagueName = normalizeLeague(league);
+	public TeamDetailStatsResponse getTeamDetailStats(
+			String league,
+			Integer year,
+			String split,
+			String patch,
+			String side) {
+		TeamAnalysisFilter filter = TeamAnalysisFilter.from(league, year, split, patch, side);
 
-		List<Object[]> detailRows = gameTeamStatRepository.findTeamDetailStatsByLeagueAndYear(year, leagueName);
+		List<Object[]> detailRows = gameTeamStatRepository.findTeamDetailStatsByFilter(
+				filter.year(),
+				filter.leagueName(),
+				filter.split(),
+				filter.patch(),
+				filter.side());
 		if (detailRows.isEmpty()) {
-			throw new IllegalArgumentException("No team detail stats found for league " + leagueName + " in year " + year);
+			throw new IllegalArgumentException(
+					"No team detail stats found for league " + filter.leagueName() + " in year " + filter.year());
 		}
 
 		Map<Long, SeriesRecord> seriesByTeam = new HashMap<>();
-		for (Object[] row : gameTeamStatRepository.findTeamSeriesStatsByLeagueAndYear(year, leagueName)) {
+		for (Object[] row : gameTeamStatRepository.findTeamSeriesStatsByFilter(
+				filter.year(),
+				filter.leagueName(),
+				filter.split(),
+				filter.patch(),
+				filter.side())) {
 			Long teamId = toLong(row[0]);
 			seriesByTeam.put(teamId, new SeriesRecord(
 					toInt(row[1]),
@@ -93,8 +108,8 @@ public class TeamDetailStatsService {
 				.toList();
 
 		return TeamDetailStatsResponse.builder()
-				.leagueName(leagueName)
-				.year(year)
+				.leagueName(filter.leagueName())
+				.year(filter.year())
 				.totalTeams(ranked.size())
 				.items(ranked)
 				.build();
@@ -147,13 +162,6 @@ public class TeamDetailStatsService {
 				.firstHeraldRatePct(setsPlayed > 0 ? round(firstHeraldCount * 100.0 / setsPlayed, 1) : 0)
 				.firstBaronRatePct(setsPlayed > 0 ? round(firstBaronCount * 100.0 / setsPlayed, 1) : 0)
 				.build();
-	}
-
-	private String normalizeLeague(String league) {
-		if (league == null || league.isBlank()) {
-			return "LCK";
-		}
-		return league.trim().toUpperCase(Locale.ROOT);
 	}
 
 	private double round(double value, int scale) {

--- a/src/main/java/com/toy/nar/app/analysis/service/TeamRadarService.java
+++ b/src/main/java/com/toy/nar/app/analysis/service/TeamRadarService.java
@@ -1,7 +1,9 @@
 package com.toy.nar.app.analysis.service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -17,329 +19,435 @@ import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.GameTeamStatRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 팀 레이더 차트 통계 서비스
  */
 @Service
 @RequiredArgsConstructor
-@Slf4j
 @Transactional(readOnly = true)
 public class TeamRadarService {
 
-        private final GameTeamStatRepository gameTeamStatRepository;
-        private final GameParticipantRepository gameParticipantRepository;
+	private final GameTeamStatRepository gameTeamStatRepository;
+	private final GameParticipantRepository gameParticipantRepository;
 
-        /**
-         * 팀 레이더 통계 조회
-         */
-        public TeamRadarResponse getTeamRadarStats(Long teamId, int year) {
-                List<GameTeamStat> teamStats = gameTeamStatRepository.findByTeamIdAndYear(teamId, year);
+	public TeamRadarResponse getTeamRadarStats(
+			Long teamId,
+			String league,
+			Integer year,
+			String split,
+			String patch,
+			String side) {
+		TeamAnalysisFilter filter = TeamAnalysisFilter.from(league, year, split, patch, side);
 
-                if (teamStats.isEmpty()) {
-                        throw new IllegalArgumentException("No games found for team " + teamId + " in year " + year);
-                }
+		List<GameTeamStat> allStats = gameTeamStatRepository.findByFilter(
+				filter.leagueName(),
+				filter.year(),
+				filter.split(),
+				filter.patch(),
+				filter.side());
+		if (allStats.isEmpty()) {
+			throw new IllegalArgumentException(
+					"No games found for league " + filter.leagueName() + " in year " + filter.year());
+		}
 
-                // 골드차 계산을 위해 선수별 통계 조회
-                List<GameParticipant> participants = gameParticipantRepository.findByTeamIdAndYearWithStats(teamId,
-                                year);
+		List<GameParticipant> allParticipants = gameParticipantRepository.findByFilterWithStats(
+				filter.leagueName(),
+				filter.year(),
+				filter.split(),
+				filter.patch(),
+				filter.side());
 
-                TeamRadarStatsDto stats = calculateTeamStats(teamStats, participants, year);
-                TeamRadarStatsDto leagueAverage = calculateLeagueAverage(year);
+		List<RadarMetrics> teamMetrics = buildTeamMetrics(allStats, allParticipants, filter.year());
+		RadarMetrics teamMetric = teamMetrics.stream()
+				.filter(metric -> metric.teamId() != null && metric.teamId().equals(teamId))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException(
+						"No games found for team " + teamId + " in league " + filter.leagueName()
+								+ " for year " + filter.year()));
 
-                return TeamRadarResponse.builder()
-                                .stats(stats)
-                                .leagueAverage(leagueAverage)
-                                .build();
-        }
+		GoldScoreContext goldScoreContext = GoldScoreContext.from(teamMetrics);
+		RadarMetrics leagueAverage = calculateLeagueAverage(allStats, teamMetrics, filter.leagueName(), filter.year());
 
-        /**
-         * 팀 통계 계산
-         */
-        private TeamRadarStatsDto calculateTeamStats(List<GameTeamStat> teamStats,
-                        List<GameParticipant> participants, int year) {
-                Team team = teamStats.get(0).getTeam();
-                int gamesPlayed = teamStats.size();
+		return TeamRadarResponse.builder()
+				.stats(toDto(teamMetric, goldScoreContext))
+				.leagueAverage(toDto(leagueAverage, goldScoreContext))
+				.build();
+	}
 
-                // === 승률 ===
-                long wins = teamStats.stream().filter(s -> s.getResult() == 1).count();
-                double winRate = (double) wins / gamesPlayed;
+	private List<RadarMetrics> buildTeamMetrics(
+			List<GameTeamStat> allStats,
+			List<GameParticipant> allParticipants,
+			int year) {
+		Map<Long, List<GameTeamStat>> statsByTeam = allStats.stream()
+				.collect(Collectors.groupingBy(gts -> gts.getTeam().getId()));
+		Map<Long, List<GameParticipant>> participantsByTeam = allParticipants.stream()
+				.collect(Collectors.groupingBy(gp -> gp.getTeam().getId()));
 
-                // === 시간대별 골드차 계산 (선수 5명 합산 후 경기당 평균) ===
-                Map<Long, List<GameParticipant>> participantsByGame = participants.stream()
-                                .collect(Collectors.groupingBy(gp -> gp.getGame().getId()));
+		return statsByTeam.entrySet().stream()
+				.map(entry -> calculateTeamMetrics(
+						entry.getValue(),
+						participantsByTeam.getOrDefault(entry.getKey(), List.of()),
+						year))
+				.toList();
+	}
 
-                double goldDiffAt10 = calculateAvgGoldDiffAtTime(participantsByGame, 10);
-                double goldDiffAt15 = calculateAvgGoldDiffAtTime(participantsByGame, 15);
-                double goldDiffAt20 = calculateAvgGoldDiffAtTime(participantsByGame, 20);
-                double goldDiffAt25 = calculateAvgGoldDiffAtTime(participantsByGame, 25);
+	private RadarMetrics calculateTeamMetrics(
+			List<GameTeamStat> teamStats,
+			List<GameParticipant> participants,
+			int year) {
+		Team team = teamStats.get(0).getTeam();
+		int gamesPlayed = teamStats.size();
 
-                // === 선취 지표 ===
-                double firstBloodRate = teamStats.stream().filter(GameTeamStat::isFirstBlood).count()
-                                / (double) gamesPlayed;
-                double firstTowerRate = teamStats.stream().filter(GameTeamStat::isFirstTower).count()
-                                / (double) gamesPlayed;
-                double firstThreeTowerRate = teamStats.stream().filter(GameTeamStat::isFirstToThreeTowers).count()
-                                / (double) gamesPlayed;
-                double firstHeraldRate = teamStats.stream().filter(GameTeamStat::isFirstHerald).count()
-                                / (double) gamesPlayed;
-                double firstDragonRate = teamStats.stream().filter(GameTeamStat::isFirstDragon).count()
-                                / (double) gamesPlayed;
-                double firstBaronRate = teamStats.stream().filter(GameTeamStat::isFirstBaron).count()
-                                / (double) gamesPlayed;
+		long wins = teamStats.stream().filter(s -> s.getResult() == 1).count();
+		double winRate = gamesPlayed > 0 ? (double) wins / gamesPlayed : 0;
 
-                // === 오브젝트 평균 ===
-                double dragonsPerGame = teamStats.stream()
-                                .mapToInt(s -> s.getDragons() != null ? s.getDragons() : 0)
-                                .average().orElse(0);
+		Map<Long, List<GameParticipant>> participantsByGame = participants.stream()
+				.collect(Collectors.groupingBy(gp -> gp.getGame().getId()));
 
-                double towersKilledAvg = teamStats.stream()
-                                .mapToInt(s -> s.getTowers() != null ? s.getTowers() : 0)
-                                .average().orElse(0);
+		double goldDiffAt10 = calculateAvgGoldDiffAtTime(participantsByGame, 10);
+		double goldDiffAt15 = calculateAvgGoldDiffAtTime(participantsByGame, 15);
+		double goldDiffAt20 = calculateAvgGoldDiffAtTime(participantsByGame, 20);
+		double goldDiffAt25 = calculateAvgGoldDiffAtTime(participantsByGame, 25);
 
-                double towersLostAvg = teamStats.stream()
-                                .mapToInt(s -> s.getOppTowers() != null ? s.getOppTowers() : 0)
-                                .average().orElse(0);
+		double firstBloodRate = teamStats.stream().filter(GameTeamStat::isFirstBlood).count()
+				/ (double) gamesPlayed;
+		double firstTowerRate = teamStats.stream().filter(GameTeamStat::isFirstTower).count()
+				/ (double) gamesPlayed;
+		double firstThreeTowerRate = teamStats.stream().filter(GameTeamStat::isFirstToThreeTowers).count()
+				/ (double) gamesPlayed;
+		double firstHeraldRate = teamStats.stream().filter(GameTeamStat::isFirstHerald).count()
+				/ (double) gamesPlayed;
+		double firstDragonRate = teamStats.stream().filter(GameTeamStat::isFirstDragon).count()
+				/ (double) gamesPlayed;
+		double firstBaronRate = teamStats.stream().filter(GameTeamStat::isFirstBaron).count()
+				/ (double) gamesPlayed;
 
-                // === 공허유충 비율 ===
-                int totalVoidGrubs = teamStats.stream()
-                                .mapToInt(s -> (s.getVoidGrubs() != null ? s.getVoidGrubs() : 0))
-                                .sum();
-                int totalOppVoidGrubs = teamStats.stream()
-                                .mapToInt(s -> (s.getOppVoidGrubs() != null ? s.getOppVoidGrubs() : 0))
-                                .sum();
-                double voidGrubsRate = (totalVoidGrubs + totalOppVoidGrubs) > 0
-                                ? (double) totalVoidGrubs / (totalVoidGrubs + totalOppVoidGrubs)
-                                : 0.5;
+		double dragonsPerGame = teamStats.stream()
+				.mapToInt(s -> s.getDragons() != null ? s.getDragons() : 0)
+				.average().orElse(0);
 
-                // === CKPM (경기 평균) ===
-                double ckpm = teamStats.stream()
-                                .map(GameTeamStat::getGame)
-                                .mapToDouble(g -> g.getCkpm() != null ? g.getCkpm() : 0)
-                                .average().orElse(0);
+		double towersKilledAvg = teamStats.stream()
+				.mapToInt(s -> s.getTowers() != null ? s.getTowers() : 0)
+				.average().orElse(0);
 
-                // === GSPD (Gold Slope Percent Difference) ===
-                double gspd = teamStats.stream()
-                                .mapToDouble(s -> s.getGspd() != null ? s.getGspd() : 0)
-                                .average().orElse(0);
+		double towersLostAvg = teamStats.stream()
+				.mapToInt(s -> s.getOppTowers() != null ? s.getOppTowers() : 0)
+				.average().orElse(0);
 
-                // === 계산 레이팅 ===
-                double earlyGameRating = (firstBloodRate + firstTowerRate + firstHeraldRate) / 3;
-                double mlr = (firstBaronRate + dragonsPerGame / 5.0 + winRate) / 3;
+		int totalVoidGrubs = teamStats.stream()
+				.mapToInt(s -> s.getVoidGrubs() != null ? s.getVoidGrubs() : 0)
+				.sum();
+		int totalOppVoidGrubs = teamStats.stream()
+				.mapToInt(s -> s.getOppVoidGrubs() != null ? s.getOppVoidGrubs() : 0)
+				.sum();
+		double voidGrubsRate = (totalVoidGrubs + totalOppVoidGrubs) > 0
+				? (double) totalVoidGrubs / (totalVoidGrubs + totalOppVoidGrubs)
+				: 0.5;
 
-                double avgKills = teamStats.stream()
-                                .mapToInt(s -> s.getTeamKills() != null ? s.getTeamKills() : 0)
-                                .average().orElse(0);
-                double pointsPerGame = avgKills + dragonsPerGame * 2 + towersKilledAvg;
+		double ckpm = teamStats.stream()
+				.map(GameTeamStat::getGame)
+				.mapToDouble(g -> g.getCkpm() != null ? g.getCkpm() : 0)
+				.average().orElse(0);
 
-                return TeamRadarStatsDto.builder()
-                                .teamId(team.getId())
-                                .teamName(team.getName())
-                                .gamesPlayed(gamesPlayed)
-                                .year(year)
-                                .winRate(round(winRate, 3))
-                                .goldDiffAt10(round(goldDiffAt10, 0))
-                                .goldDiffAt15(round(goldDiffAt15, 0))
-                                .goldDiffAt20(round(goldDiffAt20, 0))
-                                .goldDiffAt25(round(goldDiffAt25, 0))
-                                .gspd(round(gspd, 3))
-                                .ckpm(round(ckpm, 2))
-                                .firstBloodRate(round(firstBloodRate, 3))
-                                .firstTowerRate(round(firstTowerRate, 3))
-                                .firstThreeTowerRate(round(firstThreeTowerRate, 3))
-                                .firstHeraldRate(round(firstHeraldRate, 3))
-                                .firstDragonRate(round(firstDragonRate, 3))
-                                .firstBaronRate(round(firstBaronRate, 3))
-                                .dragonsPerGame(round(dragonsPerGame, 2))
-                                .voidGrubsRate(round(voidGrubsRate, 3))
-                                .towersKilledAvg(round(towersKilledAvg, 2))
-                                .towersLostAvg(round(towersLostAvg, 2))
-                                .earlyGameRating(round(earlyGameRating, 3))
-                                .midLateRating(round(mlr, 3))
-                                .pointsPerGame(round(pointsPerGame, 2))
-                                .build();
-        }
+		double gspd = teamStats.stream()
+				.mapToDouble(s -> s.getGspd() != null ? s.getGspd() : 0)
+				.average().orElse(0);
 
-        /**
-         * 시간대별 골드차 평균 계산
-         */
-        private double calculateAvgGoldDiffAtTime(Map<Long, List<GameParticipant>> participantsByGame, int minutes) {
-                if (participantsByGame.isEmpty())
-                        return 0;
+		double earlyGameRating = (firstBloodRate + firstTowerRate + firstHeraldRate) / 3;
+		double midLateRating = (firstBaronRate + dragonsPerGame / 5.0 + winRate) / 3;
 
-                double totalGoldDiff = 0;
-                int gameCount = 0;
+		double avgKills = teamStats.stream()
+				.mapToInt(s -> s.getTeamKills() != null ? s.getTeamKills() : 0)
+				.average().orElse(0);
+		double pointsPerGame = avgKills + dragonsPerGame * 2 + towersKilledAvg;
 
-                for (List<GameParticipant> gameParticipants : participantsByGame.values()) {
-                        int teamGoldDiff = 0;
-                        for (GameParticipant gp : gameParticipants) {
-                                GamePlayerStat stat = gp.getStat();
-                                if (stat != null) {
-                                        Integer goldDiff = switch (minutes) {
-                                                case 10 -> stat.getGoldDiffAt10();
-                                                case 15 -> stat.getGoldDiffAt15();
-                                                case 20 -> stat.getGoldDiffAt20();
-                                                case 25 -> stat.getGoldDiffAt25();
-                                                default -> 0;
-                                        };
-                                        teamGoldDiff += goldDiff != null ? goldDiff : 0;
-                                }
-                        }
-                        totalGoldDiff += teamGoldDiff;
-                        gameCount++;
-                }
+		return new RadarMetrics(
+				team.getId(),
+				team.getName(),
+				gamesPlayed,
+				year,
+				winRate,
+				goldDiffAt10,
+				goldDiffAt15,
+				goldDiffAt20,
+				goldDiffAt25,
+				gspd,
+				ckpm,
+				firstBloodRate,
+				firstTowerRate,
+				firstThreeTowerRate,
+				firstHeraldRate,
+				firstDragonRate,
+				firstBaronRate,
+				dragonsPerGame,
+				voidGrubsRate,
+				towersKilledAvg,
+				towersLostAvg,
+				earlyGameRating,
+				midLateRating,
+				pointsPerGame);
+	}
 
-                return gameCount > 0 ? totalGoldDiff / gameCount : 0;
-        }
+	private double calculateAvgGoldDiffAtTime(Map<Long, List<GameParticipant>> participantsByGame, int minutes) {
+		if (participantsByGame.isEmpty()) {
+			return 0;
+		}
 
-        /**
-         * GDM (분당 골드차) 계산 - gol.gg 방식
-         * 팀 earnedGold 합산 vs 상대팀 earnedGold 차이 / 경기시간(분)
-         */
-        private double calculateGoldDiffPerMin(Map<Long, List<GameParticipant>> participantsByGame,
-                        List<GameTeamStat> teamStats) {
-                if (participantsByGame.isEmpty())
-                        return 0;
+		double totalGoldDiff = 0;
+		int gameCount = 0;
 
-                double totalGdm = 0;
-                int gameCount = 0;
+		for (List<GameParticipant> gameParticipants : participantsByGame.values()) {
+			int teamGoldDiff = 0;
+			for (GameParticipant gp : gameParticipants) {
+				GamePlayerStat stat = gp.getStat();
+				if (stat == null) {
+					continue;
+				}
+				Integer goldDiff = switch (minutes) {
+					case 10 -> stat.getGoldDiffAt10();
+					case 15 -> stat.getGoldDiffAt15();
+					case 20 -> stat.getGoldDiffAt20();
+					case 25 -> stat.getGoldDiffAt25();
+					default -> 0;
+				};
+				teamGoldDiff += goldDiff != null ? goldDiff : 0;
+			}
+			totalGoldDiff += teamGoldDiff;
+			gameCount++;
+		}
 
-                for (Map.Entry<Long, List<GameParticipant>> entry : participantsByGame.entrySet()) {
-                        Long gameId = entry.getKey();
-                        List<GameParticipant> gameParticipants = entry.getValue();
+		return gameCount > 0 ? totalGoldDiff / gameCount : 0;
+	}
 
-                        // 해당 경기의 게임 시간 찾기
-                        GameTeamStat matchingStat = teamStats.stream()
-                                        .filter(s -> s.getGame().getId().equals(gameId))
-                                        .findFirst().orElse(null);
+	private RadarMetrics calculateLeagueAverage(
+			List<GameTeamStat> allStats,
+			Collection<RadarMetrics> teamMetrics,
+			String leagueName,
+			int year) {
+		int teamGameCount = allStats.size();
+		int uniqueGamesPlayed = (int) allStats.stream()
+				.map(gts -> gts.getGame().getId())
+				.distinct()
+				.count();
 
-                        if (matchingStat == null)
-                                continue;
+		long wins = allStats.stream().filter(s -> s.getResult() == 1).count();
+		double winRate = teamGameCount > 0 ? (double) wins / teamGameCount : 0;
 
-                        int gameLengthSeconds = matchingStat.getGame().getGameLengthSeconds();
-                        double gameLengthMinutes = gameLengthSeconds / 60.0;
+		double firstBloodRate = allStats.stream().filter(GameTeamStat::isFirstBlood).count()
+				/ (double) teamGameCount;
+		double firstTowerRate = allStats.stream().filter(GameTeamStat::isFirstTower).count()
+				/ (double) teamGameCount;
+		double firstThreeTowerRate = allStats.stream().filter(GameTeamStat::isFirstToThreeTowers).count()
+				/ (double) teamGameCount;
+		double firstHeraldRate = allStats.stream().filter(GameTeamStat::isFirstHerald).count()
+				/ (double) teamGameCount;
+		double firstDragonRate = allStats.stream().filter(GameTeamStat::isFirstDragon).count()
+				/ (double) teamGameCount;
+		double firstBaronRate = allStats.stream().filter(GameTeamStat::isFirstBaron).count()
+				/ (double) teamGameCount;
 
-                        // 팀 earnedGold 합산
-                        int teamGold = 0;
-                        for (GameParticipant gp : gameParticipants) {
-                                GamePlayerStat stat = gp.getStat();
-                                if (stat != null && stat.getEarnedGold() != null) {
-                                        teamGold += stat.getEarnedGold();
-                                }
-                        }
+		double dragonsPerGame = allStats.stream()
+				.mapToInt(s -> s.getDragons() != null ? s.getDragons() : 0)
+				.average().orElse(0);
 
-                        // 상대팀 골드 = 총 경기 킬당 골드 추정 (간단히 GPR 활용)
-                        // GPR = (팀골드 - 상대골드) / 상대골드 이므로
-                        // 상대골드 = 팀골드 / (1 + GPR)
-                        Double gpr = matchingStat.getGpr();
-                        int oppGold;
-                        if (gpr != null && gpr != -1) {
-                                oppGold = (int) (teamGold / (1 + gpr));
-                        } else {
-                                // GPR 없으면 승리시 +10%, 패배시 -10% 추정
-                                oppGold = matchingStat.getResult() == 1
-                                                ? (int) (teamGold * 0.9)
-                                                : (int) (teamGold * 1.1);
-                        }
+		double towersKilledAvg = allStats.stream()
+				.mapToInt(s -> s.getTowers() != null ? s.getTowers() : 0)
+				.average().orElse(0);
 
-                        double goldDiff = teamGold - oppGold;
-                        double gdm = goldDiff / gameLengthMinutes;
-                        totalGdm += gdm;
-                        gameCount++;
-                }
+		double towersLostAvg = allStats.stream()
+				.mapToInt(s -> s.getOppTowers() != null ? s.getOppTowers() : 0)
+				.average().orElse(0);
 
-                return gameCount > 0 ? totalGdm / gameCount : 0;
-        }
+		int totalVoidGrubs = allStats.stream()
+				.mapToInt(s -> s.getVoidGrubs() != null ? s.getVoidGrubs() : 0)
+				.sum();
+		int totalOppVoidGrubs = allStats.stream()
+				.mapToInt(s -> s.getOppVoidGrubs() != null ? s.getOppVoidGrubs() : 0)
+				.sum();
+		double voidGrubsRate = (totalVoidGrubs + totalOppVoidGrubs) > 0
+				? (double) totalVoidGrubs / (totalVoidGrubs + totalOppVoidGrubs)
+				: 0.5;
 
-        /**
-         * LCK 리그 평균 계산 (비교용 점선)
-         */
-        private TeamRadarStatsDto calculateLeagueAverage(int year) {
-                // LCK 리그만 필터링
-                List<GameTeamStat> allStats = gameTeamStatRepository.findByYearAndLeagueName(year, "LCK");
+		double ckpm = allStats.stream()
+				.map(GameTeamStat::getGame)
+				.mapToDouble(g -> g.getCkpm() != null ? g.getCkpm() : 0)
+				.average().orElse(0);
 
-                if (allStats.isEmpty()) {
-                        return null;
-                }
+		double gspd = allStats.stream()
+				.mapToDouble(s -> s.getGspd() != null ? s.getGspd() : 0)
+				.average().orElse(0);
 
-                int totalGames = allStats.size();
+		double earlyGameRating = (firstBloodRate + firstTowerRate + firstHeraldRate) / 3;
+		double midLateRating = (firstBaronRate + dragonsPerGame / 5.0 + winRate) / 3;
 
-                long wins = allStats.stream().filter(s -> s.getResult() == 1).count();
-                double winRate = (double) wins / totalGames;
+		double avgKills = allStats.stream()
+				.mapToInt(s -> s.getTeamKills() != null ? s.getTeamKills() : 0)
+				.average().orElse(0);
+		double pointsPerGame = avgKills + dragonsPerGame * 2 + towersKilledAvg;
 
-                double firstBloodRate = allStats.stream().filter(GameTeamStat::isFirstBlood).count()
-                                / (double) totalGames;
-                double firstTowerRate = allStats.stream().filter(GameTeamStat::isFirstTower).count()
-                                / (double) totalGames;
-                double firstThreeTowerRate = allStats.stream().filter(GameTeamStat::isFirstToThreeTowers).count()
-                                / (double) totalGames;
-                double firstHeraldRate = allStats.stream().filter(GameTeamStat::isFirstHerald).count()
-                                / (double) totalGames;
-                double firstDragonRate = allStats.stream().filter(GameTeamStat::isFirstDragon).count()
-                                / (double) totalGames;
-                double firstBaronRate = allStats.stream().filter(GameTeamStat::isFirstBaron).count()
-                                / (double) totalGames;
+		return new RadarMetrics(
+				null,
+				leagueName + " Average",
+				uniqueGamesPlayed,
+				year,
+				winRate,
+				average(teamMetrics, RadarMetrics::goldDiffAt10),
+				average(teamMetrics, RadarMetrics::goldDiffAt15),
+				average(teamMetrics, RadarMetrics::goldDiffAt20),
+				average(teamMetrics, RadarMetrics::goldDiffAt25),
+				gspd,
+				ckpm,
+				firstBloodRate,
+				firstTowerRate,
+				firstThreeTowerRate,
+				firstHeraldRate,
+				firstDragonRate,
+				firstBaronRate,
+				dragonsPerGame,
+				voidGrubsRate,
+				towersKilledAvg,
+				towersLostAvg,
+				earlyGameRating,
+				midLateRating,
+				pointsPerGame);
+	}
 
-                double dragonsPerGame = allStats.stream()
-                                .mapToInt(s -> s.getDragons() != null ? s.getDragons() : 0)
-                                .average().orElse(0);
+	private TeamRadarStatsDto toDto(RadarMetrics metrics, GoldScoreContext scoreContext) {
+		double goldDiffAt10Score = round(scoreContext.scoreAt10(metrics.goldDiffAt10()), 1);
+		double goldDiffAt15Score = round(scoreContext.scoreAt15(metrics.goldDiffAt15()), 1);
+		double goldDiffAt20Score = round(scoreContext.scoreAt20(metrics.goldDiffAt20()), 1);
+		double goldDiffAt25Score = round(scoreContext.scoreAt25(metrics.goldDiffAt25()), 1);
 
-                double towersKilledAvg = allStats.stream()
-                                .mapToInt(s -> s.getTowers() != null ? s.getTowers() : 0)
-                                .average().orElse(0);
+		return TeamRadarStatsDto.builder()
+				.teamId(metrics.teamId())
+				.teamName(metrics.teamName())
+				.gamesPlayed(metrics.gamesPlayed())
+				.year(metrics.year())
+				.winRate(round(metrics.winRate(), 3))
+				// Temporary frontend compatibility: legacy goldDiffAt* consumers still expect
+				// the radar axis value from the raw field name.
+				.goldDiffAt10(goldDiffAt10Score)
+				.goldDiffAt10Score(goldDiffAt10Score)
+				.goldDiffAt15(goldDiffAt15Score)
+				.goldDiffAt15Score(goldDiffAt15Score)
+				.goldDiffAt20(goldDiffAt20Score)
+				.goldDiffAt20Score(goldDiffAt20Score)
+				.goldDiffAt25(goldDiffAt25Score)
+				.goldDiffAt25Score(goldDiffAt25Score)
+				.gspd(round(metrics.gspd(), 3))
+				.ckpm(round(metrics.ckpm(), 2))
+				.firstBloodRate(round(metrics.firstBloodRate(), 3))
+				.firstTowerRate(round(metrics.firstTowerRate(), 3))
+				.firstThreeTowerRate(round(metrics.firstThreeTowerRate(), 3))
+				.firstHeraldRate(round(metrics.firstHeraldRate(), 3))
+				.firstDragonRate(round(metrics.firstDragonRate(), 3))
+				.firstBaronRate(round(metrics.firstBaronRate(), 3))
+				.dragonsPerGame(round(metrics.dragonsPerGame(), 2))
+				.voidGrubsRate(round(metrics.voidGrubsRate(), 3))
+				.towersKilledAvg(round(metrics.towersKilledAvg(), 2))
+				.towersLostAvg(round(metrics.towersLostAvg(), 2))
+				.earlyGameRating(round(metrics.earlyGameRating(), 3))
+				.midLateRating(round(metrics.midLateRating(), 3))
+				.pointsPerGame(round(metrics.pointsPerGame(), 2))
+				.build();
+	}
 
-                double towersLostAvg = allStats.stream()
-                                .mapToInt(s -> s.getOppTowers() != null ? s.getOppTowers() : 0)
-                                .average().orElse(0);
+	private double average(Collection<RadarMetrics> metrics, ToDoubleFunction<RadarMetrics> extractor) {
+		return metrics.stream().mapToDouble(extractor).average().orElse(0);
+	}
 
-                double ckpm = allStats.stream()
-                                .map(GameTeamStat::getGame)
-                                .mapToDouble(g -> g.getCkpm() != null ? g.getCkpm() : 0)
-                                .average().orElse(0);
+	private double round(double value, int places) {
+		double scale = Math.pow(10, places);
+		return Math.round(value * scale) / scale;
+	}
 
-                double gspd = allStats.stream()
-                                .mapToDouble(s -> s.getGspd() != null ? s.getGspd() : 0)
-                                .average().orElse(0);
+	private record RadarMetrics(
+			Long teamId,
+			String teamName,
+			int gamesPlayed,
+			int year,
+			double winRate,
+			double goldDiffAt10,
+			double goldDiffAt15,
+			double goldDiffAt20,
+			double goldDiffAt25,
+			double gspd,
+			double ckpm,
+			double firstBloodRate,
+			double firstTowerRate,
+			double firstThreeTowerRate,
+			double firstHeraldRate,
+			double firstDragonRate,
+			double firstBaronRate,
+			double dragonsPerGame,
+			double voidGrubsRate,
+			double towersKilledAvg,
+			double towersLostAvg,
+			double earlyGameRating,
+			double midLateRating,
+			double pointsPerGame) {
+	}
 
-                double earlyGameRating = (firstBloodRate + firstTowerRate + firstHeraldRate) / 3;
-                double mlr = (firstBaronRate + dragonsPerGame / 5.0 + winRate) / 3;
+	private record GoldScoreContext(
+			double avg10,
+			double maxAbs10,
+			double avg15,
+			double maxAbs15,
+			double avg20,
+			double maxAbs20,
+			double avg25,
+			double maxAbs25) {
 
-                double avgKills = allStats.stream()
-                                .mapToInt(s -> s.getTeamKills() != null ? s.getTeamKills() : 0)
-                                .average().orElse(0);
-                double pointsPerGame = avgKills + dragonsPerGame * 2 + towersKilledAvg;
+		private static GoldScoreContext from(Collection<RadarMetrics> metrics) {
+			double avg10 = metrics.stream().mapToDouble(RadarMetrics::goldDiffAt10).average().orElse(0);
+			double avg15 = metrics.stream().mapToDouble(RadarMetrics::goldDiffAt15).average().orElse(0);
+			double avg20 = metrics.stream().mapToDouble(RadarMetrics::goldDiffAt20).average().orElse(0);
+			double avg25 = metrics.stream().mapToDouble(RadarMetrics::goldDiffAt25).average().orElse(0);
 
-                return TeamRadarStatsDto.builder()
-                                .teamId(null)
-                                .teamName("LCK Average")
-                                .gamesPlayed(totalGames / 2)
-                                .year(year)
-                                .winRate(round(winRate, 3))
-                                .goldDiffAt10(0.0) // 리그 평균은 항상 0
-                                .goldDiffAt15(0.0)
-                                .goldDiffAt20(0.0)
-                                .goldDiffAt25(0.0)
-                                .gspd(round(gspd, 3))
-                                .ckpm(round(ckpm, 2))
-                                .firstBloodRate(round(firstBloodRate, 3))
-                                .firstTowerRate(round(firstTowerRate, 3))
-                                .firstThreeTowerRate(round(firstThreeTowerRate, 3))
-                                .firstHeraldRate(round(firstHeraldRate, 3))
-                                .firstDragonRate(round(firstDragonRate, 3))
-                                .firstBaronRate(round(firstBaronRate, 3))
-                                .dragonsPerGame(round(dragonsPerGame, 2))
-                                .voidGrubsRate(0.5)
-                                .towersKilledAvg(round(towersKilledAvg, 2))
-                                .towersLostAvg(round(towersLostAvg, 2))
-                                .earlyGameRating(round(earlyGameRating, 3))
-                                .midLateRating(round(mlr, 3))
-                                .pointsPerGame(round(pointsPerGame, 2))
-                                .build();
-        }
+			return new GoldScoreContext(
+					avg10,
+					maxAbsDeviation(metrics, avg10, RadarMetrics::goldDiffAt10),
+					avg15,
+					maxAbsDeviation(metrics, avg15, RadarMetrics::goldDiffAt15),
+					avg20,
+					maxAbsDeviation(metrics, avg20, RadarMetrics::goldDiffAt20),
+					avg25,
+					maxAbsDeviation(metrics, avg25, RadarMetrics::goldDiffAt25));
+		}
 
-        private double round(double value, int places) {
-                double scale = Math.pow(10, places);
-                return Math.round(value * scale) / scale;
-        }
+		private static double maxAbsDeviation(
+				Collection<RadarMetrics> metrics,
+				double average,
+				ToDoubleFunction<RadarMetrics> extractor) {
+			return metrics.stream()
+					.mapToDouble(metric -> Math.abs(extractor.applyAsDouble(metric) - average))
+					.max()
+					.orElse(0);
+		}
+
+		private double scoreAt10(double raw) {
+			return score(raw, avg10, maxAbs10);
+		}
+
+		private double scoreAt15(double raw) {
+			return score(raw, avg15, maxAbs15);
+		}
+
+		private double scoreAt20(double raw) {
+			return score(raw, avg20, maxAbs20);
+		}
+
+		private double scoreAt25(double raw) {
+			return score(raw, avg25, maxAbs25);
+		}
+
+		private double score(double raw, double average, double maxAbsDeviation) {
+			if (maxAbsDeviation == 0) {
+				return 50;
+			}
+			double normalized = 50 + 50 * (raw - average) / maxAbsDeviation;
+			return Math.max(0, Math.min(100, normalized));
+		}
+	}
 }

--- a/src/main/java/com/toy/nar/app/analysis/service/TeamScatterService.java
+++ b/src/main/java/com/toy/nar/app/analysis/service/TeamScatterService.java
@@ -20,14 +20,25 @@ public class TeamScatterService {
 
 	private final GameTeamStatRepository gameTeamStatRepository;
 
-	public TeamScatterResponse getTeamScatterStats(String leagueName, int year, String metric) {
-		String normalizedLeague = normalizeLeagueName(leagueName);
+	public TeamScatterResponse getTeamScatterStats(
+			String leagueName,
+			Integer year,
+			String split,
+			String patch,
+			String side,
+			String metric) {
+		TeamAnalysisFilter filter = TeamAnalysisFilter.from(leagueName, year, split, patch, side);
 		TeamScatterMetric scatterMetric = TeamScatterMetric.from(metric);
 
-		List<Object[]> rows = gameTeamStatRepository.findTeamScatterStatsByLeagueAndYear(year, normalizedLeague);
+		List<Object[]> rows = gameTeamStatRepository.findTeamScatterStatsByFilter(
+				filter.year(),
+				filter.leagueName(),
+				filter.split(),
+				filter.patch(),
+				filter.side());
 		if (rows.isEmpty()) {
 			throw new IllegalArgumentException(
-					"No team stats found for league " + normalizedLeague + " in year " + year);
+					"No team stats found for league " + filter.leagueName() + " in year " + filter.year());
 		}
 
 		List<TeamScatterPointDto> points = rows.stream()
@@ -53,8 +64,8 @@ public class TeamScatterService {
 		double xLeagueAverage = totalGames > 0 ? weightedX / totalGames : 0;
 
 		return TeamScatterResponse.builder()
-				.leagueName(normalizedLeague)
-				.year(year)
+				.leagueName(filter.leagueName())
+				.year(filter.year())
 				.metric(scatterMetric)
 				.xAxisLabel(scatterMetric.getAxisLabel())
 				.yAxisLabel("Win Rate (%)")
@@ -97,13 +108,6 @@ public class TeamScatterService {
 				.avgGold(round(avgGold, 2))
 				.avgObjectives(round(avgObjectives, 2))
 				.build();
-	}
-
-	private String normalizeLeagueName(String leagueName) {
-		if (leagueName == null || leagueName.isBlank()) {
-			return "LCK";
-		}
-		return leagueName.trim().toUpperCase();
 	}
 
 	private double round(double value, int scale) {

--- a/src/main/java/com/toy/nar/domain/game/repository/GameParticipantRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/GameParticipantRepository.java
@@ -100,6 +100,26 @@ public interface GameParticipantRepository
 			""")
 	List<GameParticipant> findByTeamIdAndYearWithStats(@Param("teamId") Long teamId, @Param("year") int year);
 
+	@Query("""
+				SELECT gp FROM GameParticipant gp
+				LEFT JOIN FETCH gp.stat s
+				JOIN FETCH gp.game g
+				JOIN FETCH gp.team t
+				JOIN g.league l
+				WHERE l.leagueName = :leagueName
+				AND (:year IS NULL OR YEAR(g.actualGameStartTime) = :year)
+				AND (:split IS NULL OR l.seasonSplit = :split)
+				AND (:patch IS NULL OR g.patch = :patch)
+				AND (:side IS NULL OR UPPER(gp.side) = :side)
+				ORDER BY g.actualGameStartTime
+			""")
+	List<GameParticipant> findByFilterWithStats(
+			@Param("leagueName") String leagueName,
+			@Param("year") Integer year,
+			@Param("split") String split,
+			@Param("patch") String patch,
+			@Param("side") String side);
+
 	/**
 	 * 팀-포지션별 모스트 픽 조회 (팀 랭킹용)
 	 */

--- a/src/main/java/com/toy/nar/domain/participant/repository/GameTeamStatRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/GameTeamStatRepository.java
@@ -60,6 +60,32 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 			""")
 	List<GameTeamStat> findByYearAndLeagueName(@Param("year") int year, @Param("leagueName") String leagueName);
 
+	@Query("""
+				SELECT gts FROM GameTeamStat gts
+				JOIN FETCH gts.game g
+				JOIN FETCH gts.team t
+				JOIN g.league l
+				WHERE l.leagueName = :leagueName
+				AND (:year IS NULL OR YEAR(g.actualGameStartTime) = :year)
+				AND (:split IS NULL OR l.seasonSplit = :split)
+				AND (:patch IS NULL OR g.patch = :patch)
+				AND (
+					:side IS NULL OR EXISTS (
+						SELECT 1 FROM GameParticipant gp
+						WHERE gp.game = g
+						AND gp.team = gts.team
+						AND UPPER(gp.side) = :side
+					)
+				)
+				ORDER BY g.actualGameStartTime
+			""")
+	List<GameTeamStat> findByFilter(
+			@Param("leagueName") String leagueName,
+			@Param("year") Integer year,
+			@Param("split") String split,
+			@Param("patch") String patch,
+			@Param("side") String side);
+
 	/**
 	 * 필터 기반 팀별 승률 통계 조회 (팀 랭킹용)
 	 */
@@ -149,13 +175,27 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 				JOIN game_player_stat gps ON gps.game_participant_id = gp.participant_game_id
 				GROUP BY gp.game_id, gp.team_id
 			) tg ON tg.game_id = g.game_id AND tg.team_id = t.team_id
-			WHERE YEAR(g.actual_game_start_time) = :year
+			WHERE (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 			  AND l.league_name = :leagueName
+			  AND (:split IS NULL OR l.season_split = :split)
+			  AND (:patch IS NULL OR g.patch = :patch)
+			  AND (
+				:side IS NULL OR EXISTS (
+					SELECT 1
+					FROM game_participants gp_side
+					WHERE gp_side.game_id = g.game_id
+					  AND gp_side.team_id = t.team_id
+					  AND UPPER(gp_side.side) = :side
+				)
+			  )
 			GROUP BY t.team_id, t.team_name, t.team_code, t.team_image_url
 			""", nativeQuery = true)
-	List<Object[]> findTeamScatterStatsByLeagueAndYear(
-			@Param("year") int year,
-			@Param("leagueName") String leagueName);
+	List<Object[]> findTeamScatterStatsByFilter(
+			@Param("year") Integer year,
+			@Param("leagueName") String leagueName,
+			@Param("split") String split,
+			@Param("patch") String patch,
+			@Param("side") String side);
 
 	/**
 	 * 팀별 상세 지표 집계 (세트 기준).
@@ -189,13 +229,27 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 				JOIN game_player_stat gps ON gps.game_participant_id = gp.participant_game_id
 				GROUP BY gp.game_id, gp.team_id
 			) tg ON tg.game_id = g.game_id AND tg.team_id = t.team_id
-			WHERE YEAR(g.actual_game_start_time) = :year
+			WHERE (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 			  AND l.league_name = :leagueName
+			  AND (:split IS NULL OR l.season_split = :split)
+			  AND (:patch IS NULL OR g.patch = :patch)
+			  AND (
+				:side IS NULL OR EXISTS (
+					SELECT 1
+					FROM game_participants gp_side
+					WHERE gp_side.game_id = g.game_id
+					  AND gp_side.team_id = t.team_id
+					  AND UPPER(gp_side.side) = :side
+				)
+			  )
 			GROUP BY t.team_id, t.team_name, t.team_code, t.team_image_url
 			""", nativeQuery = true)
-	List<Object[]> findTeamDetailStatsByLeagueAndYear(
-			@Param("year") int year,
-			@Param("leagueName") String leagueName);
+	List<Object[]> findTeamDetailStatsByFilter(
+			@Param("year") Integer year,
+			@Param("leagueName") String leagueName,
+			@Param("split") String split,
+			@Param("patch") String patch,
+			@Param("side") String side);
 
 	/**
 	 * 팀별 매치(시리즈) 전적 집계.
@@ -215,8 +269,19 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 					AND opp.team_id <> gts.team_id
 				JOIN games g ON g.game_id = gts.game_id
 				JOIN leagues l ON l.league_id = g.league_id
-				WHERE YEAR(g.actual_game_start_time) = :year
+				WHERE (:year IS NULL OR YEAR(g.actual_game_start_time) = :year)
 				  AND l.league_name = :leagueName
+				  AND (:split IS NULL OR l.season_split = :split)
+				  AND (:patch IS NULL OR g.patch = :patch)
+				  AND (
+					:side IS NULL OR EXISTS (
+						SELECT 1
+						FROM game_participants gp_side
+						WHERE gp_side.game_id = g.game_id
+						  AND gp_side.team_id = gts.team_id
+						  AND UPPER(gp_side.side) = :side
+					)
+				  )
 			),
 			series AS (
 				SELECT
@@ -236,9 +301,12 @@ public interface GameTeamStatRepository extends JpaRepository<GameTeamStat, Long
 			FROM series
 			GROUP BY team_id
 			""", nativeQuery = true)
-	List<Object[]> findTeamSeriesStatsByLeagueAndYear(
-			@Param("year") int year,
-			@Param("leagueName") String leagueName);
+	List<Object[]> findTeamSeriesStatsByFilter(
+			@Param("year") Integer year,
+			@Param("leagueName") String leagueName,
+			@Param("split") String split,
+			@Param("patch") String patch,
+			@Param("side") String side);
 
 	/**
 	 * 팀 페이지 대시보드 - 게임 요약(세트 기준) 집계.

--- a/src/test/java/com/toy/nar/app/analysis/service/TeamDetailStatsServiceTest.java
+++ b/src/test/java/com/toy/nar/app/analysis/service/TeamDetailStatsServiceTest.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.analysis.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -28,16 +29,21 @@ class TeamDetailStatsServiceTest {
 	@Test
 	@DisplayName("팀 승률 기준으로 상세 지표를 정렬해 반환한다")
 	void getTeamDetailStats_sortedByWinRate() {
-		when(gameTeamStatRepository.findTeamDetailStatsByLeagueAndYear(2026, "LCK"))
+		when(gameTeamStatRepository.findTeamDetailStatsByFilter(2026, "LCK", "Round 1-2", "14.1", "RED"))
 				.thenReturn(List.of(
 						new Object[] { 1L, "T1", "T1", "img1", 30L, 20L, 10L, 16.2, 64500.0, 0.8, 2.1, 6.3, 18L, 17L, 16L, 14L, 12L },
 						new Object[] { 2L, "GEN", "GEN", "img2", 30L, 21L, 9L, 15.8, 64000.0, 0.9, 2.0, 6.0, 16L, 15L, 14L, 13L, 11L }));
-		when(gameTeamStatRepository.findTeamSeriesStatsByLeagueAndYear(2026, "LCK"))
+		when(gameTeamStatRepository.findTeamSeriesStatsByFilter(2026, "LCK", "Round 1-2", "14.1", "RED"))
 				.thenReturn(List.of(
 						new Object[] { 1L, 10L, 7L, 3L },
 						new Object[] { 2L, 10L, 8L, 2L }));
 
-		TeamDetailStatsResponse response = teamDetailStatsService.getTeamDetailStats("LCK", 2026);
+		TeamDetailStatsResponse response = teamDetailStatsService.getTeamDetailStats(
+				"lck",
+				2026,
+				"Round 1-2",
+				"14.1",
+				"red");
 
 		assertThat(response.getItems()).hasSize(2);
 		assertThat(response.getItems().get(0).getTeamName()).isEqualTo("GEN");
@@ -45,15 +51,17 @@ class TeamDetailStatsServiceTest {
 		assertThat(response.getItems().get(0).getMatchesPlayed()).isEqualTo(10);
 		assertThat(response.getItems().get(0).getSetWins()).isEqualTo(21);
 		assertThat(response.getItems().get(0).getFirstBloodRatePct()).isEqualTo(53.3);
+		verify(gameTeamStatRepository).findTeamDetailStatsByFilter(2026, "LCK", "Round 1-2", "14.1", "RED");
+		verify(gameTeamStatRepository).findTeamSeriesStatsByFilter(2026, "LCK", "Round 1-2", "14.1", "RED");
 	}
 
 	@Test
 	@DisplayName("조회 데이터가 없으면 예외를 던진다")
 	void getTeamDetailStats_noData() {
-		when(gameTeamStatRepository.findTeamDetailStatsByLeagueAndYear(2026, "LCK"))
+		when(gameTeamStatRepository.findTeamDetailStatsByFilter(2026, "LCK", null, null, null))
 				.thenReturn(List.of());
 
-		assertThatThrownBy(() -> teamDetailStatsService.getTeamDetailStats("LCK", 2026))
+		assertThatThrownBy(() -> teamDetailStatsService.getTeamDetailStats("LCK", 2026, null, null, "ALL"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("No team detail stats found");
 	}

--- a/src/test/java/com/toy/nar/app/analysis/service/TeamRadarServiceTest.java
+++ b/src/test/java/com/toy/nar/app/analysis/service/TeamRadarServiceTest.java
@@ -1,0 +1,243 @@
+package com.toy.nar.app.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.toy.nar.app.analysis.dto.TeamRadarResponse;
+import com.toy.nar.domain.game.entity.Game;
+import com.toy.nar.domain.game.entity.GameParticipant;
+import com.toy.nar.domain.game.entity.League;
+import com.toy.nar.domain.game.repository.GameParticipantRepository;
+import com.toy.nar.domain.participant.entity.Champion;
+import com.toy.nar.domain.participant.entity.GamePlayerStat;
+import com.toy.nar.domain.participant.entity.GameTeamStat;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.GameTeamStatRepository;
+
+@ExtendWith(MockitoExtension.class)
+class TeamRadarServiceTest {
+
+	@Mock
+	private GameTeamStatRepository gameTeamStatRepository;
+
+	@Mock
+	private GameParticipantRepository gameParticipantRepository;
+
+	@InjectMocks
+	private TeamRadarService teamRadarService;
+
+	@Test
+	@DisplayName("ALL 필터에서는 gold raw와 score를 함께 계산하고 side는 null로 전달한다")
+	void getTeamRadarStats_allSideComputesGoldScores() {
+		League league = league(1L, "LCK", 2026, "Round 1-2");
+		Team gen = team(23L, "GEN");
+		Team t1 = team(1L, "T1");
+		Game game1 = game(101L, league, "14.1", LocalDateTime.of(2026, 1, 10, 17, 0), 1, 0.95);
+		Game game2 = game(102L, league, "14.1", LocalDateTime.of(2026, 1, 12, 17, 0), 2, 0.90);
+
+		List<GameTeamStat> allStats = List.of(
+				teamStat(game1, gen, 1, 20, true, true, true, true, true, true, 3, 1, 8, 3, 6, 1, 0.12),
+				teamStat(game2, gen, 1, 18, true, false, true, false, true, true, 2, 1, 7, 4, 4, 2, 0.10),
+				teamStat(game1, t1, 0, 10, false, false, false, false, false, false, 1, 3, 3, 8, 1, 6, -0.12),
+				teamStat(game2, t1, 0, 12, false, true, false, true, false, false, 1, 2, 4, 7, 2, 4, -0.10));
+
+		List<GameParticipant> allParticipants = new ArrayList<>();
+		allParticipants.addAll(participants(game1, gen, "Blue", 150, 250, 350, 450));
+		allParticipants.addAll(participants(game2, gen, "Red", 150, 250, 350, 450));
+		allParticipants.addAll(participants(game1, t1, "Red", -150, -250, -350, -450));
+		allParticipants.addAll(participants(game2, t1, "Blue", -150, -250, -350, -450));
+
+		when(gameTeamStatRepository.findByFilter("LCK", 2026, "Round 1-2", "14.1", null))
+				.thenReturn(allStats);
+		when(gameParticipantRepository.findByFilterWithStats("LCK", 2026, "Round 1-2", "14.1", null))
+				.thenReturn(allParticipants);
+
+		TeamRadarResponse response = teamRadarService.getTeamRadarStats(23L, "lck", 2026, "Round 1-2", "14.1", "ALL");
+
+		assertThat(response.getStats().getTeamId()).isEqualTo(23L);
+		assertThat(response.getStats().getGamesPlayed()).isEqualTo(2);
+		assertThat(response.getStats().getGoldDiffAt10()).isEqualTo(100.0);
+		assertThat(response.getStats().getGoldDiffAt15()).isEqualTo(100.0);
+		assertThat(response.getStats().getGoldDiffAt10Score()).isEqualTo(100.0);
+		assertThat(response.getLeagueAverage().getTeamName()).isEqualTo("LCK Average");
+		assertThat(response.getLeagueAverage().getGamesPlayed()).isEqualTo(2);
+		assertThat(response.getLeagueAverage().getGoldDiffAt10()).isEqualTo(50.0);
+		assertThat(response.getLeagueAverage().getGoldDiffAt10Score()).isEqualTo(50.0);
+
+		verify(gameTeamStatRepository).findByFilter("LCK", 2026, "Round 1-2", "14.1", null);
+		verify(gameParticipantRepository).findByFilterWithStats("LCK", 2026, "Round 1-2", "14.1", null);
+	}
+
+	@Test
+	@DisplayName("side 필터를 사용하면 대문자로 정규화되고 편차가 0이면 gold score는 50이다")
+	void getTeamRadarStats_normalizesSideAndHandlesFlatCohort() {
+		League league = league(1L, "LCK", 2026, "Round 1-2");
+		Team gen = team(23L, "GEN");
+		Game game = game(201L, league, "14.1", LocalDateTime.of(2026, 2, 1, 17, 0), 1, 1.02);
+
+		List<GameTeamStat> allStats = List.of(
+				teamStat(game, gen, 1, 16, true, true, true, true, true, true, 2, 0, 9, 2, 5, 0, 0.11));
+		List<GameParticipant> allParticipants = participants(game, gen, "Blue", -40, 20, 60, 120);
+
+		when(gameTeamStatRepository.findByFilter("LCK", 2026, "Round 1-2", "14.1", "BLUE"))
+				.thenReturn(allStats);
+		when(gameParticipantRepository.findByFilterWithStats("LCK", 2026, "Round 1-2", "14.1", "BLUE"))
+				.thenReturn(allParticipants);
+
+		TeamRadarResponse response = teamRadarService.getTeamRadarStats(23L, "LCK", 2026, "Round 1-2", "14.1", "blue");
+
+		assertThat(response.getStats().getGoldDiffAt10()).isEqualTo(50.0);
+		assertThat(response.getStats().getGoldDiffAt10Score()).isEqualTo(50.0);
+		assertThat(response.getLeagueAverage().getGoldDiffAt10()).isEqualTo(50.0);
+		assertThat(response.getLeagueAverage().getGoldDiffAt10Score()).isEqualTo(50.0);
+
+		verify(gameTeamStatRepository).findByFilter("LCK", 2026, "Round 1-2", "14.1", "BLUE");
+		verify(gameParticipantRepository).findByFilterWithStats("LCK", 2026, "Round 1-2", "14.1", "BLUE");
+	}
+
+	@Test
+	@DisplayName("필터에 맞는 경기 데이터가 없으면 예외를 던진다")
+	void getTeamRadarStats_noData() {
+		when(gameTeamStatRepository.findByFilter("LCK", 2026, null, null, null))
+				.thenReturn(List.of());
+
+		assertThatThrownBy(() -> teamRadarService.getTeamRadarStats(23L, "LCK", 2026, null, null, "ALL"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("No games found for league LCK in year 2026");
+	}
+
+	private Team team(Long id, String name) {
+		Team team = Team.builder()
+				.name(name)
+				.code(name)
+				.imageUrl(name + ".png")
+				.build();
+		ReflectionTestUtils.setField(team, "id", id);
+		return team;
+	}
+
+	private League league(Long id, String leagueName, int year, String split) {
+		League league = League.builder()
+				.leagueName(leagueName)
+				.seasonYear(year)
+				.seasonSplit(split)
+				.isPlayoffs(false)
+				.build();
+		ReflectionTestUtils.setField(league, "id", id);
+		return league;
+	}
+
+	private Game game(Long id, League league, String patch, LocalDateTime startTime, int gameNumber, double ckpm) {
+		Game game = Game.builder()
+				.league(league)
+				.actualGameStartTime(startTime)
+				.gameNumber(gameNumber)
+				.patch(patch)
+				.gameLengthSeconds(1800)
+				.ckpm(ckpm)
+				.build();
+		ReflectionTestUtils.setField(game, "id", id);
+		return game;
+	}
+
+	private GameTeamStat teamStat(
+			Game game,
+			Team team,
+			int result,
+			int teamKills,
+			boolean firstBlood,
+			boolean firstTower,
+			boolean firstThreeTower,
+			boolean firstHerald,
+			boolean firstDragon,
+			boolean firstBaron,
+			int dragons,
+			int oppDragons,
+			int towers,
+			int oppTowers,
+			int voidGrubs,
+			int oppVoidGrubs,
+			double gspd) {
+		return GameTeamStat.builder()
+				.game(game)
+				.team(team)
+				.result(result)
+				.teamKills(teamKills)
+				.teamDeaths(0)
+				.isFirstBlood(firstBlood)
+				.gspd(gspd)
+				.isFirstDragon(firstDragon)
+				.dragons(dragons)
+				.oppDragons(oppDragons)
+				.isFirstHerald(firstHerald)
+				.heralds(firstHerald ? 1 : 0)
+				.oppHeralds(firstHerald ? 0 : 1)
+				.voidGrubs(voidGrubs)
+				.oppVoidGrubs(oppVoidGrubs)
+				.isFirstBaron(firstBaron)
+				.barons(firstBaron ? 1 : 0)
+				.oppBarons(firstBaron ? 0 : 1)
+				.isFirstTower(firstTower)
+				.towers(towers)
+				.oppTowers(oppTowers)
+				.isFirstToThreeTowers(firstThreeTower)
+				.build();
+	}
+
+	private List<GameParticipant> participants(
+			Game game,
+			Team team,
+			String side,
+			int goldDiffAt10,
+			int goldDiffAt15,
+			int goldDiffAt20,
+			int goldDiffAt25) {
+		List<GameParticipant> participants = new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			Player player = Player.builder()
+					.name(team.getName() + "-player-" + i)
+					.imageUrl(team.getName() + "-player-" + i + ".png")
+					.build();
+			Champion champion = Champion.builder()
+					.championNameKr("챔피언" + i)
+					.championNameEn("Champion" + i)
+					.imageUrl("champion-" + i + ".png")
+					.loadingImageUrl("champion-" + i + "-loading.png")
+					.build();
+			GameParticipant participant = GameParticipant.builder()
+					.game(game)
+					.player(player)
+					.team(team)
+					.side(side)
+					.position("top")
+					.champion(champion)
+					.isWin(true)
+					.build();
+			GamePlayerStat stat = GamePlayerStat.builder()
+					.gameParticipant(participant)
+					.goldDiffAt10(goldDiffAt10)
+					.goldDiffAt15(goldDiffAt15)
+					.goldDiffAt20(goldDiffAt20)
+					.goldDiffAt25(goldDiffAt25)
+					.build();
+			participant.setStat(stat);
+			participants.add(participant);
+		}
+		return participants;
+	}
+}

--- a/src/test/java/com/toy/nar/app/analysis/service/TeamScatterServiceTest.java
+++ b/src/test/java/com/toy/nar/app/analysis/service/TeamScatterServiceTest.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.analysis.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -29,12 +30,18 @@ class TeamScatterServiceTest {
 	@Test
 	@DisplayName("KILLS 지표로 팀 스캐터 데이터를 계산한다")
 	void getTeamScatterStats_killsMetric() {
-		when(gameTeamStatRepository.findTeamScatterStatsByLeagueAndYear(2026, "LCK"))
+		when(gameTeamStatRepository.findTeamScatterStatsByFilter(2026, "LCK", "Round 1-2", "14.1", "BLUE"))
 				.thenReturn(List.of(
 						new Object[] { 1L, "T1", "T1", "img1", 20L, 14L, 19.0, 16.0, 65000.0, 10.5 },
 						new Object[] { 2L, "GEN", "GEN", "img2", 20L, 10L, 17.0, 15.0, 64000.0, 9.0 }));
 
-		TeamScatterResponse response = teamScatterService.getTeamScatterStats("LCK", 2026, "KILLS");
+		TeamScatterResponse response = teamScatterService.getTeamScatterStats(
+				"lck",
+				2026,
+				"Round 1-2",
+				"14.1",
+				"blue",
+				"KILLS");
 
 		assertThat(response.getMetric()).isEqualTo(TeamScatterMetric.KILLS);
 		assertThat(response.getPoints()).hasSize(2);
@@ -43,12 +50,13 @@ class TeamScatterServiceTest {
 		assertThat(response.getPoints().get(0).getAvgOverall()).isEqualTo(19.0);
 		assertThat(response.getXLeagueAverage()).isEqualTo(15.5);
 		assertThat(response.getYLeagueAverage()).isEqualTo(60.0);
+		verify(gameTeamStatRepository).findTeamScatterStatsByFilter(2026, "LCK", "Round 1-2", "14.1", "BLUE");
 	}
 
 	@Test
 	@DisplayName("지원하지 않는 metric 요청 시 예외를 던진다")
 	void getTeamScatterStats_invalidMetric() {
-		assertThatThrownBy(() -> teamScatterService.getTeamScatterStats("LCK", 2026, "CS"))
+		assertThatThrownBy(() -> teamScatterService.getTeamScatterStats("LCK", 2026, null, null, "ALL", "CS"))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("Unsupported metric");
 	}


### PR DESCRIPTION
## Summary
teams 분석 API의 필터 체계를 dashboard와 동일하게 맞추고, radar의 GOLD 축이 프론트에서 바로 반영되도록 score 기반 응답을 추가했습니다.

## Changes

- radar, scatter, detail-stats 엔드포인트에 league/year/split/patch/side 필터를 공통 적용

- TeamAnalysisFilter를 추가해 필터 정규화 로직 통합

- GameTeamStatRepository, GameParticipantRepository 쿼리에 split/patch/side 필터 반영

- side 필터는 EXISTS 기반으로 적용해 중복 집계 방지

- TeamRadarStatsDto에 goldDiffAt*Score 필드 추가

- 임시 프론트 호환을 위해 radar 응답의 goldDiffAt* 필드에 score 값 덮어쓰기

- TeamRadarServiceTest, TeamScatterServiceTest, TeamDetailStatsServiceTest 보강