### PR TITLE
feat: 라이브 스트리밍 수집 파이프라인 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/v3/LiveController.java
+++ b/src/main/java/com/toy/nar/api/v3/LiveController.java
@@ -1,0 +1,78 @@
+package com.toy.nar.api.v3;
+
+import com.toy.nar.app.lolesports.live.LiveBackfillService;
+import com.toy.nar.app.lolesports.live.LivePersistenceQueue;
+import com.toy.nar.app.lolesports.live.LiveSimulationService;
+import com.toy.nar.app.lolesports.live.LiveStateQueryService;
+import com.toy.nar.app.lolesports.live.LiveStateStore;
+import com.toy.nar.app.lolesports.live.dto.LiveBackfillResponse;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveGameSummaryResponse;
+import com.toy.nar.app.lolesports.live.dto.LiveSimulationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "7. Live API", description = "라이브 경기 상태 조회 API")
+@RestController
+@RequestMapping("/api/live")
+@RequiredArgsConstructor
+public class LiveController {
+
+	private final LiveStateStore liveStateStore;
+	private final LiveStateQueryService liveStateQueryService;
+	private final LiveBackfillService liveBackfillService;
+	private final LiveSimulationService liveSimulationService;
+	private final LivePersistenceQueue livePersistenceQueue;
+
+	@Operation(summary = "현재 라이브 게임 목록 조회", description = "백엔드에서 폴링 중인 라이브 게임의 최신 상태 목록을 조회합니다.")
+	@GetMapping("/games")
+	public ResponseEntity<List<LiveGameSummaryResponse>> getLiveGames() {
+		return ResponseEntity.ok(liveStateStore.getLiveGameSummaries());
+	}
+
+	@Operation(summary = "라이브 게임 최신 상태 조회", description = "특정 gameId의 최신 라이브 상태를 조회합니다.")
+	@GetMapping("/games/{gameId}")
+	public ResponseEntity<LiveGameState> getLiveGame(@PathVariable String gameId) {
+		return liveStateQueryService.getLatestState(gameId)
+				.map(ResponseEntity::ok)
+				.orElseGet(() -> ResponseEntity.notFound().build());
+	}
+
+	@Operation(summary = "분 단위 라이브 스냅샷 조회", description = "DB에 저장된 최근 60분 스냅샷을 최신순으로 조회합니다.")
+	@GetMapping("/games/{gameId}/minutes")
+	public ResponseEntity<List<LiveGameState>> getRecentMinuteSnapshots(@PathVariable String gameId) {
+		return ResponseEntity.ok(liveStateQueryService.getRecentMinuteSnapshots(gameId));
+	}
+
+	@Operation(summary = "라이브 게임 백필 실행", description = "actual_game_start_time 우선으로 시작 시각을 잡고, 없으면 분 단위로 startingTime을 늘려가며 백필합니다.")
+	@PostMapping("/games/{gameId}/backfill")
+	public ResponseEntity<LiveBackfillResponse> backfillGame(@PathVariable String gameId) {
+		return ResponseEntity.ok(liveBackfillService.backfillByMinute(gameId));
+	}
+
+	@Operation(summary = "과거 live feed 시뮬레이션", description = "과거 startingTime을 기준으로 window/details API를 재생해 현재 live processor를 검증합니다.")
+	@PostMapping("/games/{gameId}/simulate")
+	public ResponseEntity<LiveSimulationResponse> simulateGame(
+			@PathVariable String gameId,
+			@RequestParam String startingTime,
+			@RequestParam(defaultValue = "12") int ticks,
+			@RequestParam(defaultValue = "5") int stepSeconds) {
+		return ResponseEntity.ok(liveSimulationService.simulate(gameId, startingTime, ticks, stepSeconds));
+	}
+
+	@Operation(summary = "라이브 저장 큐 상태 조회", description = "snapshot/object event 비동기 저장 큐 상태를 조회합니다.")
+	@GetMapping("/queue")
+	public ResponseEntity<LivePersistenceQueue.LiveQueueStats> getQueueStats() {
+		return ResponseEntity.ok(livePersistenceQueue.stats());
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -995,6 +995,12 @@ public class LeagueMatchService {
 		if ("inProgress".equalsIgnoreCase(entity.getState())) {
 			liveStreamUrl = LeagueConstants.getLiveStreamUrl(entity.getLeagueName());
 		}
+		List<String> gameIds = leagueMatchGameRepository.findByLeagueMatch_IdOrderByGameOrderAsc(entity.getId()).stream()
+				.map(LeagueMatchGame::getGameId)
+				.filter(gameId -> gameId != null && !gameId.isBlank())
+				.distinct()
+				.toList();
+		List<String> liveGameIds = resolveLiveGameIds(entity, gameIds);
 
 		return MatchResultDto.builder().matchId(entity.getId()).leagueName(entity.getLeagueName())
 				.matchTitle(entity.getMatchTitle()).matchDate(entity.getMatchDate().toString()) // ISO
@@ -1011,7 +1017,22 @@ public class LeagueMatchService {
 						.externalTeamId(entity.getRedExternalTeamId())
 						.code(entity.getRedTeamCode()).name(entity.getRedTeamName())
 						.imageUrl(entity.getRedTeamImageUrl()).wins(entity.getRedScore()).build())
-				.sets(sets).liveStreamUrl(liveStreamUrl).build();
+				.sets(sets)
+				.gameIds(gameIds)
+				.liveGameIds(liveGameIds)
+				.liveStreamUrl(liveStreamUrl).build();
+	}
+
+	private List<String> resolveLiveGameIds(LeagueMatch entity, List<String> gameIds) {
+		if (!"inProgress".equalsIgnoreCase(entity.getState()) || gameIds == null || gameIds.isEmpty()) {
+			return List.of();
+		}
+		int completedGames = entity.getBlueScore() + entity.getRedScore();
+		int currentGameIndex = Math.min(completedGames, gameIds.size() - 1);
+		if (currentGameIndex < 0 || currentGameIndex >= gameIds.size()) {
+			return List.of();
+		}
+		return List.of(gameIds.get(currentGameIndex));
 	}
 
 	private boolean hasRealtimeRelevantChange(LeagueMatch existing, LeagueMatch incoming) {

--- a/src/main/java/com/toy/nar/app/lolesports/MatchResultDto.java
+++ b/src/main/java/com/toy/nar/app/lolesports/MatchResultDto.java
@@ -17,6 +17,8 @@ public class MatchResultDto {
 	private TeamInfo redTeam;
 	private List<SetVod> sets; // 세트별 VOD 리스트
 	private String liveStreamUrl; // 진행중 경기 라이브 스트림 URL
+	private List<String> liveGameIds; // 진행중 gameId 목록 (livestats polling 대상)
+	private List<String> gameIds; // match 하위 전체 gameId 목록 (completed 포함)
 
 	@Data
 	@Builder

--- a/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
@@ -28,22 +28,27 @@ public class WorldsService {
 	@Qualifier("applicationTaskExecutor")
 	private final Executor applicationTaskExecutor;
 
-	private static final java.util.Map<String, String> LEAGUE_IDS = java.util.Map.of(
-			"LCK", "98767991310872058",
-			"LPL", "98767991314006698",
-			"LEC", "98767991302996019",
-			"LCS", "98767991299243165",
-			"LCP", "113476371197627891",
-			"CBLOL", "98767991332355509",
-			"WORLDS", "98767975604431411",
-			"MSI", "98767991325878492");
+	private static final java.util.Map<String, String> LEAGUE_IDS = java.util.Map.ofEntries(
+			java.util.Map.entry("LCK", "98767991310872058"),
+			java.util.Map.entry("LPL", "98767991314006698"),
+			java.util.Map.entry("LEC", "98767991302996019"),
+			java.util.Map.entry("LCS", "98767991299243165"),
+			java.util.Map.entry("LCP", "113476371197627891"),
+			java.util.Map.entry("CBLOL", "98767991332355509"),
+			java.util.Map.entry("FIRST_STAND", "113464388705111224"),
+			java.util.Map.entry("WORLDS", "98767975604431411"),
+			java.util.Map.entry("MSI", "98767991325878492"));
 
 	@Value("${lolesports.riot-api.key}")
 	private String RIOT_API_KEY;
 
 	public MatchResponseWrapper getWorldsMatches(String pageToken, String leagueSlug) {
-		String leagueId = LEAGUE_IDS.getOrDefault(leagueSlug != null ? leagueSlug.toUpperCase() : "LCK",
-				LEAGUE_IDS.get("LCK"));
+		String normalizedLeague = normalizeLeagueSlug(leagueSlug);
+		String leagueId = LEAGUE_IDS.get(normalizedLeague);
+		if (leagueId == null) {
+			log.warn("Unsupported league slug for getWorldsMatches: {}", leagueSlug);
+			return MatchResponseWrapper.builder().matches(List.of()).nextPageToken(null).build();
+		}
 
 		// 1. [Schedule API] 전체 일정 조회 (이건 한 번만 하니까 block 해도 됨)
 		JsonNode scheduleRoot = callScheduleApi(pageToken, leagueId);
@@ -198,22 +203,27 @@ public class WorldsService {
 			}
 			return MatchResultDto.builder()
 					.matchId(eventId)
+					.leagueName(event.path("league").path("slug").asText("").toUpperCase())
 					.matchTitle(stageName + " | " + teamA.path("code").asText() + " vs "
 							+ teamB.path("code").asText())
 					.matchDate(matchDate)
 					.state(finalState)
 					.score(winsA + " : " + winsB)
 					.blueTeam(MatchResultDto.TeamInfo.builder()
+							.externalTeamId(teamA.path("id").asText(null))
 							.code(teamA.path("code").asText())
 							.name(teamA.path("name").asText())
 							.imageUrl(imageA)
 							.wins(winsA).build())
 					.redTeam(MatchResultDto.TeamInfo.builder()
+							.externalTeamId(teamB.path("id").asText(null))
 							.code(teamB.path("code").asText())
 							.name(teamB.path("name").asText())
 							.imageUrl(imageB)
 							.wins(winsB).build())
 					.sets(setVods)
+					.liveGameIds(extractInProgressGameIds(games))
+					.gameIds(extractAllGameIds(games))
 					.liveStreamUrl(liveStreamUrl)
 					.build();
 		} catch (Exception e) {
@@ -223,8 +233,12 @@ public class WorldsService {
 	}
 
 	public List<MatchResultDto> getRecent3Matches(String leagueSlug) {
-		String leagueId = LEAGUE_IDS.getOrDefault(leagueSlug != null ? leagueSlug.toUpperCase() : "LCK",
-				LEAGUE_IDS.get("LCK"));
+		String normalizedLeague = normalizeLeagueSlug(leagueSlug);
+		String leagueId = LEAGUE_IDS.get(normalizedLeague);
+		if (leagueId == null) {
+			log.warn("Unsupported league slug for getRecent3Matches: {}", leagueSlug);
+			return List.of();
+		}
 		// 1. [Schedule API] 전체 일정 조회
 		JsonNode scheduleRoot = callApi("/persisted/gw/getSchedule", "leagueId", leagueId);
 		if (scheduleRoot == null)
@@ -348,23 +362,28 @@ public class WorldsService {
 		}
 		return MatchResultDto.builder()
 				.matchId(eventId)
+				.leagueName(event.path("league").path("slug").asText("").toUpperCase())
 				.matchTitle(teamA.path("code").asText() + " vs " + teamB.path("code").asText())
 				.matchDate(matchDate)
 				.state(finalState)
 				.score(winsA + " : " + winsB)
 				.blueTeam(MatchResultDto.TeamInfo.builder()
+						.externalTeamId(teamA.path("id").asText(null))
 						.code(teamA.path("code").asText())
 						.name(teamA.path("name").asText())
 						.imageUrl(imageA)
 						.wins(winsA)
 						.build())
 				.redTeam(MatchResultDto.TeamInfo.builder()
+						.externalTeamId(teamB.path("id").asText(null))
 						.code(teamB.path("code").asText())
 						.name(teamB.path("name").asText())
 						.imageUrl(imageB)
 						.wins(winsB)
 						.build())
 				.sets(setVods)
+				.liveGameIds(extractInProgressGameIds(games))
+				.gameIds(extractAllGameIds(games))
 				.liveStreamUrl(liveStreamUrl)
 				.build();
 	}
@@ -429,17 +448,58 @@ public class WorldsService {
 			liveStreamUrl = LeagueConstants.getLiveStreamUrl(leagueSlug);
 		}
 		return MatchResultDto.builder()
+				.matchId(eventId)
+				.leagueName(event.path("league").path("slug").asText("").toUpperCase())
 				.matchTitle(stageName + " | " + teamA.path("code").asText() + " vs " + teamB.path("code").asText())
 				.matchDate(matchDate)
 				.state(finalState)
 				.score(winsA + " : " + winsB)
 				.blueTeam(MatchResultDto.TeamInfo.builder().code(teamA.path("code").asText())
+						.externalTeamId(teamA.path("id").asText(null))
 						.name(teamA.path("name").asText()).wins(winsA).build())
 				.redTeam(MatchResultDto.TeamInfo.builder().code(teamB.path("code").asText())
+						.externalTeamId(teamB.path("id").asText(null))
 						.name(teamB.path("name").asText()).wins(winsB).build())
 				.sets(setVods)
+				.liveGameIds(extractInProgressGameIds(games))
+				.gameIds(extractAllGameIds(games))
 				.liveStreamUrl(liveStreamUrl)
 				.build();
+	}
+
+	private String normalizeLeagueSlug(String leagueSlug) {
+		return leagueSlug == null || leagueSlug.isBlank() ? "LCK" : leagueSlug.trim().toUpperCase();
+	}
+
+	private List<String> extractInProgressGameIds(JsonNode games) {
+		List<String> ids = new ArrayList<>();
+		if (!games.isArray()) {
+			return ids;
+		}
+		for (JsonNode game : games) {
+			if (!"inProgress".equalsIgnoreCase(game.path("state").asText())) {
+				continue;
+			}
+			String gameId = game.path("id").asText();
+			if (gameId != null && !gameId.isBlank()) {
+				ids.add(gameId);
+			}
+		}
+		return ids;
+	}
+
+	private List<String> extractAllGameIds(JsonNode games) {
+		List<String> ids = new ArrayList<>();
+		if (!games.isArray()) {
+			return ids;
+		}
+		for (JsonNode game : games) {
+			String gameId = game.path("id").asText();
+			if (gameId != null && !gameId.isBlank()) {
+				ids.add(gameId);
+			}
+		}
+		return ids;
 	}
 
 	private String findBestVodUrl(JsonNode vodsNode) {

--- a/src/main/java/com/toy/nar/app/lolesports/live/ActiveLiveGame.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/ActiveLiveGame.java
@@ -1,0 +1,58 @@
+package com.toy.nar.app.lolesports.live;
+
+import java.time.LocalDateTime;
+
+public record ActiveLiveGame(
+		String gameId,
+		String matchId,
+		String leagueName,
+		String blueTeamName,
+		String redTeamName,
+		LocalDateTime lastSeenAtUtc,
+		int consecutiveFailures) {
+
+	public ActiveLiveGame withLastSeenAt(LocalDateTime seenAtUtc) {
+		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, seenAtUtc, consecutiveFailures);
+	}
+
+	public ActiveLiveGame increaseFailures() {
+		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc, consecutiveFailures + 1);
+	}
+
+	public ActiveLiveGame clearFailures() {
+		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc, 0);
+	}
+
+	public ActiveLiveGame mergeMissingMetadata(ActiveLiveGame metadata) {
+		if (metadata == null) {
+			return this;
+		}
+		return new ActiveLiveGame(
+				firstUseful(gameId, metadata.gameId()),
+				firstUseful(matchId, metadata.matchId()),
+				firstUseful(leagueName, metadata.leagueName()),
+				firstDisplayName(blueTeamName, metadata.blueTeamName()),
+				firstDisplayName(redTeamName, metadata.redTeamName()),
+				lastSeenAtUtc,
+				consecutiveFailures);
+	}
+
+	private String firstUseful(String current, String fallback) {
+		return isBlank(current) ? fallback : current;
+	}
+
+	private String firstDisplayName(String current, String fallback) {
+		if (isBlank(current) || isNumericIdentifier(current)) {
+			return fallback;
+		}
+		return current;
+	}
+
+	private boolean isBlank(String value) {
+		return value == null || value.isBlank();
+	}
+
+	private boolean isNumericIdentifier(String value) {
+		return value != null && value.length() >= 12 && value.chars().allMatch(Character::isDigit);
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/ItemMetadataResolver.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/ItemMetadataResolver.java
@@ -1,0 +1,139 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ItemMetadataResolver {
+
+	private final WebClient webClient;
+
+	@Value("${lolesports.live.item-locale:ko_KR}")
+	private String itemLocale;
+
+	@Value("${lolesports.live.item-refresh-minutes:360}")
+	private long refreshMinutes;
+
+	private volatile Instant loadedAt = Instant.EPOCH;
+	private volatile String dataDragonVersion = null;
+	private volatile Map<Integer, ItemInfo> itemsById = new HashMap<>();
+
+	public List<String> resolveItemNames(List<Integer> itemIds) {
+		ensureLoaded();
+		List<String> names = new ArrayList<>();
+		for (Integer itemId : itemIds) {
+			if (itemId == null || itemId <= 0) {
+				continue;
+			}
+			ItemInfo itemInfo = itemsById.get(itemId);
+			names.add(itemInfo != null ? itemInfo.name() : "아이템-" + itemId);
+		}
+		return names;
+	}
+
+	public List<String> resolveItemImageUrls(List<Integer> itemIds) {
+		ensureLoaded();
+		List<String> imageUrls = new ArrayList<>();
+		for (Integer itemId : itemIds) {
+			if (itemId == null || itemId <= 0) {
+				continue;
+			}
+			ItemInfo itemInfo = itemsById.get(itemId);
+			if (itemInfo != null && itemInfo.imageUrl() != null && !itemInfo.imageUrl().isBlank()) {
+				imageUrls.add(itemInfo.imageUrl());
+				continue;
+			}
+			imageUrls.add(buildFallbackImageUrl(itemId));
+		}
+		return imageUrls;
+	}
+
+	private void ensureLoaded() {
+		Instant now = Instant.now();
+		if (!itemsById.isEmpty() && Duration.between(loadedAt, now).toMinutes() < refreshMinutes) {
+			return;
+		}
+		synchronized (this) {
+			if (!itemsById.isEmpty() && Duration.between(loadedAt, Instant.now()).toMinutes() < refreshMinutes) {
+				return;
+			}
+			loadFromDataDragon();
+		}
+	}
+
+	private void loadFromDataDragon() {
+		try {
+			JsonNode versions = webClient.get()
+					.uri("https://ddragon.leagueoflegends.com/api/versions.json")
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+
+			if (versions == null || !versions.isArray() || versions.isEmpty()) {
+				log.warn("Failed to load Data Dragon versions for items.");
+				return;
+			}
+
+			String latestVersion = versions.get(0).asText();
+			JsonNode itemDataResponse = webClient.get()
+					.uri("https://ddragon.leagueoflegends.com/cdn/{version}/data/{locale}/item.json",
+							latestVersion, itemLocale)
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+
+			JsonNode itemData = itemDataResponse == null ? null : itemDataResponse.path("data");
+			if (itemData == null || !itemData.isObject()) {
+				log.warn("Failed to load Data Dragon item metadata for version: {}", latestVersion);
+				return;
+			}
+
+			Map<Integer, ItemInfo> newItemsById = new HashMap<>();
+			itemData.fields().forEachRemaining(entry -> {
+				try {
+					int itemId = Integer.parseInt(entry.getKey());
+					JsonNode itemNode = entry.getValue();
+					String name = itemNode.path("name").asText("");
+					String imageFull = itemNode.path("image").path("full").asText("");
+					String imageUrl = imageFull.isBlank()
+							? null
+							: "https://ddragon.leagueoflegends.com/cdn/" + latestVersion + "/img/item/" + imageFull;
+					newItemsById.put(itemId, new ItemInfo(name, imageUrl));
+				} catch (NumberFormatException ignore) {
+					// Ignore non-numeric item id keys.
+				}
+			});
+
+			this.itemsById = newItemsById;
+			this.dataDragonVersion = latestVersion;
+			this.loadedAt = Instant.now();
+			log.info("Loaded item metadata from Data Dragon: version={}, itemCount={}",
+					latestVersion, newItemsById.size());
+		} catch (Exception e) {
+			log.warn("Failed to refresh item metadata: {}", e.getMessage());
+		}
+	}
+
+	private String buildFallbackImageUrl(Integer itemId) {
+		if (dataDragonVersion == null || dataDragonVersion.isBlank()) {
+			return null;
+		}
+		return "https://ddragon.leagueoflegends.com/cdn/" + dataDragonVersion + "/img/item/" + itemId + ".png";
+	}
+
+	private record ItemInfo(String name, String imageUrl) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveBackfillService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveBackfillService.java
@@ -1,0 +1,297 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.live.dto.LiveBackfillResponse;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGame;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMapping;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMappingRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.domain.game.entity.Game;
+import com.toy.nar.domain.game.repository.GameRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveBackfillService {
+
+	private static final DateTimeFormatter START_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+	private final LiveStatsClient liveStatsClient;
+	private final LiveStateAggregator liveStateAggregator;
+	private final LiveMinuteSnapshotWriter snapshotWriter;
+	private final LiveObjectEventRecorder liveObjectEventRecorder;
+	private final LiveStateStore liveStateStore;
+	private final LiveGameMappingRepository liveGameMappingRepository;
+	private final LiveGameMinuteSnapshotRepository snapshotRepository;
+	private final GameRepository gameRepository;
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final LeagueMatchGameRepository leagueMatchGameRepository;
+
+	@Value("${lolesports.live.backfill.probe-max-minutes:360}")
+	private int probeMaxMinutes;
+
+	@Value("${lolesports.live.backfill.collect-max-minutes:120}")
+	private int collectMaxMinutes;
+
+	@Value("${lolesports.live.backfill.stop-empty-streak:8}")
+	private int stopEmptyStreak;
+
+	@Value("${lolesports.live.backfill.max-failures:5}")
+	private int maxFailures;
+
+	public LiveBackfillResponse backfillByMinute(String gameId) {
+		LiveContext context = resolveContext(gameId);
+		StartCandidate baseCandidate = resolveBaseStartingTime(gameId, context);
+
+		ProbeResult probeResult = probeFirstAvailableStartingTime(gameId, baseCandidate.baseStartUtc());
+		if (probeResult == null) {
+			return new LiveBackfillResponse(
+					gameId,
+					baseCandidate.source(),
+					baseCandidate.baseStartUtc(),
+					null,
+					probeMaxMinutes + 1,
+					0,
+					0,
+					probeMaxMinutes + 1,
+					0,
+					"NO_DATA_IN_PROBE_WINDOW",
+					null,
+					null);
+		}
+
+		int snapshotsWritten = 0;
+		int emptyResponses = 0;
+		int failures = 0;
+		int emptyStreak = 0;
+		int staleFrameStreak = 0;
+		int requestedMinutes = 0;
+		String stopReason = "MAX_MINUTES_REACHED";
+		LocalDateTime firstFrameTimestampUtc = null;
+		LocalDateTime lastFrameTimestampUtc = null;
+
+		for (int minuteOffset = 0; minuteOffset < collectMaxMinutes; minuteOffset++) {
+			requestedMinutes++;
+			LocalDateTime requestStartUtc = toMinuteUtc(probeResult.foundStartingTimeUtc().plusMinutes(minuteOffset));
+			try {
+				JsonNode windowResponse = minuteOffset == 0
+						? probeResult.windowResponse()
+						: liveStatsClient.getWindow(gameId, formatStartingTime(requestStartUtc));
+				JsonNode detailsResponse = minuteOffset == 0
+						? probeResult.detailsResponse()
+						: liveStatsClient.getDetails(gameId, formatStartingTime(requestStartUtc));
+
+				if (!hasFrames(windowResponse) || !hasFrames(detailsResponse)) {
+					emptyResponses++;
+					emptyStreak++;
+					if (emptyStreak >= stopEmptyStreak) {
+						stopReason = "EMPTY_STREAK_REACHED";
+						break;
+					}
+					continue;
+				}
+
+				emptyStreak = 0;
+				liveObjectEventRecorder.record(context.toActiveLiveGame(), windowResponse);
+				LiveGameState state = liveStateAggregator.aggregate(context.toActiveLiveGame(), windowResponse, detailsResponse);
+				if (state == null) {
+					continue;
+				}
+
+				if (lastFrameTimestampUtc != null && !state.frameTimestampUtc().isAfter(lastFrameTimestampUtc)) {
+					staleFrameStreak++;
+					if (staleFrameStreak >= stopEmptyStreak) {
+						stopReason = "STALE_FRAME_STREAK_REACHED";
+						break;
+					}
+					continue;
+				}
+
+				staleFrameStreak = 0;
+
+				snapshotWriter.write(state);
+				liveStateStore.putLatestState(state);
+				snapshotsWritten++;
+
+				if (firstFrameTimestampUtc == null || state.frameTimestampUtc().isBefore(firstFrameTimestampUtc)) {
+					firstFrameTimestampUtc = state.frameTimestampUtc();
+				}
+				if (lastFrameTimestampUtc == null || state.frameTimestampUtc().isAfter(lastFrameTimestampUtc)) {
+					lastFrameTimestampUtc = state.frameTimestampUtc();
+				}
+			} catch (Exception e) {
+				failures++;
+				log.warn("Live backfill failed for game {} at {}: {}", gameId, requestStartUtc, e.getMessage());
+				if (failures >= maxFailures) {
+					stopReason = "MAX_FAILURES_REACHED";
+					break;
+				}
+			}
+		}
+
+		return new LiveBackfillResponse(
+				gameId,
+				baseCandidate.source(),
+				baseCandidate.baseStartUtc(),
+				probeResult.foundStartingTimeUtc(),
+				probeResult.probeAttempts(),
+				requestedMinutes,
+				snapshotsWritten,
+				emptyResponses,
+				failures,
+				stopReason,
+				firstFrameTimestampUtc,
+				lastFrameTimestampUtc);
+	}
+
+	private ProbeResult probeFirstAvailableStartingTime(String gameId, LocalDateTime baseStartUtc) {
+		for (int minuteOffset = 0; minuteOffset <= probeMaxMinutes; minuteOffset++) {
+			LocalDateTime candidate = toMinuteUtc(baseStartUtc.plusMinutes(minuteOffset));
+			String startingTime = formatStartingTime(candidate);
+			try {
+				JsonNode windowResponse = liveStatsClient.getWindow(gameId, startingTime);
+				JsonNode detailsResponse = liveStatsClient.getDetails(gameId, startingTime);
+				if (hasFrames(windowResponse) && hasFrames(detailsResponse)) {
+					return new ProbeResult(candidate, minuteOffset + 1, windowResponse, detailsResponse);
+				}
+			} catch (Exception e) {
+				log.debug("Live backfill probe failed for game {} at {}: {}", gameId, candidate, e.getMessage());
+			}
+		}
+		return null;
+	}
+
+	private StartCandidate resolveBaseStartingTime(String gameId, LiveContext context) {
+		Optional<LiveGameMapping> mapping = liveGameMappingRepository.findByLiveGameId(gameId);
+
+		if (mapping.isPresent()) {
+			LiveGameMapping liveGameMapping = mapping.get();
+			if (liveGameMapping.getInternalGameId() != null) {
+				Optional<Game> game = gameRepository.findById(liveGameMapping.getInternalGameId());
+				if (game.isPresent()) {
+					return new StartCandidate(
+							toMinuteUtc(game.get().getActualGameStartTime()),
+							"INTERNAL_GAME_ACTUAL_START_TIME");
+				}
+			}
+		}
+
+		Optional<LeagueMatch> matchByContext = context.matchId() == null || context.matchId().isBlank()
+				? Optional.empty()
+				: leagueMatchRepository.findById(context.matchId());
+		Optional<LeagueMatch> matchByGameId = findLeagueMatchByGameId(gameId);
+		Optional<LeagueMatch> effectiveMatch = matchByContext.isPresent() ? matchByContext : matchByGameId;
+		if (effectiveMatch.isPresent() && effectiveMatch.get().getMatchDate() != null) {
+			return new StartCandidate(
+					toMinuteUtc(effectiveMatch.get().getMatchDate().minusHours(2)),
+					"MATCH_DATE_MINUS_2H");
+		}
+
+		Optional<LiveGameMinuteSnapshot> firstSnapshot = snapshotRepository.findTopByGameIdOrderByMinuteBucketUtcAsc(gameId);
+		if (firstSnapshot.isPresent()) {
+			return new StartCandidate(
+					toMinuteUtc(firstSnapshot.get().getMinuteBucketUtc()),
+					"FIRST_MINUTE_SNAPSHOT");
+		}
+
+		return new StartCandidate(
+				toMinuteUtc(LocalDateTime.now(ZoneOffset.UTC).minusHours(3)),
+				"NOW_MINUS_3H_FALLBACK");
+	}
+
+	private LiveContext resolveContext(String gameId) {
+		Optional<LiveGameMapping> mapping = liveGameMappingRepository.findByLiveGameId(gameId);
+		if (mapping.isPresent()) {
+			LiveGameMapping liveGameMapping = mapping.get();
+			return new LiveContext(
+					gameId,
+					liveGameMapping.getLiveMatchId(),
+					liveGameMapping.getLiveLeagueName(),
+					liveGameMapping.getLiveBlueTeamName(),
+					liveGameMapping.getLiveRedTeamName());
+		}
+
+		Optional<LiveGameMinuteSnapshot> latest = snapshotRepository.findTopByGameIdOrderByFrameTimestampUtcDesc(gameId);
+		if (latest.isPresent()) {
+			LiveGameMinuteSnapshot snapshot = latest.get();
+			return new LiveContext(
+					gameId,
+					snapshot.getMatchId(),
+					snapshot.getLeagueName(),
+					snapshot.getBlueTeamName(),
+					snapshot.getRedTeamName());
+		}
+
+		Optional<LeagueMatch> leagueMatch = findLeagueMatchByGameId(gameId);
+		if (leagueMatch.isPresent()) {
+			LeagueMatch match = leagueMatch.get();
+			return new LiveContext(
+					gameId,
+					match.getId(),
+					match.getLeagueName(),
+					match.getBlueTeamName(),
+					match.getRedTeamName());
+		}
+
+		return new LiveContext(gameId, null, null, null, null);
+	}
+
+	private Optional<LeagueMatch> findLeagueMatchByGameId(String gameId) {
+		return leagueMatchGameRepository.findWithMatchByGameId(gameId)
+				.map(LeagueMatchGame::getLeagueMatch);
+	}
+
+	private boolean hasFrames(JsonNode response) {
+		return response != null && response.path("frames").isArray() && !response.path("frames").isEmpty();
+	}
+
+	private LocalDateTime toMinuteUtc(LocalDateTime value) {
+		return value.withSecond(0).withNano(0);
+	}
+
+	private String formatStartingTime(LocalDateTime utcTime) {
+		return toMinuteUtc(utcTime).format(START_TIME_FORMATTER);
+	}
+
+	private record StartCandidate(LocalDateTime baseStartUtc, String source) {
+	}
+
+	private record ProbeResult(
+			LocalDateTime foundStartingTimeUtc,
+			int probeAttempts,
+			JsonNode windowResponse,
+			JsonNode detailsResponse) {
+	}
+
+	private record LiveContext(
+			String gameId,
+			String matchId,
+			String leagueName,
+			String blueTeamName,
+			String redTeamName) {
+		ActiveLiveGame toActiveLiveGame() {
+			return new ActiveLiveGame(
+					gameId,
+					matchId,
+					leagueName,
+					blueTeamName,
+					redTeamName,
+					LocalDateTime.now(ZoneOffset.UTC),
+					0);
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveFrameProcessor.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveFrameProcessor.java
@@ -1,0 +1,34 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LiveFrameProcessor {
+
+	private final LiveStateAggregator liveStateAggregator;
+	private final LiveStateStore liveStateStore;
+	private final LivePersistenceQueue livePersistenceQueue;
+
+	public Optional<LiveGameState> process(ActiveLiveGame activeGame, JsonNode windowResponse, JsonNode detailsResponse) {
+		LiveGameState state = liveStateAggregator.aggregate(activeGame, windowResponse, detailsResponse);
+		if (state == null) {
+			return Optional.empty();
+		}
+
+		liveStateStore.putLatestState(state);
+		livePersistenceQueue.enqueueSnapshot(state);
+		livePersistenceQueue.enqueueObjectEvents(activeGame, windowResponse);
+		liveStateStore.getActiveGames().put(
+				activeGame.gameId(),
+				activeGame.withLastSeenAt(LocalDateTime.now(ZoneOffset.UTC)).clearFailures());
+		return Optional.of(state);
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveGameMetadataService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveGameMetadataService.java
@@ -1,0 +1,118 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.toy.nar.app.lolesports.LeagueConstants;
+import com.toy.nar.app.lolesports.MatchResponseWrapper;
+import com.toy.nar.app.lolesports.MatchResultDto;
+import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGame;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveGameMetadataService {
+
+	private final WorldsService worldsService;
+	private final LeagueMatchGameRepository leagueMatchGameRepository;
+	private final Cache<String, Optional<ActiveLiveGame>> metadataByGameId = Caffeine.newBuilder()
+			.expireAfterWrite(60, TimeUnit.SECONDS)
+			.maximumSize(1_000)
+			.build();
+
+	public ActiveLiveGame enrich(ActiveLiveGame activeGame) {
+		if (activeGame == null || activeGame.gameId() == null || activeGame.gameId().isBlank()) {
+			return activeGame;
+		}
+		return activeGame.mergeMissingMetadata(resolve(activeGame.gameId()).orElse(null));
+	}
+
+	public Optional<ActiveLiveGame> resolve(String gameId) {
+		if (gameId == null || gameId.isBlank()) {
+			return Optional.empty();
+		}
+		return metadataByGameId.get(gameId, this::loadMetadata);
+	}
+
+	public void remember(ActiveLiveGame activeGame) {
+		if (activeGame == null || activeGame.gameId() == null || activeGame.gameId().isBlank()) {
+			return;
+		}
+		metadataByGameId.put(activeGame.gameId(), Optional.of(activeGame));
+	}
+
+	private Optional<ActiveLiveGame> loadMetadata(String gameId) {
+		Optional<ActiveLiveGame> fromDb = loadFromLocalMatchGame(gameId);
+		if (fromDb.isPresent()) {
+			return fromDb;
+		}
+		return loadFromSchedule(gameId);
+	}
+
+	private Optional<ActiveLiveGame> loadFromLocalMatchGame(String gameId) {
+		return leagueMatchGameRepository.findWithMatchByGameId(gameId)
+				.map(LeagueMatchGame::getLeagueMatch)
+				.map(match -> new ActiveLiveGame(
+						gameId,
+						match.getId(),
+						match.getLeagueName(),
+						match.getBlueTeamName(),
+						match.getRedTeamName(),
+						LocalDateTime.now(ZoneOffset.UTC),
+						0));
+	}
+
+	private Optional<ActiveLiveGame> loadFromSchedule(String gameId) {
+		for (String league : LeagueConstants.TARGET_LEAGUES) {
+			try {
+				MatchResponseWrapper response = worldsService.getWorldsMatches(null, league);
+				Optional<ActiveLiveGame> match = response.getMatches().stream()
+						.filter(matchDto -> containsGameId(matchDto.getGameIds(), gameId)
+								|| containsGameId(matchDto.getLiveGameIds(), gameId))
+						.findFirst()
+						.map(matchDto -> toActiveLiveGame(gameId, league, matchDto));
+				if (match.isPresent()) {
+					return match;
+				}
+			} catch (Exception e) {
+				log.warn("Live metadata lookup failed for gameId={} league={}: {}", gameId, league, e.getMessage());
+			}
+		}
+		return Optional.empty();
+	}
+
+	private ActiveLiveGame toActiveLiveGame(String gameId, String fallbackLeague, MatchResultDto match) {
+		String leagueName = isBlank(match.getLeagueName()) ? fallbackLeague : match.getLeagueName();
+		return new ActiveLiveGame(
+				gameId,
+				match.getMatchId(),
+				leagueName,
+				match.getBlueTeam() == null ? null : firstNonBlank(match.getBlueTeam().getName(), match.getBlueTeam().getCode()),
+				match.getRedTeam() == null ? null : firstNonBlank(match.getRedTeam().getName(), match.getRedTeam().getCode()),
+				LocalDateTime.now(ZoneOffset.UTC),
+				0);
+	}
+
+	private boolean containsGameId(List<String> gameIds, String gameId) {
+		return gameIds != null && gameIds.contains(gameId);
+	}
+
+	private String firstNonBlank(String first, String second) {
+		return isBlank(first) ? second : first;
+	}
+
+	private boolean isBlank(String value) {
+		return value == null || value.isBlank();
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveMinuteSnapshotWriter.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveMinuteSnapshotWriter.java
@@ -1,0 +1,82 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteParticipantSnapshot;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteParticipantSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveMinuteSnapshotWriter {
+
+	private final LiveGameMinuteSnapshotRepository snapshotRepository;
+	private final LiveGameMinuteParticipantSnapshotRepository participantSnapshotRepository;
+	private final ObjectMapper objectMapper;
+
+	@Transactional
+	public void write(LiveGameState state) {
+		LiveGameMinuteSnapshot snapshot = snapshotRepository
+				.findByGameIdAndMinuteBucketUtc(state.gameId(), state.minuteBucketUtc())
+				.orElseGet(() -> new LiveGameMinuteSnapshot(state.gameId(), state.minuteBucketUtc()));
+
+		if (snapshot.getFrameTimestampUtc() != null && !state.frameTimestampUtc().isAfter(snapshot.getFrameTimestampUtc())) {
+			return;
+		}
+
+		snapshot.updateSnapshot(
+				state.matchId(),
+				state.leagueName(),
+				state.blueTeamName(),
+				state.redTeamName(),
+				state.frameTimestampUtc());
+
+		LiveGameMinuteSnapshot savedSnapshot = snapshotRepository.save(snapshot);
+		participantSnapshotRepository.deleteBySnapshot_Id(savedSnapshot.getId());
+		participantSnapshotRepository.flush();
+
+		List<LiveGameMinuteParticipantSnapshot> participantRows = new ArrayList<>();
+		for (LiveParticipantState participant : state.participants()) {
+			participantRows.add(new LiveGameMinuteParticipantSnapshot(
+					savedSnapshot,
+					participant.participantId(),
+					participant.teamSide(),
+					participant.role(),
+					participant.playerName(),
+					participant.esportsPlayerId(),
+					participant.championName(),
+					participant.level(),
+					participant.kills(),
+					participant.deaths(),
+					participant.assists(),
+					participant.totalGoldEarned(),
+					participant.creepScore(),
+					participant.killParticipation(),
+					participant.championDamageShare(),
+					toJson(participant.itemIds()),
+					participant.perksJson()));
+		}
+
+		participantSnapshotRepository.saveAllAndFlush(participantRows);
+	}
+
+	private String toJson(Object value) {
+		try {
+			return objectMapper.writeValueAsString(value);
+		} catch (JsonProcessingException e) {
+			log.warn("Failed to serialize live participant field: {}", e.getMessage());
+			return "[]";
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -1,0 +1,208 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveObjectEventRecorder {
+
+	private static final String EVENT_DRAGON = "DRAGON";
+	private static final String EVENT_BARON = "BARON";
+	private static final String EVENT_TOWER = "TOWER";
+	private static final String EVENT_INHIBITOR = "INHIBITOR";
+
+	private final LiveGameObjectEventRepository objectEventRepository;
+	private final Map<String, ObservedObjectState> lastObservedByGame = new ConcurrentHashMap<>();
+
+	public void evict(String gameId) {
+		if (gameId == null || gameId.isBlank()) {
+			return;
+		}
+		lastObservedByGame.remove(gameId);
+	}
+
+	@Transactional
+	public void record(ActiveLiveGame activeGame, JsonNode windowResponse) {
+		JsonNode frames = windowResponse.path("frames");
+		if (!frames.isArray() || frames.isEmpty()) {
+			return;
+		}
+
+		List<FrameSnapshot> snapshots = toSnapshots(frames);
+		if (snapshots.isEmpty()) {
+			return;
+		}
+
+		ObservedObjectState previous = lastObservedByGame.get(activeGame.gameId());
+		for (FrameSnapshot snapshot : snapshots) {
+			if (previous != null && !snapshot.frameTimestampUtc().isAfter(previous.frameTimestampUtc())) {
+				continue;
+			}
+			if (previous != null) {
+				recordTeamDiff(activeGame, "Blue", previous.blue(), snapshot.blue(), snapshot.frameTimestampUtc());
+				recordTeamDiff(activeGame, "Red", previous.red(), snapshot.red(), snapshot.frameTimestampUtc());
+			}
+
+			previous = new ObservedObjectState(snapshot.frameTimestampUtc(), snapshot.blue(), snapshot.red());
+		}
+
+		lastObservedByGame.put(activeGame.gameId(), previous);
+	}
+
+	private List<FrameSnapshot> toSnapshots(JsonNode frames) {
+		List<FrameSnapshot> snapshots = new ArrayList<>();
+		for (JsonNode frame : frames) {
+			LocalDateTime frameTimestampUtc = parseFrameTimestamp(frame.path("rfc460Timestamp").asText(null));
+			if (frameTimestampUtc == null) {
+				continue;
+			}
+			snapshots.add(new FrameSnapshot(
+					frameTimestampUtc,
+					TeamObjectState.from(frame.path("blueTeam")),
+					TeamObjectState.from(frame.path("redTeam"))));
+		}
+		snapshots.sort(Comparator.comparing(FrameSnapshot::frameTimestampUtc));
+		return snapshots;
+	}
+
+	private void recordTeamDiff(
+			ActiveLiveGame activeGame,
+			String teamSide,
+			TeamObjectState previous,
+			TeamObjectState current,
+			LocalDateTime frameTimestampUtc) {
+		recordCounterEvents(activeGame, teamSide, EVENT_TOWER, previous.towers(), current.towers(), frameTimestampUtc);
+		recordCounterEvents(activeGame, teamSide, EVENT_BARON, previous.barons(), current.barons(), frameTimestampUtc);
+		recordCounterEvents(activeGame, teamSide, EVENT_INHIBITOR, previous.inhibitors(), current.inhibitors(),
+				frameTimestampUtc);
+		recordDragonEvents(activeGame, teamSide, previous.dragons(), current.dragons(), frameTimestampUtc);
+	}
+
+	private void recordCounterEvents(
+			ActiveLiveGame activeGame,
+			String teamSide,
+			String eventType,
+			int previousValue,
+			int currentValue,
+			LocalDateTime frameTimestampUtc) {
+		if (currentValue <= previousValue) {
+			return;
+		}
+
+		for (int order = previousValue + 1; order <= currentValue; order++) {
+			saveEventIfAbsent(
+					activeGame,
+					teamSide,
+					eventType,
+					null,
+					order,
+					order,
+					frameTimestampUtc);
+		}
+	}
+
+	private void recordDragonEvents(
+			ActiveLiveGame activeGame,
+			String teamSide,
+			List<String> previousDragons,
+			List<String> currentDragons,
+			LocalDateTime frameTimestampUtc) {
+		if (currentDragons.size() <= previousDragons.size()) {
+			return;
+		}
+
+		for (int index = previousDragons.size(); index < currentDragons.size(); index++) {
+			String dragonType = currentDragons.get(index);
+			saveEventIfAbsent(
+					activeGame,
+					teamSide,
+					EVENT_DRAGON,
+					dragonType,
+					index + 1,
+					index + 1,
+					frameTimestampUtc);
+		}
+	}
+
+	private void saveEventIfAbsent(
+			ActiveLiveGame activeGame,
+			String teamSide,
+			String eventType,
+			String eventSubType,
+			int eventOrder,
+			int valueAfter,
+			LocalDateTime frameTimestampUtc) {
+		boolean exists = objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
+				activeGame.gameId(), teamSide, eventType, eventOrder);
+		if (exists) {
+			return;
+		}
+
+		LiveGameObjectEvent event = new LiveGameObjectEvent(
+				activeGame.gameId(),
+				activeGame.matchId(),
+				activeGame.leagueName(),
+				teamSide,
+				eventType,
+				eventSubType,
+				eventOrder,
+				valueAfter,
+				frameTimestampUtc);
+		objectEventRepository.save(event);
+	}
+
+	private LocalDateTime parseFrameTimestamp(String raw) {
+		if (raw == null || raw.isBlank()) {
+			return null;
+		}
+		try {
+			return LocalDateTime.ofInstant(Instant.parse(raw), ZoneOffset.UTC);
+		} catch (Exception e) {
+			log.debug("Failed to parse object frame timestamp: {}", raw);
+			return null;
+		}
+	}
+
+	private record TeamObjectState(int towers, int barons, int inhibitors, List<String> dragons) {
+
+		static TeamObjectState from(JsonNode teamNode) {
+			int towers = teamNode.path("towers").isNumber() ? teamNode.path("towers").asInt() : 0;
+			int barons = teamNode.path("barons").isNumber() ? teamNode.path("barons").asInt() : 0;
+			int inhibitors = teamNode.path("inhibitors").isNumber() ? teamNode.path("inhibitors").asInt() : 0;
+
+			List<String> dragons = new ArrayList<>();
+			JsonNode dragonNode = teamNode.path("dragons");
+			if (dragonNode.isArray()) {
+				for (JsonNode dragon : dragonNode) {
+					String dragonType = dragon.asText(null);
+					if (dragonType != null && !dragonType.isBlank()) {
+						dragons.add(dragonType);
+					}
+				}
+			}
+			return new TeamObjectState(towers, barons, inhibitors, dragons);
+		}
+	}
+
+	private record FrameSnapshot(LocalDateTime frameTimestampUtc, TeamObjectState blue, TeamObjectState red) {
+	}
+
+	private record ObservedObjectState(LocalDateTime frameTimestampUtc, TeamObjectState blue, TeamObjectState red) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePersistenceQueue.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePersistenceQueue.java
@@ -1,0 +1,137 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LivePersistenceQueue {
+
+	private final LiveMinuteSnapshotWriter snapshotWriter;
+	private final LiveObjectEventRecorder objectEventRecorder;
+	@Qualifier("applicationTaskExecutor")
+	private final AsyncTaskExecutor applicationTaskExecutor;
+
+	@Value("${lolesports.live.queue.snapshot-capacity:600}")
+	private int snapshotCapacity;
+
+	@Value("${lolesports.live.queue.object-capacity:1200}")
+	private int objectCapacity;
+
+	private BlockingQueue<LiveGameState> snapshotQueue;
+	private BlockingQueue<ObjectEventTask> objectQueue;
+	private final AtomicBoolean running = new AtomicBoolean(false);
+	private final AtomicLong droppedSnapshots = new AtomicLong();
+	private final AtomicLong droppedObjectEvents = new AtomicLong();
+
+	@PostConstruct
+	void start() {
+		snapshotQueue = new ArrayBlockingQueue<>(snapshotCapacity);
+		objectQueue = new ArrayBlockingQueue<>(objectCapacity);
+		running.set(true);
+		applicationTaskExecutor.execute(this::runSnapshotWorker);
+		applicationTaskExecutor.execute(this::runObjectWorker);
+	}
+
+	@PreDestroy
+	void stop() {
+		running.set(false);
+	}
+
+	public void enqueueSnapshot(LiveGameState state) {
+		if (state == null) {
+			return;
+		}
+		if (snapshotQueue.offer(state)) {
+			return;
+		}
+		LiveGameState dropped = snapshotQueue.poll();
+		if (dropped != null) {
+			droppedSnapshots.incrementAndGet();
+		}
+		if (!snapshotQueue.offer(state)) {
+			droppedSnapshots.incrementAndGet();
+			log.warn("Live snapshot queue is full. Dropped latest snapshot gameId={} minute={}",
+					state.gameId(),
+					state.minuteBucketUtc());
+		}
+	}
+
+	public void enqueueObjectEvents(ActiveLiveGame activeGame, JsonNode windowResponse) {
+		if (activeGame == null || windowResponse == null) {
+			return;
+		}
+		boolean accepted = objectQueue.offer(new ObjectEventTask(activeGame, windowResponse));
+		if (!accepted) {
+			long dropped = droppedObjectEvents.incrementAndGet();
+			log.warn("Live object event queue is full. Dropped object task gameId={} droppedCount={}",
+					activeGame.gameId(),
+					dropped);
+		}
+	}
+
+	public LiveQueueStats stats() {
+		return new LiveQueueStats(
+				snapshotQueue == null ? 0 : snapshotQueue.size(),
+				objectQueue == null ? 0 : objectQueue.size(),
+				droppedSnapshots.get(),
+				droppedObjectEvents.get());
+	}
+
+	private void runSnapshotWorker() {
+		while (running.get()) {
+			try {
+				LiveGameState state = snapshotQueue.poll(1, TimeUnit.SECONDS);
+				if (state != null) {
+					snapshotWriter.write(state);
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			} catch (Exception e) {
+				log.warn("Live snapshot worker failed: {}", e.getMessage(), e);
+			}
+		}
+	}
+
+	private void runObjectWorker() {
+		while (running.get()) {
+			try {
+				ObjectEventTask task = objectQueue.poll(1, TimeUnit.SECONDS);
+				if (task != null) {
+					objectEventRecorder.record(task.activeGame(), task.windowResponse());
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			} catch (Exception e) {
+				log.warn("Live object worker failed: {}", e.getMessage(), e);
+			}
+		}
+	}
+
+	private record ObjectEventTask(ActiveLiveGame activeGame, JsonNode windowResponse) {
+	}
+
+	public record LiveQueueStats(
+			int snapshotQueueSize,
+			int objectQueueSize,
+			long droppedSnapshots,
+			long droppedObjectEvents) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -1,0 +1,143 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.LeagueConstants;
+import com.toy.nar.app.lolesports.MatchResponseWrapper;
+import com.toy.nar.app.lolesports.MatchResultDto;
+import com.toy.nar.app.lolesports.WorldsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "lolesports.live", name = "enabled", havingValue = "true")
+public class LivePollingScheduler {
+
+	private static final DateTimeFormatter START_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+	private static final long INITIAL_LOOKBACK_SECONDS = 90L;
+
+	private final WorldsService worldsService;
+	private final LiveStatsClient liveStatsClient;
+	private final LiveObjectEventRecorder liveObjectEventRecorder;
+	private final LiveStateStore liveStateStore;
+	private final LiveFrameProcessor liveFrameProcessor;
+	private final LiveGameMetadataService liveGameMetadataService;
+
+	@org.springframework.beans.factory.annotation.Value("${lolesports.live.stale-threshold-ms:180000}")
+	private long staleThresholdMs;
+
+	@org.springframework.beans.factory.annotation.Value("${lolesports.live.max-consecutive-failures:6}")
+	private int maxConsecutiveFailures;
+
+	@Scheduled(fixedDelayString = "${lolesports.live.discovery-interval-ms:60000}")
+	public void discoverLiveGames() {
+		Map<String, ActiveLiveGame> activeGames = liveStateStore.getActiveGames();
+		Set<String> discoveredGameIds = new HashSet<>();
+		LocalDateTime nowUtc = LocalDateTime.now(ZoneOffset.UTC);
+
+		for (String league : LeagueConstants.TARGET_LEAGUES) {
+			try {
+				MatchResponseWrapper response = worldsService.getWorldsMatches(null, league);
+				for (MatchResultDto match : response.getMatches()) {
+					if (!"inProgress".equalsIgnoreCase(match.getState()) || match.getLiveGameIds() == null) {
+						continue;
+					}
+
+					for (String gameId : match.getLiveGameIds()) {
+						if (gameId == null || gameId.isBlank()) {
+							continue;
+						}
+						discoveredGameIds.add(gameId);
+						ActiveLiveGame current = activeGames.get(gameId);
+						String resolvedLeagueName = (match.getLeagueName() == null || match.getLeagueName().isBlank())
+								? league
+								: match.getLeagueName();
+						ActiveLiveGame next = new ActiveLiveGame(
+								gameId,
+								match.getMatchId(),
+								resolvedLeagueName,
+								match.getBlueTeam() != null ? match.getBlueTeam().getName() : null,
+								match.getRedTeam() != null ? match.getRedTeam().getName() : null,
+								nowUtc,
+								current != null ? current.consecutiveFailures() : 0);
+						activeGames.put(gameId, next);
+						liveGameMetadataService.remember(next);
+					}
+				}
+			} catch (Exception e) {
+				log.warn("Live discovery failed for league {}: {}", league, e.getMessage());
+			}
+		}
+
+		List<String> toRemove = new ArrayList<>();
+		for (ActiveLiveGame activeGame : activeGames.values()) {
+			boolean notDiscovered = !discoveredGameIds.contains(activeGame.gameId());
+			boolean stale = activeGame.lastSeenAtUtc() != null
+					&& java.time.Duration.between(activeGame.lastSeenAtUtc(), nowUtc).toMillis() > staleThresholdMs;
+			if (notDiscovered && stale) {
+				toRemove.add(activeGame.gameId());
+			}
+		}
+
+		toRemove.forEach(gameId -> {
+			liveStateStore.removeGame(gameId);
+			liveObjectEventRecorder.evict(gameId);
+		});
+	}
+
+	@Scheduled(fixedDelayString = "${lolesports.live.poll-interval-ms:5000}")
+	public void pollActiveGames() {
+		List<ActiveLiveGame> activeGames = new ArrayList<>(liveStateStore.getActiveGames().values());
+		if (activeGames.isEmpty()) {
+			return;
+		}
+
+		for (ActiveLiveGame activeGame : activeGames) {
+			try {
+				String startingTime = computeStartingTime(activeGame.gameId());
+				JsonNode window = liveStatsClient.getWindow(activeGame.gameId(), startingTime);
+				JsonNode details = liveStatsClient.getDetails(activeGame.gameId(), startingTime);
+				liveFrameProcessor.process(activeGame, window, details);
+			} catch (Exception e) {
+				ActiveLiveGame failed = activeGame.increaseFailures();
+				if (failed.consecutiveFailures() >= maxConsecutiveFailures) {
+					log.warn("Removing game {} after {} consecutive polling failures", failed.gameId(), failed.consecutiveFailures());
+					liveStateStore.removeGame(failed.gameId());
+					liveObjectEventRecorder.evict(failed.gameId());
+					continue;
+				}
+				liveStateStore.getActiveGames().put(failed.gameId(), failed);
+				log.warn("Live polling failed for game {}: {}", failed.gameId(), e.getMessage());
+			}
+		}
+	}
+
+	private String computeStartingTime(String gameId) {
+		Instant candidate = liveStateStore.getLatestState(gameId)
+				.map(state -> state.frameTimestampUtc().toInstant(ZoneOffset.UTC).minusSeconds(10))
+				.orElseGet(() -> Instant.now().minusSeconds(INITIAL_LOOKBACK_SECONDS));
+
+		Instant minAllowed = Instant.now().minus(Duration.ofMinutes(5));
+		if (candidate.isBefore(minAllowed)) {
+			candidate = minAllowed;
+		}
+
+		long flooredSeconds = (candidate.getEpochSecond() / 10) * 10;
+		return LocalDateTime.ofInstant(Instant.ofEpochSecond(flooredSeconds), ZoneOffset.UTC).format(START_TIME_FORMATTER);
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveReconciliationScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveReconciliationScheduler.java
@@ -1,0 +1,25 @@
+package com.toy.nar.app.lolesports.live;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "lolesports.live", name = "enabled", havingValue = "true")
+public class LiveReconciliationScheduler {
+
+	private final LiveReconciliationService reconciliationService;
+
+	@Scheduled(fixedDelayString = "${lolesports.live.reconcile-interval-ms:60000}")
+	public void reconcile() {
+		try {
+			reconciliationService.reconcileRecentGames();
+		} catch (Exception e) {
+			log.warn("Live reconciliation failed: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveReconciliationService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveReconciliationService.java
@@ -1,0 +1,468 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.toy.nar.app.lolesports.live.entity.LiveGameMapping;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteParticipantSnapshot;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.entity.LiveParticipantMapping;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMappingRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteParticipantSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveParticipantMappingRepository;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGame;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.common.util.NameNormalizer;
+import com.toy.nar.domain.game.entity.Game;
+import com.toy.nar.domain.game.entity.GameParticipant;
+import com.toy.nar.domain.game.repository.GameParticipantRepository;
+import com.toy.nar.domain.game.repository.GameRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveReconciliationService {
+
+	private final LiveGameMinuteSnapshotRepository snapshotRepository;
+	private final LiveGameMinuteParticipantSnapshotRepository participantSnapshotRepository;
+	private final LiveGameMappingRepository gameMappingRepository;
+	private final LiveParticipantMappingRepository participantMappingRepository;
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final LeagueMatchGameRepository leagueMatchGameRepository;
+	private final GameRepository gameRepository;
+	private final GameParticipantRepository gameParticipantRepository;
+
+	@Value("${lolesports.live.reconcile-game-limit:50}")
+	private int reconcileGameLimit;
+
+	@Value("${lolesports.live.reconcile-candidate-window-hours:24}")
+	private long candidateWindowHours;
+
+	@Value("${lolesports.live.reconcile-ambiguity-gap-minutes:15}")
+	private long ambiguityGapMinutes;
+
+	@Value("${lolesports.live.reconcile-max-game-gap-minutes:360}")
+	private long maxGameGapMinutes;
+
+	@Transactional
+	public void reconcileRecentGames() {
+		List<String> liveGameIds = snapshotRepository.findRecentGameIds(PageRequest.of(0, reconcileGameLimit));
+		for (String liveGameId : liveGameIds) {
+			reconcileSingleGame(liveGameId);
+		}
+	}
+
+	@Transactional
+	public void reconcileByGameId(String liveGameId) {
+		if (liveGameId == null || liveGameId.isBlank()) {
+			return;
+		}
+		reconcileSingleGame(liveGameId);
+	}
+
+	private void reconcileSingleGame(String liveGameId) {
+		Optional<LiveGameMinuteSnapshot> latestOptional = snapshotRepository
+				.findTopByGameIdOrderByFrameTimestampUtcDesc(liveGameId);
+		if (latestOptional.isEmpty()) {
+			return;
+		}
+
+		LiveGameMinuteSnapshot latest = latestOptional.get();
+		LiveGameMinuteSnapshot first = snapshotRepository
+				.findTopByGameIdOrderByMinuteBucketUtcAsc(liveGameId)
+				.orElse(latest);
+
+		LiveGameMapping gameMapping = gameMappingRepository.findByLiveGameId(liveGameId)
+				.orElseGet(() -> new LiveGameMapping(liveGameId));
+
+		String resolvedMatchId = resolveLiveMatchId(liveGameId, latest, gameMapping);
+		Optional<LeagueMatch> resolvedLeagueMatch = resolvedMatchId == null || resolvedMatchId.isBlank()
+				? Optional.empty()
+				: leagueMatchRepository.findById(resolvedMatchId);
+		gameMapping.updateLiveContext(
+				resolvedMatchId,
+				resolveLeagueName(latest, gameMapping, resolvedLeagueMatch),
+				resolveTeamName(latest.getBlueTeamName(), gameMapping.getLiveBlueTeamName(), resolvedLeagueMatch.map(LeagueMatch::getBlueTeamName).orElse(null)),
+				resolveTeamName(latest.getRedTeamName(), gameMapping.getLiveRedTeamName(), resolvedLeagueMatch.map(LeagueMatch::getRedTeamName).orElse(null)),
+				first.getMinuteBucketUtc(),
+				latest.getFrameTimestampUtc());
+
+		reconcileGameMapping(gameMapping, latest, first);
+		LiveGameMapping savedGameMapping = gameMappingRepository.save(gameMapping);
+
+		reconcileParticipantMappings(savedGameMapping, latest);
+	}
+
+	private void reconcileGameMapping(
+			LiveGameMapping mapping,
+			LiveGameMinuteSnapshot latest,
+			LiveGameMinuteSnapshot first) {
+		String liveMatchId = mapping.getLiveMatchId();
+		if (liveMatchId == null || liveMatchId.isBlank()) {
+			mapping.markPending("live_match_id_missing");
+			return;
+		}
+
+		Optional<LeagueMatch> leagueMatchOptional = leagueMatchRepository.findById(liveMatchId);
+		if (leagueMatchOptional.isEmpty()) {
+			mapping.markPending("league_match_not_found");
+			return;
+		}
+
+		LeagueMatch leagueMatch = leagueMatchOptional.get();
+		if (leagueMatch.getMatchDate() == null) {
+			mapping.markPending("league_match_date_missing");
+			return;
+		}
+
+		LocalDateTime referenceTime = first.getMinuteBucketUtc() != null
+				? first.getMinuteBucketUtc()
+				: leagueMatch.getMatchDate();
+		LocalDateTime start = leagueMatch.getMatchDate().minusHours(candidateWindowHours);
+		LocalDateTime end = leagueMatch.getMatchDate().plusHours(candidateWindowHours);
+
+		List<Game> rawCandidates = gameRepository.findAllWithParticipantsByActualGameStartTimeBetween(start, end);
+		List<Game> leagueCandidates = rawCandidates.stream()
+				.filter(game -> sameLeague(game, mapping.getLiveLeagueName()))
+				.toList();
+
+		List<Game> teamCandidates = leagueCandidates.stream()
+				.filter(game -> teamMatched(game, mapping.getLiveBlueTeamName(), mapping.getLiveRedTeamName()))
+				.toList();
+
+		if (teamCandidates.isEmpty()) {
+			mapping.markPending("team_candidate_not_found");
+			return;
+		}
+
+		List<Game> effectiveCandidates = teamCandidates;
+		if (effectiveCandidates.isEmpty()) {
+			mapping.markPending("no_internal_game_candidate");
+			return;
+		}
+
+		List<GameDistance> sorted = effectiveCandidates.stream()
+				.map(candidate -> new GameDistance(
+						candidate,
+						Math.abs(Duration.between(referenceTime, candidate.getActualGameStartTime()).toMinutes())))
+				.sorted(Comparator.comparingLong(GameDistance::distanceMinutes))
+				.toList();
+
+		if (sorted.size() > 1) {
+			long bestGap = sorted.get(0).distanceMinutes();
+			long secondGap = sorted.get(1).distanceMinutes();
+			if (Math.abs(secondGap - bestGap) <= ambiguityGapMinutes) {
+				mapping.markAmbiguous("multiple_candidates_close_in_time");
+				return;
+			}
+		}
+
+		GameDistance best = sorted.get(0);
+		if (best.distanceMinutes() > maxGameGapMinutes) {
+			mapping.markPending("candidate_time_gap_too_large");
+			return;
+		}
+
+		double confidence = confidenceByTimeGap(best.distanceMinutes(), !teamCandidates.isEmpty());
+		String method = !teamCandidates.isEmpty()
+				? "LEAGUE_TEAM_TIME_NEAREST"
+				: "LEAGUE_TIME_NEAREST";
+		String reason = "candidate_gap_minutes=" + best.distanceMinutes();
+
+		mapping.markMapped(best.game().getId(), confidence, method, reason);
+	}
+
+	private String resolveLiveMatchId(
+			String liveGameId,
+			LiveGameMinuteSnapshot latestSnapshot,
+			LiveGameMapping existingMapping) {
+		if (latestSnapshot.getMatchId() != null && !latestSnapshot.getMatchId().isBlank()) {
+			return latestSnapshot.getMatchId();
+		}
+		if (existingMapping.getLiveMatchId() != null && !existingMapping.getLiveMatchId().isBlank()) {
+			return existingMapping.getLiveMatchId();
+		}
+		return leagueMatchGameRepository.findWithMatchByGameId(liveGameId)
+				.map(LeagueMatchGame::getLeagueMatch)
+				.map(LeagueMatch::getId)
+				.orElse(null);
+	}
+
+	private String firstNonBlank(String primary, String secondary) {
+		if (primary != null && !primary.isBlank()) {
+			return primary;
+		}
+		return secondary;
+	}
+
+	private String resolveLeagueName(
+			LiveGameMinuteSnapshot latestSnapshot,
+			LiveGameMapping mapping,
+			Optional<LeagueMatch> leagueMatch) {
+		if (leagueMatch.isPresent() && leagueMatch.get().getLeagueName() != null && !leagueMatch.get().getLeagueName().isBlank()) {
+			return leagueMatch.get().getLeagueName();
+		}
+		return firstNonBlank(latestSnapshot.getLeagueName(), mapping.getLiveLeagueName());
+	}
+
+	private String resolveTeamName(String latest, String mapped, String fromLeagueMatch) {
+		if (fromLeagueMatch != null && !fromLeagueMatch.isBlank()) {
+			return fromLeagueMatch;
+		}
+		if (isLikelyEsportsTeamId(latest)) {
+			return firstNonBlank(mapped, latest);
+		}
+		return firstNonBlank(latest, mapped);
+	}
+
+	private boolean isLikelyEsportsTeamId(String value) {
+		if (value == null || value.isBlank()) {
+			return false;
+		}
+		return value.matches("\\d{12,}");
+	}
+
+	private void reconcileParticipantMappings(LiveGameMapping gameMapping, LiveGameMinuteSnapshot latestSnapshot) {
+		List<LiveGameMinuteParticipantSnapshot> liveParticipants = participantSnapshotRepository
+				.findBySnapshot_IdOrderByParticipantIdAsc(latestSnapshot.getId());
+		if (liveParticipants.isEmpty()) {
+			return;
+		}
+
+		List<GameParticipant> internalParticipants = List.of();
+		if (gameMapping.getInternalGameId() != null) {
+			internalParticipants = gameParticipantRepository.findWithDetailsByGameIds(List.of(gameMapping.getInternalGameId()));
+		}
+
+		for (LiveGameMinuteParticipantSnapshot liveParticipant : liveParticipants) {
+			LiveParticipantMapping participantMapping = participantMappingRepository
+					.findByLiveGameIdAndLiveParticipantId(
+							liveParticipant.getSnapshot().getGameId(),
+							liveParticipant.getParticipantId())
+					.orElseGet(() -> new LiveParticipantMapping(
+							liveParticipant.getSnapshot().getGameId(),
+							liveParticipant.getParticipantId()));
+
+			participantMapping.updateLiveContext(
+					liveParticipant.getTeamSide(),
+					liveParticipant.getRole(),
+					liveParticipant.getPlayerName(),
+					liveParticipant.getEsportsPlayerId(),
+					liveParticipant.getChampionName());
+
+			if (gameMapping.getInternalGameId() == null) {
+				participantMapping.markPending("game_not_mapped");
+				participantMappingRepository.save(participantMapping);
+				continue;
+			}
+
+			Optional<ParticipantMatchResult> matched = findParticipantMatch(liveParticipant, internalParticipants);
+			if (matched.isPresent()) {
+				ParticipantMatchResult matchResult = matched.get();
+				GameParticipant gameParticipant = matchResult.gameParticipant();
+				participantMapping.markMapped(
+						gameParticipant.getId(),
+						gameParticipant.getGame().getId(),
+						gameParticipant.getPlayer().getId(),
+						gameParticipant.getTeam().getId(),
+						gameParticipant.getChampion().getId(),
+						matchResult.confidence(),
+						matchResult.method(),
+						matchResult.reason());
+			} else {
+				participantMapping.markPending("participant_candidate_not_found");
+			}
+			participantMappingRepository.save(participantMapping);
+		}
+	}
+
+	private Optional<ParticipantMatchResult> findParticipantMatch(
+			LiveGameMinuteParticipantSnapshot liveParticipant,
+			List<GameParticipant> internalParticipants) {
+		List<GameParticipant> sideCandidates = internalParticipants.stream()
+				.filter(candidate -> sameSide(candidate.getSide(), liveParticipant.getTeamSide()))
+				.toList();
+		if (sideCandidates.isEmpty()) {
+			return Optional.empty();
+		}
+
+		Set<String> nameCandidates = toLiveNameCandidates(liveParticipant.getPlayerName());
+		List<GameParticipant> nameMatched = sideCandidates.stream()
+				.filter(candidate -> nameCandidates.contains(normalizeText(candidate.getPlayer().getName())))
+				.toList();
+
+		if (nameMatched.size() == 1) {
+			GameParticipant chosen = nameMatched.get(0);
+			if (!sameChampion(liveParticipant.getChampionName(), chosen.getChampion().getChampionNameEn())) {
+				return Optional.empty();
+			}
+			return Optional.of(new ParticipantMatchResult(
+					chosen,
+					0.98d,
+					"PLAYER_NAME_SIDE",
+					"player_name + side matched"));
+		}
+		if (nameMatched.size() > 1) {
+			return Optional.empty();
+		}
+
+		String liveRole = normalizeRole(liveParticipant.getRole());
+		if (liveRole != null) {
+			List<GameParticipant> roleMatched = sideCandidates.stream()
+					.filter(candidate -> liveRole.equals(normalizeRole(candidate.getPosition())))
+					.toList();
+			if (roleMatched.size() == 1) {
+				GameParticipant chosen = roleMatched.get(0);
+				if (!sameChampion(liveParticipant.getChampionName(), chosen.getChampion().getChampionNameEn())) {
+					return Optional.empty();
+				}
+				return Optional.of(new ParticipantMatchResult(
+						chosen,
+						0.75d,
+						"ROLE_SIDE_CHAMPION",
+						"role + side + champion matched"));
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	private boolean sameLeague(Game game, String liveLeagueName) {
+		if (game == null || game.getLeague() == null) {
+			return false;
+		}
+		if (liveLeagueName == null || liveLeagueName.isBlank()) {
+			return true;
+		}
+		return liveLeagueName.trim().equalsIgnoreCase(game.getLeague().getLeagueName());
+	}
+
+	private boolean teamMatched(Game game, String liveBlue, String liveRed) {
+		if (liveBlue == null || liveRed == null) {
+			return true;
+		}
+
+		String internalBlue = teamNameFromGame(game, "Blue");
+		String internalRed = teamNameFromGame(game, "Red");
+		if (internalBlue == null || internalRed == null) {
+			return false;
+		}
+
+		String normLiveBlue = NameNormalizer.normalizeTeamName(liveBlue);
+		String normLiveRed = NameNormalizer.normalizeTeamName(liveRed);
+		String normInternalBlue = NameNormalizer.normalizeTeamName(internalBlue);
+		String normInternalRed = NameNormalizer.normalizeTeamName(internalRed);
+
+		boolean sameSide = normLiveBlue.equalsIgnoreCase(normInternalBlue)
+				&& normLiveRed.equalsIgnoreCase(normInternalRed);
+		boolean swappedSide = normLiveBlue.equalsIgnoreCase(normInternalRed)
+				&& normLiveRed.equalsIgnoreCase(normInternalBlue);
+		return sameSide || swappedSide;
+	}
+
+	private String teamNameFromGame(Game game, String side) {
+		return game.getParticipants().stream()
+				.filter(participant -> sameSide(participant.getSide(), side))
+				.map(participant -> participant.getTeam().getName())
+				.filter(Objects::nonNull)
+				.findFirst()
+				.orElse(null);
+	}
+
+	private boolean sameSide(String left, String right) {
+		if (left == null || right == null) {
+			return false;
+		}
+		return normalizeText(left).equals(normalizeText(right));
+	}
+
+	private Set<String> toLiveNameCandidates(String livePlayerName) {
+		if (livePlayerName == null || livePlayerName.isBlank()) {
+			return Set.of();
+		}
+		String trimmed = livePlayerName.trim();
+		List<String> candidates = new ArrayList<>();
+		candidates.add(normalizeText(trimmed));
+
+		String[] parts = trimmed.split("\\s+");
+		if (parts.length >= 2) {
+			candidates.add(normalizeText(String.join(" ", java.util.Arrays.copyOfRange(parts, 1, parts.length))));
+			candidates.add(normalizeText(parts[parts.length - 1]));
+		}
+
+		return candidates.stream()
+				.filter(value -> value != null && !value.isBlank())
+				.collect(Collectors.toSet());
+	}
+
+	private boolean sameChampion(String liveChampionName, String internalChampionName) {
+		String left = NameNormalizer.normalizeChampionName(liveChampionName);
+		String right = NameNormalizer.normalizeChampionName(internalChampionName);
+		return !left.isBlank() && left.equalsIgnoreCase(right);
+	}
+
+	private String normalizeRole(String role) {
+		if (role == null || role.isBlank()) {
+			return null;
+		}
+		String normalized = role.trim().toLowerCase(Locale.ROOT);
+		return switch (normalized) {
+			case "top" -> "top";
+			case "jungle", "jungler", "jng" -> "jng";
+			case "middle", "mid" -> "mid";
+			case "bottom", "bot", "adc" -> "bot";
+			case "support", "sup" -> "sup";
+			default -> normalized;
+		};
+	}
+
+	private String normalizeText(String value) {
+		if (value == null) {
+			return "";
+		}
+		return value.trim().toLowerCase(Locale.ROOT);
+	}
+
+	private double confidenceByTimeGap(long minutes, boolean teamMatched) {
+		if (teamMatched) {
+			if (minutes <= 30) {
+				return 0.95d;
+			}
+			if (minutes <= 120) {
+				return 0.88d;
+			}
+			return 0.8d;
+		}
+		if (minutes <= 30) {
+			return 0.82d;
+		}
+		if (minutes <= 120) {
+			return 0.74d;
+		}
+		return 0.65d;
+	}
+
+	private record GameDistance(Game game, long distanceMinutes) {
+	}
+
+	private record ParticipantMatchResult(GameParticipant gameParticipant, double confidence, String method,
+			String reason) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveSimulationService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveSimulationService.java
@@ -1,0 +1,115 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveSimulationResponse;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGame;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveSimulationService {
+
+	private static final DateTimeFormatter START_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+	private static final int MAX_TICKS = 240;
+
+	private final LiveStatsClient liveStatsClient;
+	private final LiveFrameProcessor liveFrameProcessor;
+	private final LeagueMatchGameRepository leagueMatchGameRepository;
+	private final LiveGameMetadataService liveGameMetadataService;
+
+	public LiveSimulationResponse simulate(String gameId, String startingTime, int ticks, int stepSeconds) {
+		LocalDateTime firstStartingTimeUtc = parseStartingTime(startingTime);
+		int safeTicks = Math.max(1, Math.min(ticks, MAX_TICKS));
+		int safeStepSeconds = Math.max(1, stepSeconds);
+		ActiveLiveGame activeGame = liveGameMetadataService.enrich(resolveActiveGame(gameId));
+
+		int processedFrames = 0;
+		int emptyResponses = 0;
+		int failures = 0;
+		LocalDateTime firstFrameTimestampUtc = null;
+		LocalDateTime lastFrameTimestampUtc = null;
+
+		for (int index = 0; index < safeTicks; index++) {
+			LocalDateTime tickStartUtc = firstStartingTimeUtc.plusSeconds((long) index * safeStepSeconds);
+			try {
+				JsonNode windowResponse = liveStatsClient.getWindow(gameId, formatStartingTime(tickStartUtc));
+				JsonNode detailsResponse = liveStatsClient.getDetails(gameId, formatStartingTime(tickStartUtc));
+				if (!hasFrames(windowResponse) || !hasFrames(detailsResponse)) {
+					emptyResponses++;
+					continue;
+				}
+				Optional<LiveGameState> state = liveFrameProcessor.process(activeGame, windowResponse, detailsResponse);
+				if (state.isEmpty()) {
+					emptyResponses++;
+					continue;
+				}
+				processedFrames++;
+				LocalDateTime frameTimestampUtc = state.get().frameTimestampUtc();
+				if (firstFrameTimestampUtc == null || frameTimestampUtc.isBefore(firstFrameTimestampUtc)) {
+					firstFrameTimestampUtc = frameTimestampUtc;
+				}
+				if (lastFrameTimestampUtc == null || frameTimestampUtc.isAfter(lastFrameTimestampUtc)) {
+					lastFrameTimestampUtc = frameTimestampUtc;
+				}
+			} catch (Exception e) {
+				failures++;
+				log.warn("Live simulation failed for gameId={} startingTime={}: {}", gameId, tickStartUtc, e.getMessage());
+			}
+		}
+
+		return new LiveSimulationResponse(
+				gameId,
+				firstStartingTimeUtc,
+				safeTicks,
+				safeStepSeconds,
+				processedFrames,
+				emptyResponses,
+				failures,
+				firstFrameTimestampUtc,
+				lastFrameTimestampUtc);
+	}
+
+	private ActiveLiveGame resolveActiveGame(String gameId) {
+		Optional<LeagueMatchGame> matchGame = leagueMatchGameRepository.findWithMatchByGameId(gameId);
+		if (matchGame.isEmpty()) {
+			return new ActiveLiveGame(gameId, null, null, null, null, LocalDateTime.now(ZoneOffset.UTC), 0);
+		}
+		LeagueMatch match = matchGame.get().getLeagueMatch();
+		return new ActiveLiveGame(
+				gameId,
+				match.getId(),
+				match.getLeagueName(),
+				match.getBlueTeamName(),
+				match.getRedTeamName(),
+				LocalDateTime.now(ZoneOffset.UTC),
+				0);
+	}
+
+	private LocalDateTime parseStartingTime(String startingTime) {
+		try {
+			return LocalDateTime.ofInstant(Instant.parse(startingTime), ZoneOffset.UTC);
+		} catch (Exception e) {
+			return LocalDateTime.parse(startingTime, DateTimeFormatter.ISO_DATE_TIME);
+		}
+	}
+
+	private String formatStartingTime(LocalDateTime startingTimeUtc) {
+		return startingTimeUtc.atOffset(ZoneOffset.UTC).format(START_TIME_FORMATTER);
+	}
+
+	private boolean hasFrames(JsonNode response) {
+		return response != null && response.path("frames").isArray() && !response.path("frames").isEmpty();
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStateAggregator.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStateAggregator.java
@@ -1,0 +1,231 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LiveStateAggregator {
+
+	private final ObjectMapper objectMapper;
+	private final RuneMetadataResolver runeMetadataResolver;
+	private final ItemMetadataResolver itemMetadataResolver;
+
+	public LiveGameState aggregate(
+			ActiveLiveGame activeGame,
+			JsonNode windowResponse,
+			JsonNode detailsResponse) {
+		JsonNode latestFrame = extractLatestFrame(detailsResponse);
+		if (latestFrame == null || latestFrame.isMissingNode()) {
+			return null;
+		}
+
+		String frameTimestampRaw = latestFrame.path("rfc460Timestamp").asText(null);
+		if (frameTimestampRaw == null || frameTimestampRaw.isBlank()) {
+			return null;
+		}
+
+		LocalDateTime frameTimestampUtc = LocalDateTime.ofInstant(Instant.parse(frameTimestampRaw), ZoneOffset.UTC);
+		LocalDateTime minuteBucketUtc = frameTimestampUtc.withSecond(0).withNano(0);
+
+		JsonNode gameMetadata = windowResponse.path("gameMetadata");
+		JsonNode blueTeamMetadata = gameMetadata.path("blueTeamMetadata");
+		JsonNode redTeamMetadata = gameMetadata.path("redTeamMetadata");
+
+		Set<Integer> blueParticipantIds = collectParticipantIds(blueTeamMetadata.path("participantMetadata"));
+		Map<Integer, JsonNode> participantMetaById = collectParticipantMeta(gameMetadata);
+
+		List<LiveParticipantState> participants = new ArrayList<>();
+		JsonNode frameParticipants = latestFrame.path("participants");
+		if (frameParticipants.isArray()) {
+			for (JsonNode frameParticipant : frameParticipants) {
+				Integer participantId = frameParticipant.path("participantId").isMissingNode()
+						? null
+						: frameParticipant.path("participantId").asInt();
+				if (participantId == null) {
+					continue;
+				}
+
+				JsonNode participantMeta = participantMetaById.get(participantId);
+				JsonNode perkMetadata = frameParticipant.path("perkMetadata");
+				String perksJson = serializeJson(perkMetadata);
+				Integer primaryStyleId = intOrNull(perkMetadata, "styleId");
+				Integer subStyleId = intOrNull(perkMetadata, "subStyleId");
+				List<Integer> runeIds = intList(perkMetadata.path("perks"));
+				String primaryStyleName = runeMetadataResolver.resolveStyleName(primaryStyleId);
+				String subStyleName = runeMetadataResolver.resolveStyleName(subStyleId);
+				List<String> runeNames = runeMetadataResolver.resolveRuneNames(runeIds);
+				List<Integer> itemIds = intList(frameParticipant.path("items"));
+				List<String> itemNames = itemMetadataResolver.resolveItemNames(itemIds);
+				List<String> itemImageUrls = itemMetadataResolver.resolveItemImageUrls(itemIds);
+
+				participants.add(new LiveParticipantState(
+						participantId,
+						blueParticipantIds.contains(participantId) ? "Blue" : "Red",
+						textOrNull(participantMeta, "role"),
+						textOrNull(participantMeta, "summonerName"),
+						textOrNull(participantMeta, "esportsPlayerId"),
+						textOrNull(participantMeta, "championId"),
+						intOrNull(frameParticipant, "level"),
+						intOrNull(frameParticipant, "kills"),
+						intOrNull(frameParticipant, "deaths"),
+						intOrNull(frameParticipant, "assists"),
+						intOrNull(frameParticipant, "totalGoldEarned"),
+						intOrNull(frameParticipant, "creepScore"),
+						doubleOrNull(frameParticipant, "killParticipation"),
+						doubleOrNull(frameParticipant, "championDamageShare"),
+						itemIds,
+						itemNames,
+						itemImageUrls,
+						perksJson,
+						primaryStyleName,
+						subStyleName,
+						runeNames));
+			}
+		}
+
+		return new LiveGameState(
+				activeGame.gameId(),
+				activeGame.matchId(),
+				activeGame.leagueName(),
+				firstNonBlank(
+						activeGame.blueTeamName(),
+						textOrNull(blueTeamMetadata, "esportsTeamId")),
+				firstNonBlank(
+						activeGame.redTeamName(),
+						textOrNull(redTeamMetadata, "esportsTeamId")),
+				minuteBucketUtc,
+				frameTimestampUtc,
+				participants,
+				List.of());
+	}
+
+	private JsonNode extractLatestFrame(JsonNode detailsResponse) {
+		JsonNode frames = detailsResponse.path("frames");
+		if (!frames.isArray() || frames.isEmpty()) {
+			return null;
+		}
+
+		Instant latest = Instant.EPOCH;
+		JsonNode latestFrame = null;
+
+		for (JsonNode frame : frames) {
+			String rawTimestamp = frame.path("rfc460Timestamp").asText(null);
+			if (rawTimestamp == null || rawTimestamp.isBlank()) {
+				continue;
+			}
+			try {
+				Instant timestamp = Instant.parse(rawTimestamp);
+				if (timestamp.isAfter(latest)) {
+					latest = timestamp;
+					latestFrame = frame;
+				}
+			} catch (Exception e) {
+				log.debug("Failed to parse frame timestamp: {}", rawTimestamp);
+			}
+		}
+		return latestFrame;
+	}
+
+	private Set<Integer> collectParticipantIds(JsonNode participantsNode) {
+		Set<Integer> ids = new HashSet<>();
+		if (!participantsNode.isArray()) {
+			return ids;
+		}
+		for (JsonNode participant : participantsNode) {
+			if (participant.path("participantId").canConvertToInt()) {
+				ids.add(participant.path("participantId").asInt());
+			}
+		}
+		return ids;
+	}
+
+	private Map<Integer, JsonNode> collectParticipantMeta(JsonNode gameMetadata) {
+		Map<Integer, JsonNode> participantMetaById = new HashMap<>();
+		collectParticipantMetaFromSide(gameMetadata.path("blueTeamMetadata"), participantMetaById);
+		collectParticipantMetaFromSide(gameMetadata.path("redTeamMetadata"), participantMetaById);
+		return participantMetaById;
+	}
+
+	private void collectParticipantMetaFromSide(JsonNode sideMeta, Map<Integer, JsonNode> collector) {
+		JsonNode participants = sideMeta.path("participantMetadata");
+		if (!participants.isArray()) {
+			return;
+		}
+		for (JsonNode participant : participants) {
+			if (participant.path("participantId").canConvertToInt()) {
+				collector.put(participant.path("participantId").asInt(), participant);
+			}
+		}
+	}
+
+	private Integer intOrNull(JsonNode node, String field) {
+		JsonNode target = node.path(field);
+		return target.isNumber() ? target.asInt() : null;
+	}
+
+	private Double doubleOrNull(JsonNode node, String field) {
+		JsonNode target = node.path(field);
+		return target.isNumber() ? target.asDouble() : null;
+	}
+
+	private String textOrNull(JsonNode node, String field) {
+		if (node == null || node.isMissingNode()) {
+			return null;
+		}
+		JsonNode target = node.path(field);
+		if (target.isMissingNode() || target.isNull()) {
+			return null;
+		}
+		String value = target.asText(null);
+		return value == null || value.isBlank() ? null : value;
+	}
+
+	private List<Integer> intList(JsonNode arrayNode) {
+		List<Integer> values = new ArrayList<>();
+		if (!arrayNode.isArray()) {
+			return values;
+		}
+		for (JsonNode item : arrayNode) {
+			if (item.isNumber()) {
+				values.add(item.asInt());
+			}
+		}
+		return values;
+	}
+
+	private String serializeJson(JsonNode node) {
+		if (node == null || node.isMissingNode() || node.isNull()) {
+			return "{}";
+		}
+		try {
+			return objectMapper.writeValueAsString(node);
+		} catch (JsonProcessingException e) {
+			return "{}";
+		}
+	}
+
+	private String firstNonBlank(String first, String second) {
+		if (first != null && !first.isBlank()) {
+			return first;
+		}
+		return second;
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStateQueryService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStateQueryService.java
@@ -1,0 +1,196 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveObjectEventResponse;
+import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteParticipantSnapshot;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteParticipantSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LiveStateQueryService {
+
+	private final LiveStateStore liveStateStore;
+	private final LiveGameMinuteSnapshotRepository snapshotRepository;
+	private final LiveGameMinuteParticipantSnapshotRepository participantSnapshotRepository;
+	private final LiveGameObjectEventRepository objectEventRepository;
+	private final ObjectMapper objectMapper;
+	private final RuneMetadataResolver runeMetadataResolver;
+	private final ItemMetadataResolver itemMetadataResolver;
+	private final LiveGameMetadataService liveGameMetadataService;
+
+	public Optional<LiveGameState> getLatestState(String gameId) {
+		Optional<LiveGameState> inMemory = liveStateStore.getLatestState(gameId);
+		if (inMemory.isPresent()) {
+			return Optional.of(enrichObjectTimeline(enrichMetadata(inMemory.get())));
+		}
+
+		return snapshotRepository.findTopByGameIdOrderByMinuteBucketUtcDesc(gameId)
+				.map(this::toState)
+				.map(this::enrichMetadata)
+				.map(this::enrichObjectTimeline);
+	}
+
+	public List<LiveGameState> getRecentMinuteSnapshots(String gameId) {
+		return snapshotRepository.findTop60ByGameIdOrderByMinuteBucketUtcDesc(gameId).stream()
+				.map(this::toState)
+				.toList();
+	}
+
+	private LiveGameState toState(LiveGameMinuteSnapshot snapshot) {
+		List<LiveParticipantState> participants = participantSnapshotRepository
+				.findBySnapshot_IdOrderByParticipantIdAsc(snapshot.getId()).stream()
+				.map(this::toParticipantState)
+				.toList();
+
+		return new LiveGameState(
+				snapshot.getGameId(),
+				snapshot.getMatchId(),
+				snapshot.getLeagueName(),
+				snapshot.getBlueTeamName(),
+				snapshot.getRedTeamName(),
+				snapshot.getMinuteBucketUtc(),
+				snapshot.getFrameTimestampUtc(),
+				participants,
+				List.of());
+	}
+
+	private LiveGameState enrichObjectTimeline(LiveGameState state) {
+		List<LiveGameObjectEvent> objectEvents = state.frameTimestampUtc() == null
+				? objectEventRepository.findByGameIdOrderBySourceFrameTimestampUtcAscIdAsc(state.gameId())
+				: objectEventRepository
+						.findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+								state.gameId(),
+								state.frameTimestampUtc());
+		List<LiveObjectEventResponse> timeline = objectEvents.stream()
+				.map(this::toObjectEventResponse)
+				.toList();
+
+		return new LiveGameState(
+				state.gameId(),
+				state.matchId(),
+				state.leagueName(),
+				state.blueTeamName(),
+				state.redTeamName(),
+				state.minuteBucketUtc(),
+				state.frameTimestampUtc(),
+				state.participants(),
+				timeline);
+	}
+
+	private LiveGameState enrichMetadata(LiveGameState state) {
+		ActiveLiveGame metadata = liveGameMetadataService.enrich(new ActiveLiveGame(
+				state.gameId(),
+				state.matchId(),
+				state.leagueName(),
+				state.blueTeamName(),
+				state.redTeamName(),
+				null,
+				0));
+		return new LiveGameState(
+				state.gameId(),
+				metadata.matchId(),
+				metadata.leagueName(),
+				metadata.blueTeamName(),
+				metadata.redTeamName(),
+				state.minuteBucketUtc(),
+				state.frameTimestampUtc(),
+				state.participants(),
+				state.objectTimeline());
+	}
+
+	private LiveObjectEventResponse toObjectEventResponse(LiveGameObjectEvent event) {
+		return new LiveObjectEventResponse(
+				event.getTeamSide(),
+				event.getEventType(),
+				event.getEventSubType(),
+				event.getEventOrder(),
+				event.getValueAfter(),
+				event.getSourceFrameTimestampUtc());
+	}
+
+	private LiveParticipantState toParticipantState(LiveGameMinuteParticipantSnapshot participant) {
+		List<Integer> itemIds = parseItemIds(participant.getItemIdsJson());
+		PerkInfo perkInfo = extractPerkInfo(participant.getPerksJson());
+		return new LiveParticipantState(
+				participant.getParticipantId(),
+				participant.getTeamSide(),
+				participant.getRole(),
+				participant.getPlayerName(),
+				participant.getEsportsPlayerId(),
+				participant.getChampionName(),
+				participant.getLevel(),
+				participant.getKills(),
+				participant.getDeaths(),
+				participant.getAssists(),
+				participant.getTotalGoldEarned(),
+				participant.getCreepScore(),
+				participant.getKillParticipation(),
+				participant.getChampionDamageShare(),
+				itemIds,
+				itemMetadataResolver.resolveItemNames(itemIds),
+				itemMetadataResolver.resolveItemImageUrls(itemIds),
+				participant.getPerksJson(),
+				perkInfo.primaryStyleName(),
+				perkInfo.subStyleName(),
+				perkInfo.runeNames());
+	}
+
+	private List<Integer> parseItemIds(String itemIdsJson) {
+		if (itemIdsJson == null || itemIdsJson.isBlank()) {
+			return Collections.emptyList();
+		}
+		try {
+			return objectMapper.readValue(itemIdsJson, new TypeReference<>() {
+			});
+		} catch (IOException e) {
+			return Collections.emptyList();
+		}
+	}
+
+	private PerkInfo extractPerkInfo(String perksJson) {
+		if (perksJson == null || perksJson.isBlank() || "{}".equals(perksJson)) {
+			return new PerkInfo(null, null, List.of());
+		}
+		try {
+			com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(perksJson);
+			Integer primaryStyleId = node.path("styleId").isNumber() ? node.path("styleId").asInt() : null;
+			Integer subStyleId = node.path("subStyleId").isNumber() ? node.path("subStyleId").asInt() : null;
+
+			List<Integer> runeIds = new java.util.ArrayList<>();
+			com.fasterxml.jackson.databind.JsonNode perks = node.path("perks");
+			if (perks.isArray()) {
+				for (com.fasterxml.jackson.databind.JsonNode runeId : perks) {
+					if (runeId.isNumber()) {
+						runeIds.add(runeId.asInt());
+					}
+				}
+			}
+
+			return new PerkInfo(
+					runeMetadataResolver.resolveStyleName(primaryStyleId),
+					runeMetadataResolver.resolveStyleName(subStyleId),
+					runeMetadataResolver.resolveRuneNames(runeIds));
+		} catch (IOException e) {
+			return new PerkInfo(null, null, List.of());
+		}
+	}
+
+	private record PerkInfo(String primaryStyleName, String subStyleName, List<String> runeNames) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStateStore.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStateStore.java
@@ -1,0 +1,59 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveGameSummaryResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class LiveStateStore {
+
+	private final Map<String, ActiveLiveGame> activeGames = new ConcurrentHashMap<>();
+	private final Map<String, LiveGameState> latestStates = new ConcurrentHashMap<>();
+
+	public Map<String, ActiveLiveGame> getActiveGames() {
+		return activeGames;
+	}
+
+	public void putLatestState(LiveGameState state) {
+		latestStates.compute(state.gameId(), (gameId, existing) -> {
+			if (existing == null) {
+				return state;
+			}
+			if (existing.frameTimestampUtc() == null) {
+				return state;
+			}
+			if (state.frameTimestampUtc() == null) {
+				return existing;
+			}
+			return state.frameTimestampUtc().isAfter(existing.frameTimestampUtc()) ? state : existing;
+		});
+	}
+
+	public Optional<LiveGameState> getLatestState(String gameId) {
+		return Optional.ofNullable(latestStates.get(gameId));
+	}
+
+	public void removeGame(String gameId) {
+		activeGames.remove(gameId);
+		latestStates.remove(gameId);
+	}
+
+	public List<LiveGameSummaryResponse> getLiveGameSummaries() {
+		return latestStates.values().stream()
+				.sorted(Comparator.comparing(LiveGameState::frameTimestampUtc).reversed())
+				.map(state -> new LiveGameSummaryResponse(
+						state.gameId(),
+						state.matchId(),
+						state.leagueName(),
+						state.blueTeamName(),
+						state.redTeamName(),
+						state.frameTimestampUtc()))
+				.toList();
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStatsClient.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStatsClient.java
@@ -1,0 +1,50 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LiveStatsClient {
+
+	private final WebClient webClient;
+
+	@Value("${lolesports.riot-api.key}")
+	private String riotApiKey;
+
+	@Value("${lolesports.live.request-timeout-ms:3000}")
+	private long requestTimeoutMs;
+
+	public JsonNode getWindow(String gameId, String startingTime) {
+		return call(gameId, startingTime, "window");
+	}
+
+	public JsonNode getDetails(String gameId, String startingTime) {
+		return call(gameId, startingTime, "details");
+	}
+
+	private JsonNode call(String gameId, String startingTime, String endpoint) {
+		return webClient.get()
+				.uri(uriBuilder -> uriBuilder
+						.scheme("https")
+						.host("feed.lolesports.com")
+						.path("/livestats/v1/" + endpoint + "/{gameId}")
+						.queryParam("startingTime", startingTime)
+						.build(gameId))
+				.header("x-api-key", riotApiKey)
+				.accept(MediaType.APPLICATION_JSON)
+				.retrieve()
+				.bodyToMono(JsonNode.class)
+				.timeout(Duration.ofMillis(requestTimeoutMs))
+				.block();
+	}
+}
+

--- a/src/main/java/com/toy/nar/app/lolesports/live/RuneMetadataResolver.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/RuneMetadataResolver.java
@@ -1,0 +1,142 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RuneMetadataResolver {
+
+	private static final Map<Integer, String> STAT_SHARD_NAMES = Map.of(
+			5001, "체력 +65",
+			5002, "방어력 +10",
+			5003, "마법 저항력 +10",
+			5005, "공격 속도 +10%",
+			5007, "스킬 가속 +8",
+			5008, "적응형 능력치 +9",
+			5010, "이동 속도 +2%",
+			5011, "강인함 +10% 및 둔화 저항 +10%");
+
+	private final WebClient webClient;
+
+	@Value("${lolesports.live.rune-locale:ko_KR}")
+	private String runeLocale;
+
+	@Value("${lolesports.live.rune-refresh-minutes:360}")
+	private long refreshMinutes;
+
+	private volatile Instant loadedAt = Instant.EPOCH;
+	private volatile Map<Integer, String> runeNamesById = new HashMap<>(STAT_SHARD_NAMES);
+	private volatile Map<Integer, String> styleNamesById = new HashMap<>();
+
+	public String resolveStyleName(Integer styleId) {
+		if (styleId == null) {
+			return null;
+		}
+		ensureLoaded();
+		return styleNamesById.getOrDefault(styleId, "스타일-" + styleId);
+	}
+
+	public List<String> resolveRuneNames(List<Integer> runeIds) {
+		ensureLoaded();
+		List<String> names = new ArrayList<>();
+		for (Integer runeId : runeIds) {
+			if (runeId == null) {
+				continue;
+			}
+			names.add(runeNamesById.getOrDefault(runeId, "룬-" + runeId));
+		}
+		return names;
+	}
+
+	private void ensureLoaded() {
+		Instant now = Instant.now();
+		if (!runeNamesById.isEmpty() && Duration.between(loadedAt, now).toMinutes() < refreshMinutes) {
+			return;
+		}
+		synchronized (this) {
+			if (!runeNamesById.isEmpty() && Duration.between(loadedAt, Instant.now()).toMinutes() < refreshMinutes) {
+				return;
+			}
+			loadFromDataDragon();
+		}
+	}
+
+	private void loadFromDataDragon() {
+		try {
+			JsonNode versions = webClient.get()
+					.uri("https://ddragon.leagueoflegends.com/api/versions.json")
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+
+			if (versions == null || !versions.isArray() || versions.isEmpty()) {
+				log.warn("Failed to load Data Dragon versions.");
+				return;
+			}
+
+			String latestVersion = versions.get(0).asText();
+			JsonNode runeTrees = webClient.get()
+					.uri("https://ddragon.leagueoflegends.com/cdn/{version}/data/{locale}/runesReforged.json",
+							latestVersion, runeLocale)
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+
+			if (runeTrees == null || !runeTrees.isArray()) {
+				log.warn("Failed to load Data Dragon runes for version: {}", latestVersion);
+				return;
+			}
+
+			Map<Integer, String> newRuneNames = new HashMap<>(STAT_SHARD_NAMES);
+			Map<Integer, String> newStyleNames = new HashMap<>();
+
+			for (JsonNode style : runeTrees) {
+				int styleId = style.path("id").asInt(-1);
+				String styleName = style.path("name").asText("");
+				if (styleId > 0 && !styleName.isBlank()) {
+					newStyleNames.put(styleId, styleName);
+				}
+
+				JsonNode slots = style.path("slots");
+				if (!slots.isArray()) {
+					continue;
+				}
+				for (JsonNode slot : slots) {
+					JsonNode runes = slot.path("runes");
+					if (!runes.isArray()) {
+						continue;
+					}
+					for (JsonNode rune : runes) {
+						int runeId = rune.path("id").asInt(-1);
+						String runeName = rune.path("name").asText("");
+						if (runeId > 0 && !runeName.isBlank()) {
+							newRuneNames.put(runeId, runeName);
+						}
+					}
+				}
+			}
+
+			this.runeNamesById = newRuneNames;
+			this.styleNamesById = newStyleNames;
+			this.loadedAt = Instant.now();
+			log.info("Loaded rune metadata from Data Dragon: version={}, runeCount={}, styleCount={}",
+					latestVersion, newRuneNames.size(), newStyleNames.size());
+		} catch (Exception e) {
+			log.warn("Failed to refresh rune metadata: {}", e.getMessage());
+		}
+	}
+}
+

--- a/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveBackfillResponse.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveBackfillResponse.java
@@ -1,0 +1,18 @@
+package com.toy.nar.app.lolesports.live.dto;
+
+import java.time.LocalDateTime;
+
+public record LiveBackfillResponse(
+		String gameId,
+		String startingTimeSource,
+		LocalDateTime baseStartingTimeUtc,
+		LocalDateTime resolvedStartingTimeUtc,
+		Integer probeAttempts,
+		Integer minutesRequested,
+		Integer snapshotsWritten,
+		Integer emptyResponses,
+		Integer failures,
+		String stopReason,
+		LocalDateTime firstFrameTimestampUtc,
+		LocalDateTime lastFrameTimestampUtc) {
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveGameState.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveGameState.java
@@ -1,0 +1,16 @@
+package com.toy.nar.app.lolesports.live.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LiveGameState(
+		String gameId,
+		String matchId,
+		String leagueName,
+		String blueTeamName,
+		String redTeamName,
+		LocalDateTime minuteBucketUtc,
+		LocalDateTime frameTimestampUtc,
+		List<LiveParticipantState> participants,
+		List<LiveObjectEventResponse> objectTimeline) {
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveGameSummaryResponse.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveGameSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.toy.nar.app.lolesports.live.dto;
+
+import java.time.LocalDateTime;
+
+public record LiveGameSummaryResponse(
+		String gameId,
+		String matchId,
+		String leagueName,
+		String blueTeamName,
+		String redTeamName,
+		LocalDateTime frameTimestampUtc) {
+}
+

--- a/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveObjectEventResponse.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveObjectEventResponse.java
@@ -1,0 +1,12 @@
+package com.toy.nar.app.lolesports.live.dto;
+
+import java.time.LocalDateTime;
+
+public record LiveObjectEventResponse(
+		String teamSide,
+		String eventType,
+		String eventSubType,
+		Integer eventOrder,
+		Integer valueAfter,
+		LocalDateTime sourceFrameTimestampUtc) {
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveParticipantState.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveParticipantState.java
@@ -1,0 +1,27 @@
+package com.toy.nar.app.lolesports.live.dto;
+
+import java.util.List;
+
+public record LiveParticipantState(
+		Integer participantId,
+		String teamSide,
+		String role,
+		String playerName,
+		String esportsPlayerId,
+		String championName,
+		Integer level,
+		Integer kills,
+		Integer deaths,
+		Integer assists,
+		Integer totalGoldEarned,
+		Integer creepScore,
+		Double killParticipation,
+		Double championDamageShare,
+		List<Integer> itemIds,
+		List<String> itemNames,
+		List<String> itemImageUrls,
+		String perksJson,
+		String primaryStyleName,
+		String subStyleName,
+		List<String> runeNames) {
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveSimulationResponse.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/dto/LiveSimulationResponse.java
@@ -1,0 +1,15 @@
+package com.toy.nar.app.lolesports.live.dto;
+
+import java.time.LocalDateTime;
+
+public record LiveSimulationResponse(
+		String gameId,
+		LocalDateTime firstStartingTimeUtc,
+		Integer ticksRequested,
+		Integer stepSeconds,
+		Integer processedFrames,
+		Integer emptyResponses,
+		Integer failures,
+		LocalDateTime firstFrameTimestampUtc,
+		LocalDateTime lastFrameTimestampUtc) {
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameMapping.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameMapping.java
@@ -1,0 +1,120 @@
+package com.toy.nar.app.lolesports.live.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "live_game_mapping", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_game_mapping_live_game", columnNames = "live_game_id") })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveGameMapping {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "live_game_id", nullable = false, length = 64)
+	private String liveGameId;
+
+	@Column(name = "live_match_id", length = 64)
+	private String liveMatchId;
+
+	@Column(name = "live_league_name", length = 20)
+	private String liveLeagueName;
+
+	@Column(name = "live_blue_team_name", length = 120)
+	private String liveBlueTeamName;
+
+	@Column(name = "live_red_team_name", length = 120)
+	private String liveRedTeamName;
+
+	@Column(name = "first_minute_bucket_utc")
+	private LocalDateTime firstMinuteBucketUtc;
+
+	@Column(name = "last_frame_timestamp_utc")
+	private LocalDateTime lastFrameTimestampUtc;
+
+	@Column(name = "internal_game_id")
+	private Long internalGameId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20)
+	private MappingStatus status = MappingStatus.PENDING;
+
+	@Column(name = "confidence")
+	private Double confidence;
+
+	@Column(name = "mapping_method", length = 64)
+	private String mappingMethod;
+
+	@Column(name = "reason", length = 500)
+	private String reason;
+
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	public LiveGameMapping(String liveGameId) {
+		this.liveGameId = Objects.requireNonNull(liveGameId);
+		this.status = MappingStatus.PENDING;
+	}
+
+	public void updateLiveContext(
+			String liveMatchId,
+			String liveLeagueName,
+			String liveBlueTeamName,
+			String liveRedTeamName,
+			LocalDateTime firstMinuteBucketUtc,
+			LocalDateTime lastFrameTimestampUtc) {
+		this.liveMatchId = liveMatchId;
+		this.liveLeagueName = liveLeagueName;
+		this.liveBlueTeamName = liveBlueTeamName;
+		this.liveRedTeamName = liveRedTeamName;
+		this.firstMinuteBucketUtc = firstMinuteBucketUtc;
+		this.lastFrameTimestampUtc = lastFrameTimestampUtc;
+	}
+
+	public void markMapped(Long internalGameId, double confidence, String mappingMethod, String reason) {
+		this.internalGameId = internalGameId;
+		this.status = MappingStatus.MAPPED;
+		this.confidence = confidence;
+		this.mappingMethod = mappingMethod;
+		this.reason = reason;
+	}
+
+	public void markPending(String reason) {
+		this.status = MappingStatus.PENDING;
+		this.confidence = null;
+		this.mappingMethod = null;
+		this.reason = reason;
+		this.internalGameId = null;
+	}
+
+	public void markAmbiguous(String reason) {
+		this.status = MappingStatus.AMBIGUOUS;
+		this.confidence = null;
+		this.mappingMethod = null;
+		this.reason = reason;
+		this.internalGameId = null;
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameMinuteParticipantSnapshot.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameMinuteParticipantSnapshot.java
@@ -1,0 +1,117 @@
+package com.toy.nar.app.lolesports.live.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "live_game_minute_participant_snapshot", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_minute_participant", columnNames = { "snapshot_id", "participant_id" }) })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveGameMinuteParticipantSnapshot {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "snapshot_id", nullable = false)
+	private LiveGameMinuteSnapshot snapshot;
+
+	@Column(name = "participant_id", nullable = false)
+	private Integer participantId;
+
+	@Column(name = "team_side", length = 8)
+	private String teamSide;
+
+	@Column(name = "role", length = 20)
+	private String role;
+
+	@Column(name = "player_name", length = 100)
+	private String playerName;
+
+	@Column(name = "esports_player_id", length = 64)
+	private String esportsPlayerId;
+
+	@Column(name = "champion_name", length = 50)
+	private String championName;
+
+	@Column(name = "level")
+	private Integer level;
+
+	@Column(name = "kills")
+	private Integer kills;
+
+	@Column(name = "deaths")
+	private Integer deaths;
+
+	@Column(name = "assists")
+	private Integer assists;
+
+	@Column(name = "total_gold_earned")
+	private Integer totalGoldEarned;
+
+	@Column(name = "creep_score")
+	private Integer creepScore;
+
+	@Column(name = "kill_participation")
+	private Double killParticipation;
+
+	@Column(name = "champion_damage_share")
+	private Double championDamageShare;
+
+	@Column(name = "item_ids_json", columnDefinition = "TEXT")
+	private String itemIdsJson;
+
+	@Column(name = "perks_json", columnDefinition = "TEXT")
+	private String perksJson;
+
+	public LiveGameMinuteParticipantSnapshot(
+			LiveGameMinuteSnapshot snapshot,
+			Integer participantId,
+			String teamSide,
+			String role,
+			String playerName,
+			String esportsPlayerId,
+			String championName,
+			Integer level,
+			Integer kills,
+			Integer deaths,
+			Integer assists,
+			Integer totalGoldEarned,
+			Integer creepScore,
+			Double killParticipation,
+			Double championDamageShare,
+			String itemIdsJson,
+			String perksJson) {
+		this.snapshot = snapshot;
+		this.participantId = participantId;
+		this.teamSide = teamSide;
+		this.role = role;
+		this.playerName = playerName;
+		this.esportsPlayerId = esportsPlayerId;
+		this.championName = championName;
+		this.level = level;
+		this.kills = kills;
+		this.deaths = deaths;
+		this.assists = assists;
+		this.totalGoldEarned = totalGoldEarned;
+		this.creepScore = creepScore;
+		this.killParticipation = killParticipation;
+		this.championDamageShare = championDamageShare;
+		this.itemIdsJson = itemIdsJson;
+		this.perksJson = perksJson;
+	}
+}
+

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameMinuteSnapshot.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameMinuteSnapshot.java
@@ -1,0 +1,89 @@
+package com.toy.nar.app.lolesports.live.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "live_game_minute_snapshot", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_game_minute_bucket", columnNames = { "game_id", "minute_bucket_utc" }) })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveGameMinuteSnapshot {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "game_id", nullable = false, length = 64)
+	private String gameId;
+
+	@Column(name = "match_id", length = 64)
+	private String matchId;
+
+	@Column(name = "league_name", length = 20)
+	private String leagueName;
+
+	@Column(name = "blue_team_name", length = 120)
+	private String blueTeamName;
+
+	@Column(name = "red_team_name", length = 120)
+	private String redTeamName;
+
+	@Column(name = "minute_bucket_utc", nullable = false)
+	private LocalDateTime minuteBucketUtc;
+
+	@Column(name = "frame_timestamp_utc", nullable = false)
+	private LocalDateTime frameTimestampUtc;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	public LiveGameMinuteSnapshot(String gameId, LocalDateTime minuteBucketUtc) {
+		this.gameId = Objects.requireNonNull(gameId);
+		this.minuteBucketUtc = Objects.requireNonNull(minuteBucketUtc);
+	}
+
+	public void updateSnapshot(
+			String matchId,
+			String leagueName,
+			String blueTeamName,
+			String redTeamName,
+			LocalDateTime frameTimestampUtc) {
+		this.matchId = matchId;
+		this.leagueName = leagueName;
+		this.blueTeamName = blueTeamName;
+		this.redTeamName = redTeamName;
+		this.frameTimestampUtc = Objects.requireNonNull(frameTimestampUtc);
+	}
+
+	@PrePersist
+	public void onCreate() {
+		LocalDateTime now = LocalDateTime.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		updatedAt = now;
+	}
+
+	@PreUpdate
+	public void onUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+}
+

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameObjectEvent.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameObjectEvent.java
@@ -1,0 +1,80 @@
+package com.toy.nar.app.lolesports.live.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "live_game_object_event", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_game_object_event", columnNames = {
+				"game_id", "team_side", "event_type", "event_order" }) })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveGameObjectEvent {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "game_id", nullable = false, length = 64)
+	private String gameId;
+
+	@Column(name = "match_id", length = 64)
+	private String matchId;
+
+	@Column(name = "league_name", length = 20)
+	private String leagueName;
+
+	@Column(name = "team_side", nullable = false, length = 8)
+	private String teamSide;
+
+	@Column(name = "event_type", nullable = false, length = 20)
+	private String eventType;
+
+	@Column(name = "event_sub_type", length = 50)
+	private String eventSubType;
+
+	@Column(name = "event_order", nullable = false)
+	private Integer eventOrder;
+
+	@Column(name = "value_after", nullable = false)
+	private Integer valueAfter;
+
+	@Column(name = "source_frame_timestamp_utc", nullable = false)
+	private LocalDateTime sourceFrameTimestampUtc;
+
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	public LiveGameObjectEvent(
+			String gameId,
+			String matchId,
+			String leagueName,
+			String teamSide,
+			String eventType,
+			String eventSubType,
+			Integer eventOrder,
+			Integer valueAfter,
+			LocalDateTime sourceFrameTimestampUtc) {
+		this.gameId = gameId;
+		this.matchId = matchId;
+		this.leagueName = leagueName;
+		this.teamSide = teamSide;
+		this.eventType = eventType;
+		this.eventSubType = eventSubType;
+		this.eventOrder = eventOrder;
+		this.valueAfter = valueAfter;
+		this.sourceFrameTimestampUtc = sourceFrameTimestampUtc;
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveParticipantMapping.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveParticipantMapping.java
@@ -1,0 +1,151 @@
+package com.toy.nar.app.lolesports.live.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "live_participant_mapping", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_participant_mapping", columnNames = { "live_game_id", "live_participant_id" }) })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveParticipantMapping {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "live_game_id", nullable = false, length = 64)
+	private String liveGameId;
+
+	@Column(name = "live_participant_id", nullable = false)
+	private Integer liveParticipantId;
+
+	@Column(name = "live_team_side", length = 8)
+	private String liveTeamSide;
+
+	@Column(name = "live_role", length = 20)
+	private String liveRole;
+
+	@Column(name = "live_player_name", length = 100)
+	private String livePlayerName;
+
+	@Column(name = "live_esports_player_id", length = 64)
+	private String liveEsportsPlayerId;
+
+	@Column(name = "live_champion_name", length = 50)
+	private String liveChampionName;
+
+	@Column(name = "internal_game_participant_id")
+	private Long internalGameParticipantId;
+
+	@Column(name = "internal_game_id")
+	private Long internalGameId;
+
+	@Column(name = "internal_player_id")
+	private Long internalPlayerId;
+
+	@Column(name = "internal_team_id")
+	private Long internalTeamId;
+
+	@Column(name = "internal_champion_id")
+	private Long internalChampionId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20)
+	private MappingStatus status = MappingStatus.PENDING;
+
+	@Column(name = "confidence")
+	private Double confidence;
+
+	@Column(name = "mapping_method", length = 64)
+	private String mappingMethod;
+
+	@Column(name = "reason", length = 500)
+	private String reason;
+
+	@CreationTimestamp
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@UpdateTimestamp
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	public LiveParticipantMapping(String liveGameId, Integer liveParticipantId) {
+		this.liveGameId = Objects.requireNonNull(liveGameId);
+		this.liveParticipantId = Objects.requireNonNull(liveParticipantId);
+		this.status = MappingStatus.PENDING;
+	}
+
+	public void updateLiveContext(
+			String liveTeamSide,
+			String liveRole,
+			String livePlayerName,
+			String liveEsportsPlayerId,
+			String liveChampionName) {
+		this.liveTeamSide = liveTeamSide;
+		this.liveRole = liveRole;
+		this.livePlayerName = livePlayerName;
+		this.liveEsportsPlayerId = liveEsportsPlayerId;
+		this.liveChampionName = liveChampionName;
+	}
+
+	public void markMapped(
+			Long internalGameParticipantId,
+			Long internalGameId,
+			Long internalPlayerId,
+			Long internalTeamId,
+			Long internalChampionId,
+			double confidence,
+			String mappingMethod,
+			String reason) {
+		this.internalGameParticipantId = internalGameParticipantId;
+		this.internalGameId = internalGameId;
+		this.internalPlayerId = internalPlayerId;
+		this.internalTeamId = internalTeamId;
+		this.internalChampionId = internalChampionId;
+		this.status = MappingStatus.MAPPED;
+		this.confidence = confidence;
+		this.mappingMethod = mappingMethod;
+		this.reason = reason;
+	}
+
+	public void markPending(String reason) {
+		this.internalGameParticipantId = null;
+		this.internalGameId = null;
+		this.internalPlayerId = null;
+		this.internalTeamId = null;
+		this.internalChampionId = null;
+		this.status = MappingStatus.PENDING;
+		this.confidence = null;
+		this.mappingMethod = null;
+		this.reason = reason;
+	}
+
+	public void markAmbiguous(String reason) {
+		this.internalGameParticipantId = null;
+		this.internalGameId = null;
+		this.internalPlayerId = null;
+		this.internalTeamId = null;
+		this.internalChampionId = null;
+		this.status = MappingStatus.AMBIGUOUS;
+		this.confidence = null;
+		this.mappingMethod = null;
+		this.reason = reason;
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/MappingStatus.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/MappingStatus.java
@@ -1,0 +1,7 @@
+package com.toy.nar.app.lolesports.live.entity;
+
+public enum MappingStatus {
+	PENDING,
+	MAPPED,
+	AMBIGUOUS
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMappingRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMappingRepository.java
@@ -1,0 +1,16 @@
+package com.toy.nar.app.lolesports.live.repository;
+
+import com.toy.nar.app.lolesports.live.entity.LiveGameMapping;
+import com.toy.nar.app.lolesports.live.entity.MappingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveGameMappingRepository extends JpaRepository<LiveGameMapping, Long> {
+
+	Optional<LiveGameMapping> findByLiveGameId(String liveGameId);
+
+	List<LiveGameMapping> findByStatusIn(Collection<MappingStatus> statuses);
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMinuteParticipantSnapshotRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMinuteParticipantSnapshotRepository.java
@@ -1,0 +1,13 @@
+package com.toy.nar.app.lolesports.live.repository;
+
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteParticipantSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LiveGameMinuteParticipantSnapshotRepository extends JpaRepository<LiveGameMinuteParticipantSnapshot, Long> {
+
+	void deleteBySnapshot_Id(Long snapshotId);
+
+	List<LiveGameMinuteParticipantSnapshot> findBySnapshot_IdOrderByParticipantIdAsc(Long snapshotId);
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMinuteSnapshotRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMinuteSnapshotRepository.java
@@ -1,0 +1,31 @@
+package com.toy.nar.app.lolesports.live.repository;
+
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveGameMinuteSnapshotRepository extends JpaRepository<LiveGameMinuteSnapshot, Long> {
+
+	Optional<LiveGameMinuteSnapshot> findByGameIdAndMinuteBucketUtc(String gameId, LocalDateTime minuteBucketUtc);
+
+	Optional<LiveGameMinuteSnapshot> findTopByGameIdOrderByMinuteBucketUtcDesc(String gameId);
+
+	Optional<LiveGameMinuteSnapshot> findTopByGameIdOrderByMinuteBucketUtcAsc(String gameId);
+
+	Optional<LiveGameMinuteSnapshot> findTopByGameIdOrderByFrameTimestampUtcDesc(String gameId);
+
+	List<LiveGameMinuteSnapshot> findTop60ByGameIdOrderByMinuteBucketUtcDesc(String gameId);
+
+	@Query("""
+			SELECT s.gameId
+			FROM LiveGameMinuteSnapshot s
+			GROUP BY s.gameId
+			ORDER BY MAX(s.frameTimestampUtc) DESC
+			""")
+	List<String> findRecentGameIds(Pageable pageable);
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameObjectEventRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameObjectEventRepository.java
@@ -1,0 +1,22 @@
+package com.toy.nar.app.lolesports.live.repository;
+
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface LiveGameObjectEventRepository extends JpaRepository<LiveGameObjectEvent, Long> {
+
+	boolean existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
+			String gameId,
+			String teamSide,
+			String eventType,
+			Integer eventOrder);
+
+	List<LiveGameObjectEvent> findByGameIdOrderBySourceFrameTimestampUtcAscIdAsc(String gameId);
+
+	List<LiveGameObjectEvent> findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+			String gameId,
+			LocalDateTime sourceFrameTimestampUtc);
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveParticipantMappingRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveParticipantMappingRepository.java
@@ -1,0 +1,18 @@
+package com.toy.nar.app.lolesports.live.repository;
+
+import com.toy.nar.app.lolesports.live.entity.LiveParticipantMapping;
+import com.toy.nar.app.lolesports.live.entity.MappingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveParticipantMappingRepository extends JpaRepository<LiveParticipantMapping, Long> {
+
+	Optional<LiveParticipantMapping> findByLiveGameIdAndLiveParticipantId(String liveGameId, Integer liveParticipantId);
+
+	List<LiveParticipantMapping> findByLiveGameId(String liveGameId);
+
+	List<LiveParticipantMapping> findByStatusIn(Collection<MappingStatus> statuses);
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -118,9 +118,12 @@ lolesports:
     team-metadata-cron: ${LOL_TEAM_METADATA_CRON:0 15 4 * * *}
     active-leagues: ${LOL_ACTIVE_LEAGUES:LCK,LPL,LEC,LCS,LCP,CBLOL,MSI,WORLDS,FIRST_STAND}
   live:
-    enabled: true
+    enabled: ${LOL_LIVE_ENABLED:false}
     discovery-interval-ms: 60000
-    poll-interval-ms: 10000
+    poll-interval-ms: 5000
     stale-threshold-ms: 180000
     request-timeout-ms: 3000
     max-consecutive-failures: 6
+    queue:
+      snapshot-capacity: ${LOL_LIVE_SNAPSHOT_QUEUE_CAPACITY:600}
+      object-capacity: ${LOL_LIVE_OBJECT_QUEUE_CAPACITY:1200}

--- a/src/main/resources/db/migration/V35__Create_live_streaming_tables.sql
+++ b/src/main/resources/db/migration/V35__Create_live_streaming_tables.sql
@@ -1,0 +1,129 @@
+CREATE TABLE IF NOT EXISTS league_match_game (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    match_id VARCHAR(50) NOT NULL,
+    game_id VARCHAR(64) NOT NULL,
+    game_order INT,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT fk_league_match_game_match
+        FOREIGN KEY (match_id) REFERENCES league_match(id) ON DELETE CASCADE,
+    CONSTRAINT uk_league_match_game_game_id UNIQUE (game_id),
+    CONSTRAINT uk_league_match_game_match_game UNIQUE (match_id, game_id),
+    INDEX idx_league_match_game_match_id (match_id),
+    INDEX idx_league_match_game_match_order (match_id, game_order)
+);
+
+CREATE TABLE IF NOT EXISTS live_game_minute_snapshot (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    game_id VARCHAR(64) NOT NULL,
+    match_id VARCHAR(64),
+    league_name VARCHAR(20),
+    blue_team_name VARCHAR(120),
+    red_team_name VARCHAR(120),
+    minute_bucket_utc DATETIME(3) NOT NULL,
+    frame_timestamp_utc DATETIME(3) NOT NULL,
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    CONSTRAINT uk_live_game_minute_bucket UNIQUE (game_id, minute_bucket_utc),
+    INDEX idx_live_minute_snapshot_game_frame (game_id, frame_timestamp_utc DESC)
+);
+
+CREATE TABLE IF NOT EXISTS live_game_minute_participant_snapshot (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    snapshot_id BIGINT NOT NULL,
+    participant_id INT NOT NULL,
+    team_side VARCHAR(8),
+    role VARCHAR(20),
+    player_name VARCHAR(100),
+    esports_player_id VARCHAR(64),
+    champion_name VARCHAR(50),
+    level INT,
+    kills INT,
+    deaths INT,
+    assists INT,
+    total_gold_earned INT,
+    creep_score INT,
+    kill_participation DOUBLE,
+    champion_damage_share DOUBLE,
+    item_ids_json TEXT,
+    perks_json TEXT,
+    CONSTRAINT fk_live_minute_participant_snapshot
+        FOREIGN KEY (snapshot_id) REFERENCES live_game_minute_snapshot(id) ON DELETE CASCADE,
+    CONSTRAINT uk_live_minute_participant UNIQUE (snapshot_id, participant_id)
+);
+
+CREATE TABLE IF NOT EXISTS live_game_object_event (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    game_id VARCHAR(64) NOT NULL,
+    match_id VARCHAR(64),
+    league_name VARCHAR(20),
+    team_side VARCHAR(8) NOT NULL,
+    event_type VARCHAR(20) NOT NULL,
+    event_sub_type VARCHAR(50),
+    event_order INT NOT NULL,
+    value_after INT NOT NULL,
+    source_frame_timestamp_utc DATETIME(3) NOT NULL,
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    CONSTRAINT uk_live_game_object_event UNIQUE (game_id, team_side, event_type, event_order),
+    INDEX idx_live_game_object_event_game_time (game_id, source_frame_timestamp_utc, id)
+);
+
+CREATE TABLE IF NOT EXISTS live_game_mapping (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    live_game_id VARCHAR(64) NOT NULL,
+    live_match_id VARCHAR(64),
+    live_league_name VARCHAR(20),
+    live_blue_team_name VARCHAR(120),
+    live_red_team_name VARCHAR(120),
+    first_minute_bucket_utc DATETIME(3),
+    last_frame_timestamp_utc DATETIME(3),
+    internal_game_id BIGINT,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    confidence DOUBLE,
+    mapping_method VARCHAR(64),
+    reason VARCHAR(500),
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    CONSTRAINT uk_live_game_mapping_live_game UNIQUE (live_game_id),
+    CONSTRAINT fk_live_game_mapping_internal_game
+        FOREIGN KEY (internal_game_id) REFERENCES games(game_id) ON DELETE SET NULL,
+    INDEX idx_live_game_mapping_status (status),
+    INDEX idx_live_game_mapping_match (live_match_id),
+    INDEX idx_live_game_mapping_internal_game (internal_game_id)
+);
+
+CREATE TABLE IF NOT EXISTS live_participant_mapping (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    live_game_id VARCHAR(64) NOT NULL,
+    live_participant_id INT NOT NULL,
+    live_team_side VARCHAR(8),
+    live_role VARCHAR(20),
+    live_player_name VARCHAR(100),
+    live_esports_player_id VARCHAR(64),
+    live_champion_name VARCHAR(50),
+    internal_game_participant_id BIGINT,
+    internal_game_id BIGINT,
+    internal_player_id BIGINT,
+    internal_team_id BIGINT,
+    internal_champion_id BIGINT,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    confidence DOUBLE,
+    mapping_method VARCHAR(64),
+    reason VARCHAR(500),
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+    CONSTRAINT uk_live_participant_mapping UNIQUE (live_game_id, live_participant_id),
+    CONSTRAINT fk_live_participant_mapping_game_participant
+        FOREIGN KEY (internal_game_participant_id) REFERENCES game_participants(participant_game_id) ON DELETE SET NULL,
+    CONSTRAINT fk_live_participant_mapping_game
+        FOREIGN KEY (internal_game_id) REFERENCES games(game_id) ON DELETE SET NULL,
+    CONSTRAINT fk_live_participant_mapping_player
+        FOREIGN KEY (internal_player_id) REFERENCES players(player_id) ON DELETE SET NULL,
+    CONSTRAINT fk_live_participant_mapping_team
+        FOREIGN KEY (internal_team_id) REFERENCES teams(team_id) ON DELETE SET NULL,
+    CONSTRAINT fk_live_participant_mapping_champion
+        FOREIGN KEY (internal_champion_id) REFERENCES champions(champion_id) ON DELETE SET NULL,
+    INDEX idx_live_participant_mapping_status (status),
+    INDEX idx_live_participant_mapping_game (live_game_id),
+    INDEX idx_live_participant_mapping_internal_game (internal_game_id)
+);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveGameMetadataServiceTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveGameMetadataServiceTest.java
@@ -1,0 +1,46 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.toy.nar.app.lolesports.MatchResponseWrapper;
+import com.toy.nar.app.lolesports.MatchResultDto;
+import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LiveGameMetadataServiceTest {
+
+	@Test
+	void resolvesMetadataFromScheduleAndCachesByGameId() {
+		WorldsService worldsService = mock(WorldsService.class);
+		LeagueMatchGameRepository leagueMatchGameRepository = mock(LeagueMatchGameRepository.class);
+		LiveGameMetadataService service = new LiveGameMetadataService(worldsService, leagueMatchGameRepository);
+		when(leagueMatchGameRepository.findWithMatchByGameId("game-1")).thenReturn(Optional.empty());
+		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(MatchResultDto.builder()
+						.matchId("match-1")
+						.leagueName("LCK")
+						.blueTeam(MatchResultDto.TeamInfo.builder().name("kt Rolster").code("KT").build())
+						.redTeam(MatchResultDto.TeamInfo.builder().name("Hanwha Life Esports").code("HLE").build())
+						.gameIds(List.of("game-1"))
+						.build()))
+				.build());
+
+		ActiveLiveGame first = service.resolve("game-1").orElseThrow();
+		ActiveLiveGame second = service.resolve("game-1").orElseThrow();
+
+		assertThat(first.matchId()).isEqualTo("match-1");
+		assertThat(first.leagueName()).isEqualTo("LCK");
+		assertThat(first.blueTeamName()).isEqualTo("kt Rolster");
+		assertThat(first.redTeamName()).isEqualTo("Hanwha Life Esports");
+		assertThat(second).isEqualTo(first);
+		verify(worldsService, times(1)).getWorldsMatches(null, "LCK");
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveMinuteSnapshotWriterTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveMinuteSnapshotWriterTest.java
@@ -1,0 +1,78 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteParticipantSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LiveMinuteSnapshotWriterTest {
+
+	private final LiveGameMinuteSnapshotRepository snapshotRepository = mock(LiveGameMinuteSnapshotRepository.class);
+	private final LiveGameMinuteParticipantSnapshotRepository participantSnapshotRepository =
+			mock(LiveGameMinuteParticipantSnapshotRepository.class);
+	private final LiveMinuteSnapshotWriter writer = new LiveMinuteSnapshotWriter(
+			snapshotRepository,
+			participantSnapshotRepository,
+			new ObjectMapper());
+
+	@Test
+	void sameOrOlderFrameDoesNotRewriteSnapshot() {
+		LocalDateTime minute = LocalDateTime.of(2026, 5, 17, 8, 18);
+		LiveGameMinuteSnapshot existing = new LiveGameMinuteSnapshot("game-1", minute);
+		existing.updateSnapshot("match-1", "LCK", "KT", "HLE", minute.plusSeconds(10));
+		when(snapshotRepository.findByGameIdAndMinuteBucketUtc("game-1", minute)).thenReturn(Optional.of(existing));
+
+		writer.write(state("game-1", minute, minute.plusSeconds(10)));
+
+		verify(snapshotRepository, never()).save(any());
+		verify(participantSnapshotRepository, never()).deleteBySnapshot_Id(any());
+		verify(participantSnapshotRepository, never()).saveAllAndFlush(any());
+	}
+
+	private LiveGameState state(String gameId, LocalDateTime minute, LocalDateTime frameTimestampUtc) {
+		return new LiveGameState(
+				gameId,
+				"match-1",
+				"LCK",
+				"KT",
+				"HLE",
+				minute,
+				frameTimestampUtc,
+				List.of(new LiveParticipantState(
+						1,
+						"Blue",
+						"top",
+						"KT PerfecT",
+						"player-1",
+						"Zaahen",
+						11,
+						0,
+						0,
+						0,
+						4307,
+						120,
+						0.0,
+						0.22,
+						List.of(2031, 3078),
+						List.of(),
+						List.of(),
+						"{}",
+						null,
+						null,
+						List.of())),
+				List.of());
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
@@ -1,0 +1,52 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LiveObjectEventRecorderTest {
+
+	private final LiveGameObjectEventRepository objectEventRepository = mock(LiveGameObjectEventRepository.class);
+	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(objectEventRepository);
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void replayingSameWindowDoesNotSaveDuplicateObjectEvents() throws Exception {
+		when(objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(any(), any(), any(), any()))
+				.thenReturn(false);
+		ActiveLiveGame game = new ActiveLiveGame("game-1", "match-1", "LCK", "KT", "HLE",
+				LocalDateTime.now(ZoneOffset.UTC), 0);
+		JsonNode window = objectMapper.readTree("""
+				{
+				  "frames": [
+				    {
+				      "rfc460Timestamp": "2026-05-17T08:18:00.000Z",
+				      "blueTeam": { "towers": 0, "barons": 0, "inhibitors": 0, "dragons": [] },
+				      "redTeam": { "towers": 0, "barons": 0, "inhibitors": 0, "dragons": [] }
+				    },
+				    {
+				      "rfc460Timestamp": "2026-05-17T08:18:10.000Z",
+				      "blueTeam": { "towers": 1, "barons": 0, "inhibitors": 0, "dragons": ["mountain"] },
+				      "redTeam": { "towers": 0, "barons": 0, "inhibitors": 0, "dragons": [] }
+				    }
+				  ]
+				}
+				""");
+
+		recorder.record(game, window);
+		recorder.record(game, window);
+
+		verify(objectEventRepository, times(2)).save(any(LiveGameObjectEvent.class));
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -1,0 +1,49 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.toy.nar.app.lolesports.WorldsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LivePollingSchedulerTest {
+
+	@Test
+	void removesActiveGameAfterConsecutiveLiveFeedFailures() {
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStatsClient liveStatsClient = mock(LiveStatsClient.class);
+		LiveObjectEventRecorder objectEventRecorder = mock(LiveObjectEventRecorder.class);
+		LiveStateStore liveStateStore = new LiveStateStore();
+		LiveFrameProcessor liveFrameProcessor = mock(LiveFrameProcessor.class);
+		LiveGameMetadataService liveGameMetadataService = mock(LiveGameMetadataService.class);
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService,
+				liveStatsClient,
+				objectEventRecorder,
+				liveStateStore,
+				liveFrameProcessor,
+				liveGameMetadataService);
+		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 2);
+		liveStateStore.getActiveGames().put("game-1", new ActiveLiveGame(
+				"game-1",
+				"match-1",
+				"LCK",
+				"KT",
+				"HLE",
+				LocalDateTime.now(ZoneOffset.UTC),
+				1));
+		when(liveStatsClient.getWindow(anyString(), anyString())).thenThrow(new RuntimeException("timeout"));
+
+		scheduler.pollActiveGames();
+
+		assertThat(liveStateStore.getActiveGames()).doesNotContainKey("game-1");
+		verify(objectEventRecorder).evict("game-1");
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveStateQueryServiceTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveStateQueryServiceTest.java
@@ -1,0 +1,113 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteParticipantSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+class LiveStateQueryServiceTest {
+
+	private final LiveStateStore liveStateStore = new LiveStateStore();
+	private final LiveGameMinuteSnapshotRepository snapshotRepository = mock(LiveGameMinuteSnapshotRepository.class);
+	private final LiveGameMinuteParticipantSnapshotRepository participantSnapshotRepository =
+			mock(LiveGameMinuteParticipantSnapshotRepository.class);
+	private final LiveGameObjectEventRepository objectEventRepository = mock(LiveGameObjectEventRepository.class);
+	private final RuneMetadataResolver runeMetadataResolver = mock(RuneMetadataResolver.class);
+	private final ItemMetadataResolver itemMetadataResolver = mock(ItemMetadataResolver.class);
+	private final LiveGameMetadataService liveGameMetadataService = mock(LiveGameMetadataService.class);
+	private final LiveStateQueryService service = new LiveStateQueryService(
+			liveStateStore,
+			snapshotRepository,
+			participantSnapshotRepository,
+			objectEventRepository,
+			new ObjectMapper(),
+			runeMetadataResolver,
+			itemMetadataResolver,
+			liveGameMetadataService);
+
+	@Test
+	void objectTimelineIsBoundedByStateFrameTimestamp() {
+		LocalDateTime frameTimestampUtc = LocalDateTime.of(2026, 5, 16, 12, 0, 10);
+		LiveGameState state = new LiveGameState(
+				"game-1",
+				"match-1",
+				"LCK",
+				"Blue",
+				"Red",
+				frameTimestampUtc.withSecond(0),
+				frameTimestampUtc,
+				List.of(),
+				List.of());
+		liveStateStore.putLatestState(state);
+		when(liveGameMetadataService.enrich(any(ActiveLiveGame.class)))
+				.thenAnswer(invocation -> invocation.getArgument(0));
+
+		LiveGameObjectEvent dragon = new LiveGameObjectEvent(
+				"game-1",
+				"match-1",
+				"LCK",
+				"Blue",
+				"DRAGON",
+				"FIRE",
+				1,
+				1,
+				frameTimestampUtc.minusSeconds(1));
+		when(objectEventRepository
+				.findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+						"game-1",
+						frameTimestampUtc))
+				.thenReturn(List.of(dragon));
+
+		LiveGameState result = service.getLatestState("game-1").orElseThrow();
+
+		assertThat(result.objectTimeline()).hasSize(1);
+		assertThat(result.objectTimeline().get(0).sourceFrameTimestampUtc()).isBeforeOrEqualTo(frameTimestampUtc);
+		verify(objectEventRepository)
+				.findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+						"game-1",
+						frameTimestampUtc);
+		verify(objectEventRepository, never()).findByGameIdOrderBySourceFrameTimestampUtcAscIdAsc("game-1");
+	}
+
+	@Test
+	void fallsBackToLatestDbSnapshotWhenMemoryCacheIsEmpty() {
+		LocalDateTime frameTimestampUtc = LocalDateTime.of(2026, 5, 17, 8, 18, 9);
+		LiveGameMinuteSnapshot snapshot = new LiveGameMinuteSnapshot(
+				"game-1",
+				frameTimestampUtc.withSecond(0));
+		snapshot.updateSnapshot("match-1", "LCK", "KT", "HLE", frameTimestampUtc);
+		when(snapshotRepository.findTopByGameIdOrderByMinuteBucketUtcDesc("game-1"))
+				.thenReturn(Optional.of(snapshot));
+		when(participantSnapshotRepository.findBySnapshot_IdOrderByParticipantIdAsc(null)).thenReturn(List.of());
+		when(liveGameMetadataService.enrich(any(ActiveLiveGame.class)))
+				.thenAnswer(invocation -> invocation.getArgument(0));
+		when(objectEventRepository
+				.findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+						"game-1",
+						frameTimestampUtc))
+				.thenReturn(List.of());
+
+		LiveGameState result = service.getLatestState("game-1").orElseThrow();
+
+		assertThat(result.matchId()).isEqualTo("match-1");
+		assertThat(result.leagueName()).isEqualTo("LCK");
+		assertThat(result.blueTeamName()).isEqualTo("KT");
+		assertThat(result.redTeamName()).isEqualTo("HLE");
+		assertThat(result.frameTimestampUtc()).isEqualTo(frameTimestampUtc);
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveStateStoreTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveStateStoreTest.java
@@ -1,0 +1,38 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiveStateStoreTest {
+
+	@Test
+	void doesNotOverwriteLatestStateWithOlderFrame() {
+		LiveStateStore store = new LiveStateStore();
+		LiveGameState newer = stateAt(LocalDateTime.of(2026, 5, 16, 12, 0, 10));
+		LiveGameState older = stateAt(LocalDateTime.of(2026, 5, 16, 12, 0, 5));
+
+		store.putLatestState(newer);
+		store.putLatestState(older);
+
+		assertThat(store.getLatestState("game-1"))
+				.hasValueSatisfying(state -> assertThat(state.frameTimestampUtc()).isEqualTo(newer.frameTimestampUtc()));
+	}
+
+	private LiveGameState stateAt(LocalDateTime frameTimestampUtc) {
+		return new LiveGameState(
+				"game-1",
+				"match-1",
+				"LCK",
+				"Blue",
+				"Red",
+				frameTimestampUtc.withSecond(0),
+				frameTimestampUtc,
+				List.of(),
+				List.of());
+	}
+}


### PR DESCRIPTION
## Summary
라이브 경기 상세 화면에서 사용할 실시간 상태와 이벤트 데이터를 수집하고, 운영 배포 시 기본 비활성화 상태로 안전하게 배포할 수 있도록 라이브 스트리밍 백엔드 파이프라인을 추가합니다.

## Changes

- LoL Esports live feed window/details 기반 상태 집계, 메모리 캐시, snapshot 저장, object event 저장 흐름을 추가했습니다.
- DB write를 bounded queue와 worker로 분리하고 queue 상태 조회 API를 추가했습니다.
- gameId 기준 matchId, league, 팀명 메타데이터 fallback 캐싱을 추가했습니다.
- 과거 startingTime 기반 simulation/backfill API와 DB fallback 조회를 추가했습니다.
- live 관련 Flyway migration과 snapshot/object/mapping 엔티티 및 repository를 추가했습니다.
- prod live scheduler 기본값을 LOL_LIVE_ENABLED=false로 두어 명시적으로 켜기 전까지 비활성화되도록 했습니다.
- live cache 최신성, replay 멱등성, API 장애 제거, DB fallback 단위 테스트를 추가했습니다.