### PR TITLE
fix: 온보딩 팀 조회를 LCK 10개로 제한

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -5,7 +5,6 @@ import com.toy.nar.api.auth.dto.OnboardingRequest;
 import com.toy.nar.api.auth.dto.OnboardingTeamOptionResponse;
 import com.toy.nar.api.auth.dto.TokenResponse;
 import com.toy.nar.app.auth.JwtTokenProvider;
-import com.toy.nar.domain.game.repository.LeagueTeamRepository;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.entity.RefreshToken;
 import com.toy.nar.domain.member.repository.MemberRepository;
@@ -29,6 +28,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -38,11 +40,15 @@ import static org.springframework.http.HttpStatus.*;
 @Tag(name = "8. 인증 / 로그인", description = "소셜 로그인과 JWT 기반 사용자 인증 API")
 public class AuthController {
 
+    private static final List<String> LCK_ONBOARDING_TEAM_CODES = List.of(
+            "T1", "HLE", "GEN", "DK", "KT",
+            "DNS", "BFX", "NS", "BRO", "KRX"
+    );
+
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TeamRepository teamRepository;
-    private final LeagueTeamRepository leagueTeamRepository;
 
     @Operation(
             summary = "온보딩용 LCK 팀 목록 조회",
@@ -51,7 +57,12 @@ public class AuthController {
     @ApiResponse(responseCode = "200", description = "LCK 팀 목록 조회 성공")
     @GetMapping("/onboarding/teams")
     public ResponseEntity<List<OnboardingTeamOptionResponse>> getOnboardingTeams() {
-        List<OnboardingTeamOptionResponse> teams = leagueTeamRepository.findLatestTeamsByLeagueName("LCK").stream()
+        Map<String, Team> teamsByCode = teamRepository.findAllByCodeIn(LCK_ONBOARDING_TEAM_CODES).stream()
+                .collect(Collectors.toMap(Team::getCode, Function.identity()));
+
+        List<OnboardingTeamOptionResponse> teams = LCK_ONBOARDING_TEAM_CODES.stream()
+                .map(teamsByCode::get)
+                .filter(team -> team != null)
                 .map(OnboardingTeamOptionResponse::from)
                 .toList();
         return ResponseEntity.ok(teams);

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -33,6 +33,9 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	@Query("SELECT t FROM Team t WHERE LOWER(t.code) = LOWER(:code) AND t.code IS NOT NULL")
 	List<Team> findByCodeIgnoreCase(@Param("code") String code);
 
+	@Query("SELECT t FROM Team t WHERE t.code IN :codes")
+	List<Team> findAllByCodeIn(@Param("codes") Collection<String> codes);
+
 	@Query("SELECT t FROM Team t WHERE LOWER(t.name) = LOWER(:name)")
 	Optional<Team> findByNameIgnoreCase(@Param("name") String name);
 }


### PR DESCRIPTION
## Summary
온보딩 팀 조회 API가 리그 매핑 오염의 영향을 받아 LCK 외 팀까지 반환하던 문제를 제거하고, 온보딩 화면에서 필요한 LCK 10개 팀만 안정적으로 내려주도록 수정한다.

## Changes

- AuthController에서 온보딩 팀 조회 기준을 league_teams 조회에서 LCK 10개 팀 코드 화이트리스트 기반으로 변경했다.

- TeamRepository에 팀 코드 목록으로 조회하는 메서드를 추가했다.

- application.yml과 로그 등 사용자 작업 파일은 이번 커밋에서 제외했다.