### PR TITLE
fix: 구글 드라이브 팀 중복 동기화 방지

### DIFF
--- a/src/main/java/com/toy/nar/app/data/ingestion/EntityResolver.java
+++ b/src/main/java/com/toy/nar/app/data/ingestion/EntityResolver.java
@@ -21,6 +21,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,6 +50,16 @@ public class EntityResolver {
 
 	@Transactional(readOnly = true)
 	public void initializeCaches() {
+		if (teamCache.isEmpty()) {
+			Map<String, Team> cachedTeams = teamRepository.findAllWithLeagueTeams().stream()
+					.collect(Collectors.toMap(
+							team -> NameNormalizer.normalizeTeamLookupKey(team.getName()),
+							team -> team,
+							(existing, ignored) -> existing,
+							LinkedHashMap::new));
+			teamCache.putAll(cachedTeams);
+			log.info("Initialized Team cache with {} entries.", teamCache.size());
+		}
 		if (championCache.isEmpty()) {
 			championCache.putAll(championRepository.findAll().stream()
 					.collect(Collectors.toMap(
@@ -80,6 +91,7 @@ public class EntityResolver {
 	private void resolveTeams(Set<String> originalNames) {
 		resolveEntitiesByName(
 				originalNames,
+				NameNormalizer::normalizeTeamLookupKey,
 				NameNormalizer::normalizeTeamName,
 				teamCache,
 				teamRepository::findAllByNameInWithLeagueTeams,
@@ -90,6 +102,7 @@ public class EntityResolver {
 	private void resolvePlayers(Set<String> originalNames) {
 		resolveEntitiesByName(
 				originalNames,
+				NameNormalizer::normalizePlayerLookupKey,
 				NameNormalizer::normalizePlayerName,
 				playerCache,
 				playerRepository::findAllByNameInIgnoreCase,
@@ -100,13 +113,13 @@ public class EntityResolver {
 	public Team resolveTeam(String teamName) {
 		if (!StringUtils.hasText(teamName))
 			return null;
-		return teamCache.get(NameNormalizer.normalizeTeamName(teamName.trim()));
+		return teamCache.get(NameNormalizer.normalizeTeamLookupKey(teamName.trim()));
 	}
 
 	public Player resolvePlayer(String playerName) {
 		if (!StringUtils.hasText(playerName))
 			return null;
-		return playerCache.get(NameNormalizer.normalizePlayerName(playerName.trim()));
+		return playerCache.get(NameNormalizer.normalizePlayerLookupKey(playerName.trim()));
 	}
 
 	public Champion resolveChampion(String championName) {
@@ -153,7 +166,7 @@ public class EntityResolver {
 							.build();
 
 					requiredTeamNames.forEach(teamName -> {
-						String teamLookupKey = NameNormalizer.normalizeTeamName(teamName);
+						String teamLookupKey = NameNormalizer.normalizeTeamLookupKey(teamName);
 						Team team = teamCache.get(teamLookupKey);
 						if (team != null) {
 							newLeague.addLeagueTeam(team);
@@ -173,35 +186,47 @@ public class EntityResolver {
 
 	private <T, ID> void resolveEntitiesByName(
 			Set<String> originalNames,
-			Function<String, String> storageNormalizer,
+			Function<String, String> lookupKeyNormalizer,
+			Function<String, String> canonicalNameNormalizer,
 			Map<String, T> cache,
 			Function<Set<String>, List<T>> findInDb,
 			Function<String, T> entityCreator,
 			JpaRepository<T, ID> repository) {
-		Set<String> newNormalizedNames = originalNames.stream()
+		Map<String, String> canonicalNamesByKey = originalNames.stream()
 				.filter(StringUtils::hasText)
-				.map(name -> storageNormalizer.apply(name.trim()))
-				.filter(normalizedName -> !cache.containsKey(normalizedName))
+				.map(String::trim)
+				.map(canonicalNameNormalizer)
+				.collect(Collectors.toMap(
+						lookupKeyNormalizer,
+						Function.identity(),
+						(existing, ignored) -> existing,
+						LinkedHashMap::new));
+
+		Set<String> missingKeys = canonicalNamesByKey.keySet().stream()
+				.filter(lookupKey -> !cache.containsKey(lookupKey))
 				.collect(Collectors.toSet());
 
-		if (newNormalizedNames.isEmpty())
+		if (missingKeys.isEmpty())
 			return;
 
-		log.debug("Querying DB for {} with keys: {}", repository.getClass().getSimpleName(), newNormalizedNames);
-		List<T> existingEntities = findInDb.apply(newNormalizedNames);
+		Set<String> canonicalNamesToFind = canonicalNamesByKey.entrySet().stream()
+				.filter(entry -> missingKeys.contains(entry.getKey()))
+				.map(Map.Entry::getValue)
+				.collect(Collectors.toSet());
+
+		log.debug("Querying DB for {} with names: {}", repository.getClass().getSimpleName(), canonicalNamesToFind);
+		List<T> existingEntities = findInDb.apply(canonicalNamesToFind);
 		log.debug("Found {} existing entities from DB.", existingEntities.size());
 
 		existingEntities.forEach(entity -> {
-			String normalizedName = storageNormalizer.apply(getNameFromEntity(entity));
-			cache.put(normalizedName, entity);
+			String lookupKey = lookupKeyNormalizer.apply(getNameFromEntity(entity));
+			cache.put(lookupKey, entity);
 		});
 
-		Set<String> namesOfExistingEntities = existingEntities.stream()
-				.map(entity -> storageNormalizer.apply(getNameFromEntity(entity)))
-				.collect(Collectors.toSet());
-
-		List<T> entitiesToCreate = newNormalizedNames.stream()
-				.filter(normalizedName -> !namesOfExistingEntities.contains(normalizedName))
+		List<T> entitiesToCreate = canonicalNamesByKey.entrySet().stream()
+				.filter(entry -> !cache.containsKey(entry.getKey()))
+				.map(Map.Entry::getValue)
+				.distinct()
 				.map(entityCreator)
 				.collect(Collectors.toList());
 
@@ -212,8 +237,8 @@ public class EntityResolver {
 			log.info("Successfully created {} new entities.", savedEntities.size());
 
 			savedEntities.forEach(entity -> {
-				String normalizedName = getNameFromEntity(entity);
-				cache.put(normalizedName, entity);
+				String lookupKey = lookupKeyNormalizer.apply(getNameFromEntity(entity));
+				cache.put(lookupKey, entity);
 			});
 		}
 	}

--- a/src/main/java/com/toy/nar/common/util/NameNormalizer.java
+++ b/src/main/java/com/toy/nar/common/util/NameNormalizer.java
@@ -1,6 +1,8 @@
 package com.toy.nar.common.util;
 
+import java.text.Normalizer;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.springframework.util.StringUtils;
@@ -100,6 +102,10 @@ public class NameNormalizer {
 		return toTitleCase(trimmed);
 	}
 
+	public static String normalizeTeamLookupKey(String teamName) {
+		return normalizeLookupKey(normalizeTeamName(teamName));
+	}
+
 	/**
 	 * [수정] 플레이어 이름을 표준 형식(Title Case, 양끝 공백 없음)으로 변환합니다.
 	 * 예: " hide on bush " -> "Hide On Bush"
@@ -109,6 +115,10 @@ public class NameNormalizer {
 			return "";
 		}
 		return toTitleCase(playerName.trim());
+	}
+
+	public static String normalizePlayerLookupKey(String playerName) {
+		return normalizeLookupKey(normalizePlayerName(playerName));
 	}
 
 	/**
@@ -129,6 +139,19 @@ public class NameNormalizer {
 					return Character.toUpperCase(lowerWord.charAt(0)) + lowerWord.substring(1);
 				})
 				.collect(Collectors.joining(" "));
+	}
+
+	private static String normalizeLookupKey(String input) {
+		if (!StringUtils.hasText(input)) {
+			return "";
+		}
+
+		String decomposed = Normalizer.normalize(input.trim(), Normalizer.Form.NFD);
+		String withoutDiacritics = decomposed.replaceAll("\\p{M}+", "");
+
+		return withoutDiacritics
+				.toLowerCase(Locale.ROOT)
+				.replaceAll("[\\p{Punct}\\s]+", "");
 	}
 
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -15,6 +15,9 @@ import com.toy.nar.domain.participant.entity.Team;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
+	@Query("SELECT DISTINCT t FROM Team t LEFT JOIN FETCH t.leagueTeams")
+	List<Team> findAllWithLeagueTeams();
+
 	@Query("SELECT t FROM Team t WHERE t.name IN :names")
 	List<Team> findAllByNameInIgnoreCase(@Param("names") Set<String> names);
 

--- a/src/test/java/com/toy/nar/app/data/ingestion/EntityResolverTest.java
+++ b/src/test/java/com/toy/nar/app/data/ingestion/EntityResolverTest.java
@@ -1,0 +1,85 @@
+package com.toy.nar.app.data.ingestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.toy.nar.app.data.ingestion.dto.GameDataCsvDto;
+import com.toy.nar.domain.game.entity.League;
+import com.toy.nar.domain.game.repository.LeagueRepository;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.ChampionRepository;
+import com.toy.nar.domain.participant.repository.PlayerRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+
+@ExtendWith(MockitoExtension.class)
+class EntityResolverTest {
+
+	@Mock
+	private LeagueRepository leagueRepository;
+
+	@Mock
+	private TeamRepository teamRepository;
+
+	@Mock
+	private PlayerRepository playerRepository;
+
+	@Mock
+	private ChampionRepository championRepository;
+
+	@InjectMocks
+	private EntityResolver entityResolver;
+
+	@Test
+	@DisplayName("악센트만 다른 기존 팀 이름은 새로 생성하지 않는다")
+	void resolveEntitiesFromChunk_reusesExistingTeamWhenOnlyAccentDiffers() {
+		Team existingTeam = Team.builder()
+				.name("Leviatán")
+				.code("LEV")
+				.build();
+		Player existingPlayer = Player.builder()
+				.name("Zothve")
+				.build();
+		League existingLeague = League.builder()
+				.leagueName("LTA S")
+				.seasonYear(2025)
+				.seasonSplit("Split 1")
+				.isPlayoffs(false)
+				.build();
+
+		when(teamRepository.findAllWithLeagueTeams()).thenReturn(List.of(existingTeam));
+		when(playerRepository.findAllByNameInIgnoreCase(anySet())).thenReturn(List.of(existingPlayer));
+		when(leagueRepository.findLeaguesWithTeamsByIdentifiers(anySet(), anySet()))
+				.thenReturn(List.of(existingLeague));
+		when(championRepository.findAll()).thenReturn(List.of());
+
+		entityResolver.initializeCaches();
+
+		GameDataCsvDto dto = new GameDataCsvDto();
+		dto.setLeague("LTA S");
+		dto.setYear(2025);
+		dto.setSplit("Split 1");
+		dto.setPlayoffs(0);
+		dto.setPlayername("Zothve");
+		dto.setTeamname("Leviatan");
+
+		entityResolver.resolveEntitiesFromChunk(List.of(dto));
+
+		assertThat(entityResolver.resolveTeam("Leviatan")).isSameAs(existingTeam);
+		verify(teamRepository, never()).findAllByNameInWithLeagueTeams(anySet());
+		verify(teamRepository, never()).saveAll(anyList());
+	}
+}


### PR DESCRIPTION
## Summary
Google Drive CSV 동기화 중 기존 팀명이 악센트 표기만 다른 경우를 같은 팀으로 인식하지 못해 중복 insert가 발생했다. Leviatán과 Leviatan 같은 표기 차이를 내부 조회 키에서 흡수해 기존 팀을 재사용하도록 수정했다.

## Changes
- 팀 및 플레이어 비교용 lookup key 정규화를 추가해 악센트, 공백, 구두점 차이를 무시하도록 변경
- EntityResolver가 동기화 시작 시 팀 캐시를 preload하고 lookup key 기준으로 조회 및 생성 여부를 판단하도록 수정
- TeamRepository에 leagueTeams 포함 전체 팀 preload 쿼리를 추가
- Leviatán과 Leviatan 표기 차이에서도 새 Team을 생성하지 않는 재현 테스트 추가