### PR TITLE
fix: OAuth2 인증 요청을 쿠키 기반 저장소로 전환

### DIFF
--- a/src/main/java/com/toy/nar/app/auth/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/toy/nar/app/auth/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,46 @@
+package com.toy.nar.app.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CookieOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final int COOKIE_MAX_AGE = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Optional<Cookie> cookie = CookieUtils.getCookie(request, COOKIE_NAME);
+        log.debug("[OAuth2Cookie] load - cookie present={}, uri={}", cookie.isPresent(), request.getRequestURI());
+        return cookie.map(c -> CookieUtils.deserialize(c, OAuth2AuthorizationRequest.class)).orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+            log.debug("[OAuth2Cookie] save - deleted cookie");
+            return;
+        }
+        log.debug("[OAuth2Cookie] save - setting cookie, state={}", authorizationRequest.getState());
+        CookieUtils.addCookie(response, COOKIE_NAME, CookieUtils.serialize(authorizationRequest), COOKIE_MAX_AGE);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                  HttpServletResponse response) {
+        OAuth2AuthorizationRequest request0 = loadAuthorizationRequest(request);
+        CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+        return request0;
+    }
+}

--- a/src/main/java/com/toy/nar/app/auth/CookieUtils.java
+++ b/src/main/java/com/toy/nar/app/auth/CookieUtils.java
@@ -1,0 +1,47 @@
+package com.toy.nar.app.auth;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return Optional.empty();
+        return Arrays.stream(cookies).filter(c -> c.getName().equals(name)).findFirst();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return;
+        Arrays.stream(cookies).filter(c -> c.getName().equals(name)).forEach(c -> {
+            c.setValue("");
+            c.setPath("/");
+            c.setMaxAge(0);
+            response.addCookie(c);
+        });
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return (T) SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue()));
+    }
+}

--- a/src/main/java/com/toy/nar/app/auth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/toy/nar/app/auth/OAuth2AuthenticationFailureHandler.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
@@ -10,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
@@ -20,6 +22,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
+        log.error("[OAuth2] 인증 실패: {}", exception.getMessage(), exception);
         String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl + "/oauth/callback")
                 .queryParam("error", "oauth_failed")
                 .build().toUriString();

--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.toy.nar.config;
 
+import com.toy.nar.app.auth.CookieOAuth2AuthorizationRequestRepository;
 import com.toy.nar.app.auth.CustomOAuth2UserService;
 import com.toy.nar.app.auth.JwtAuthenticationFilter;
 import com.toy.nar.app.auth.JwtTokenProvider;
@@ -24,12 +25,13 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler successHandler;
     private final OAuth2AuthenticationFailureHandler failureHandler;
+    private final CookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/v1/**", "/api/v3/**",
@@ -42,6 +44,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(a -> a
+                                .authorizationRequestRepository(authorizationRequestRepository))
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(successHandler)
                         .failureHandler(failureHandler)


### PR DESCRIPTION
## Summary
- 세션 기반 저장소 대신 쿠키 기반 CookieOAuth2AuthorizationRequestRepository로 교체
- 세션 정책 STATELESS → IF_REQUIRED
- OAuth2AuthenticationFailureHandler 원인 로깅 추가
## Why
일반 브라우저에서 이전 OAuth 시도로 남은 state 쿠키/세션이 새 요청과 충돌해
콜백 단계에서 [invalid_request]가 발생했다. 쿠키 기반 저장소는 매 요청마다
authorization request 쿠키를 새로 발급·삭제하므로 문제를 해결한다.
## Test plan
- [x] Google/Kakao/Naver 로그인 성공
- [x] /api/auth/me, onboarding, refresh, logout 정상
- [ ] api.nar.kr 배포 후 재검증