### PR TITLE
feat: 온보딩 선호 리그와 선수 저장 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -1,15 +1,20 @@
 package com.toy.nar.api.auth;
 
 import com.toy.nar.api.auth.dto.MemberResponse;
+import com.toy.nar.api.auth.dto.OnboardingLeagueOptionResponse;
+import com.toy.nar.api.auth.dto.OnboardingPlayerOptionResponse;
 import com.toy.nar.api.auth.dto.OnboardingRequest;
 import com.toy.nar.api.auth.dto.OnboardingTeamOptionResponse;
 import com.toy.nar.api.auth.dto.TokenResponse;
 import com.toy.nar.app.auth.JwtTokenProvider;
+import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.entity.RefreshToken;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.RefreshTokenRepository;
+import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,8 +32,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,6 +47,8 @@ import static org.springframework.http.HttpStatus.*;
 @Tag(name = "8. 인증 / 로그인", description = "소셜 로그인과 JWT 기반 사용자 인증 API")
 public class AuthController {
 
+    private static final int DEFAULT_ONBOARDING_YEAR = 2026;
+
     private static final List<String> LCK_ONBOARDING_TEAM_CODES = List.of(
             "T1", "HLE", "GEN", "DK", "KT",
             "DNS", "BFX", "NS", "BRO", "KRX"
@@ -48,24 +57,56 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final LeagueRepository leagueRepository;
     private final TeamRepository teamRepository;
+    private final PlayerRepository playerRepository;
 
     @Operation(
-            summary = "온보딩용 LCK 팀 목록 조회",
-            description = "온보딩 화면에서 선택할 최신 시즌 LCK 팀 목록을 조회합니다."
+            summary = "온보딩용 리그 목록 조회",
+            description = "온보딩 화면에서 선택할 시즌별 리그 목록을 조회합니다."
     )
-    @ApiResponse(responseCode = "200", description = "LCK 팀 목록 조회 성공")
-    @GetMapping("/onboarding/teams")
-    public ResponseEntity<List<OnboardingTeamOptionResponse>> getOnboardingTeams() {
-        Map<String, Team> teamsByCode = teamRepository.findAllByCodeIn(LCK_ONBOARDING_TEAM_CODES).stream()
-                .collect(Collectors.toMap(Team::getCode, Function.identity()));
+    @ApiResponse(responseCode = "200", description = "리그 목록 조회 성공")
+    @GetMapping("/onboarding/leagues")
+    public ResponseEntity<List<OnboardingLeagueOptionResponse>> getOnboardingLeagues(
+            @Parameter(description = "연도", example = "2026") @RequestParam(defaultValue = "2026") int year) {
+        List<OnboardingLeagueOptionResponse> leagues = leagueRepository.findDistinctLeagueNamesByYear(year).stream()
+                .map(OnboardingLeagueOptionResponse::new)
+                .toList();
+        return ResponseEntity.ok(leagues);
+    }
 
-        List<OnboardingTeamOptionResponse> teams = LCK_ONBOARDING_TEAM_CODES.stream()
-                .map(teamsByCode::get)
-                .filter(team -> team != null)
+    @Operation(
+            summary = "온보딩용 팀 목록 조회",
+            description = "온보딩 화면에서 선택한 리그/시즌의 팀 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "팀 목록 조회 성공")
+    @GetMapping("/onboarding/teams")
+    public ResponseEntity<List<OnboardingTeamOptionResponse>> getOnboardingTeams(
+            @Parameter(description = "리그명", example = "LCK") @RequestParam(defaultValue = "LCK") String league,
+            @Parameter(description = "연도", example = "2026") @RequestParam(defaultValue = "2026") int year) {
+        String leagueName = normalizeLeagueName(league);
+        List<OnboardingTeamOptionResponse> teams = findSelectableTeams(leagueName, year).stream()
                 .map(OnboardingTeamOptionResponse::from)
                 .toList();
         return ResponseEntity.ok(teams);
+    }
+
+    @Operation(
+            summary = "온보딩용 선수 목록 조회",
+            description = "온보딩 화면에서 선택한 리그/시즌의 선수 목록을 조회합니다. teamId를 전달하면 해당 팀 선수만 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "선수 목록 조회 성공")
+    @GetMapping("/onboarding/players")
+    public ResponseEntity<List<OnboardingPlayerOptionResponse>> getOnboardingPlayers(
+            @Parameter(description = "리그명", example = "LCK") @RequestParam(defaultValue = "LCK") String league,
+            @Parameter(description = "연도", example = "2026") @RequestParam(defaultValue = "2026") int year,
+            @Parameter(description = "팀 ID", example = "1") @RequestParam(required = false) Long teamId) {
+        String leagueName = normalizeLeagueName(league);
+        List<OnboardingPlayerOptionResponse> players = playerRepository.findOnboardingPlayers(leagueName, year, teamId)
+                .stream()
+                .map(OnboardingPlayerOptionResponse::from)
+                .toList();
+        return ResponseEntity.ok(players);
     }
 
     @Operation(
@@ -121,7 +162,7 @@ public class AuthController {
 
     @Operation(
             summary = "온보딩 완료",
-            description = "로그인한 사용자의 선호 팀을 저장하고 온보딩을 완료합니다."
+            description = "로그인한 사용자의 선호 리그, 팀, 선수를 저장하고 온보딩을 완료합니다."
     )
     @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
@@ -136,8 +177,11 @@ public class AuthController {
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
         Team team = teamRepository.findById(request.favoriteTeamId())
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "팀을 찾을 수 없습니다"));
+        String favoriteLeagueName = normalizeLeagueName(request.favoriteLeagueName());
+        validateSelectableTeam(favoriteLeagueName, team.getId());
+        List<Player> favoritePlayers = resolveFavoritePlayers(request.favoritePlayerIds(), favoriteLeagueName, team.getId());
 
-        member.completeOnboarding(team);
+        member.completeOnboarding(favoriteLeagueName, team, favoritePlayers);
         return ResponseEntity.ok(MemberResponse.from(member));
     }
 
@@ -151,9 +195,66 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
     })
     @GetMapping("/me")
+    @Transactional(readOnly = true)
     public ResponseEntity<MemberResponse> me(@AuthenticationPrincipal Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
         return ResponseEntity.ok(MemberResponse.from(member));
+    }
+
+    private List<Team> findSelectableTeams(String leagueName, int year) {
+        List<Team> onboardingTeams = teamRepository.findOnboardingTeams(leagueName, year);
+        if (onboardingTeams.isEmpty() && "LCK".equals(leagueName)) {
+            return findDefaultLckTeams();
+        }
+        return onboardingTeams;
+    }
+
+    private List<Team> findDefaultLckTeams() {
+        Map<String, Team> teamsByCode = teamRepository.findAllByCodeIn(LCK_ONBOARDING_TEAM_CODES).stream()
+                .collect(Collectors.toMap(Team::getCode, Function.identity()));
+
+        return LCK_ONBOARDING_TEAM_CODES.stream()
+                .map(teamsByCode::get)
+                .filter(team -> team != null)
+                .toList();
+    }
+
+    private void validateSelectableTeam(String leagueName, Long teamId) {
+        boolean isSelectableTeam = findSelectableTeams(leagueName, DEFAULT_ONBOARDING_YEAR).stream()
+                .anyMatch(team -> team.getId().equals(teamId));
+        if (!isSelectableTeam) {
+            throw new ResponseStatusException(BAD_REQUEST, "선택한 리그에 속하지 않는 팀입니다");
+        }
+    }
+
+    private List<Player> resolveFavoritePlayers(List<Long> favoritePlayerIds, String leagueName, Long teamId) {
+        if (favoritePlayerIds == null || favoritePlayerIds.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> requestedIds = new HashSet<>(favoritePlayerIds);
+        List<Player> players = playerRepository.findAllById(requestedIds);
+        if (players.size() != requestedIds.size()) {
+            throw new ResponseStatusException(NOT_FOUND, "선수를 찾을 수 없습니다");
+        }
+
+        Set<Long> selectablePlayerIds = playerRepository.findOnboardingPlayers(leagueName, DEFAULT_ONBOARDING_YEAR, teamId).stream()
+                .map(Player::getId)
+                .collect(Collectors.toSet());
+        boolean hasUnavailablePlayer = requestedIds.stream()
+                .anyMatch(playerId -> !selectablePlayerIds.contains(playerId));
+        if (hasUnavailablePlayer) {
+            throw new ResponseStatusException(BAD_REQUEST, "선택한 리그/팀에 속하지 않는 선수가 포함되어 있습니다");
+        }
+
+        return players;
+    }
+
+    private String normalizeLeagueName(String leagueName) {
+        if (leagueName == null || leagueName.isBlank()) {
+            return "LCK";
+        }
+        return leagueName.trim().toUpperCase();
     }
 }

--- a/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
@@ -1,7 +1,10 @@
 package com.toy.nar.api.auth.dto;
 
 import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberFavoritePlayer;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
 
 @Schema(description = "로그인 사용자 정보 응답")
 public record MemberResponse(
@@ -9,8 +12,12 @@ public record MemberResponse(
 		Long id,
 		@Schema(description = "랜덤 생성 또는 사용 중인 닉네임", example = "용맹한바론")
 		String nickname,
+		@Schema(description = "선호 리그명", example = "LCK", nullable = true)
+		String favoriteLeagueName,
 		@Schema(description = "선호 팀 ID", example = "3", nullable = true)
 		Long favoriteTeamId,
+		@Schema(description = "선호 선수 ID 목록", example = "[10, 11]")
+		List<Long> favoritePlayerIds,
 		@Schema(description = "온보딩 완료 여부", example = "false")
 		boolean isOnboarded) {
 
@@ -18,7 +25,12 @@ public record MemberResponse(
         return new MemberResponse(
                 member.getId(),
                 member.getNickname(),
+                member.getFavoriteLeagueName(),
                 member.getFavoriteTeam() != null ? member.getFavoriteTeam().getId() : null,
+                member.getFavoritePlayers().stream()
+                        .map(MemberFavoritePlayer::getPlayer)
+                        .map(player -> player.getId())
+                        .toList(),
                 member.isOnboarded()
         );
     }

--- a/src/main/java/com/toy/nar/api/auth/dto/OnboardingLeagueOptionResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/OnboardingLeagueOptionResponse.java
@@ -1,0 +1,10 @@
+package com.toy.nar.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "온보딩 리그 선택 옵션")
+public record OnboardingLeagueOptionResponse(
+        @Schema(description = "리그명", example = "LCK")
+        String name
+) {
+}

--- a/src/main/java/com/toy/nar/api/auth/dto/OnboardingPlayerOptionResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/OnboardingPlayerOptionResponse.java
@@ -1,0 +1,26 @@
+package com.toy.nar.api.auth.dto;
+
+import com.toy.nar.domain.participant.entity.Player;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "온보딩 선수 선택 옵션")
+public record OnboardingPlayerOptionResponse(
+        @Schema(description = "선수 ID", example = "10")
+        Long id,
+        @Schema(description = "선수명", example = "Faker")
+        String name,
+        @Schema(description = "선수 이미지 URL", nullable = true)
+        String imageUrl,
+        @Schema(description = "포지션", example = "mid", nullable = true)
+        String role
+) {
+
+    public static OnboardingPlayerOptionResponse from(Player player) {
+        return new OnboardingPlayerOptionResponse(
+                player.getId(),
+                player.getName(),
+                player.getImageUrl(),
+                player.getRole()
+        );
+    }
+}

--- a/src/main/java/com/toy/nar/api/auth/dto/OnboardingRequest.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/OnboardingRequest.java
@@ -3,8 +3,14 @@ package com.toy.nar.api.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 @Schema(description = "온보딩 완료 요청")
 public record OnboardingRequest(
+		@Schema(description = "선호 리그명", example = "LCK")
+		String favoriteLeagueName,
 		@Schema(description = "선호 팀 ID", example = "1")
-		@NotNull Long favoriteTeamId) {
+		@NotNull Long favoriteTeamId,
+		@Schema(description = "선호 선수 ID 목록", example = "[10, 11]")
+		List<Long> favoritePlayerIds) {
 }

--- a/src/main/java/com/toy/nar/domain/game/repository/LeagueRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/LeagueRepository.java
@@ -34,6 +34,9 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 	@Query("SELECT DISTINCT l.leagueName FROM League l WHERE l.seasonYear = 2025")
 	List<String> findDistinctLeagueNames();
 
+	@Query("SELECT DISTINCT l.leagueName FROM League l WHERE l.seasonYear = :year ORDER BY l.leagueName")
+	List<String> findDistinctLeagueNamesByYear(@Param("year") int year);
+
 	@Query("SELECT DISTINCT l.seasonSplit FROM League l WHERE l.leagueName = :leagueName AND l.seasonYear = :seasonYear")
 	List<String> findSplitsByLeague(@Param("leagueName") String leagueName, @Param("seasonYear") Integer seasonYear);
 

--- a/src/main/java/com/toy/nar/domain/member/entity/Member.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/Member.java
@@ -1,12 +1,16 @@
 package com.toy.nar.domain.member.entity;
 
 import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.entity.Player;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.time.LocalDateTime;
 
 @Entity
@@ -25,9 +29,15 @@ public class Member {
     @Column
     private String email;
 
+    @Column(name = "favorite_league_name", length = 50)
+    private String favoriteLeagueName;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "favorite_team_id")
     private Team favoriteTeam;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberFavoritePlayer> favoritePlayers = new ArrayList<>();
 
     @Column(name = "onboarded_at")
     private LocalDateTime onboardedAt;
@@ -42,9 +52,25 @@ public class Member {
         this.createdAt = LocalDateTime.now();
     }
 
-    public void completeOnboarding(Team favoriteTeam) {
+    public void completeOnboarding(String favoriteLeagueName, Team favoriteTeam, Collection<Player> favoritePlayers) {
+        this.favoriteLeagueName = favoriteLeagueName;
         this.favoriteTeam = favoriteTeam;
+        replaceFavoritePlayers(favoritePlayers);
         this.onboardedAt = LocalDateTime.now();
+    }
+
+    private void replaceFavoritePlayers(Collection<Player> players) {
+        this.favoritePlayers.clear();
+        if (players == null) {
+            return;
+        }
+        players.stream()
+                .distinct()
+                .map(player -> MemberFavoritePlayer.builder()
+                        .member(this)
+                        .player(player)
+                        .build())
+                .forEach(this.favoritePlayers::add);
     }
 
     public boolean isOnboarded() {

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberFavoritePlayer.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberFavoritePlayer.java
@@ -1,0 +1,48 @@
+package com.toy.nar.domain.member.entity;
+
+import com.toy.nar.domain.participant.entity.Player;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_favorite_player", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "player_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberFavoritePlayer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "player_id", nullable = false)
+    private Player player;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private java.time.LocalDateTime createdAt;
+
+    @Builder
+    public MemberFavoritePlayer(Member member, Player player) {
+        this.member = member;
+        this.player = player;
+        this.createdAt = java.time.LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -20,4 +20,21 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 		"JOIN g.league l " +
 		"WHERE l.leagueName = :leagueName")
 	List<Player> findPlayersByLeagueName(@Param("leagueName") String leagueName);
+
+	@Query("""
+			SELECT DISTINCT p
+			FROM GameParticipant gp
+			JOIN gp.player p
+			JOIN gp.team t
+			JOIN gp.game g
+			JOIN g.league l
+			WHERE l.leagueName = :leagueName
+			  AND l.seasonYear = :year
+			  AND (:teamId IS NULL OR t.id = :teamId)
+			ORDER BY p.name
+			""")
+	List<Player> findOnboardingPlayers(
+			@Param("leagueName") String leagueName,
+			@Param("year") int year,
+			@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -36,6 +36,16 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	@Query("SELECT t FROM Team t WHERE t.code IN :codes")
 	List<Team> findAllByCodeIn(@Param("codes") Collection<String> codes);
 
+	@Query("""
+			SELECT DISTINCT t
+			FROM LeagueTeam lt
+			JOIN lt.team t
+			WHERE lt.league.leagueName = :leagueName
+			  AND lt.league.seasonYear = :year
+			ORDER BY t.name
+			""")
+	List<Team> findOnboardingTeams(@Param("leagueName") String leagueName, @Param("year") int year);
+
 	@Query("SELECT t FROM Team t WHERE LOWER(t.name) = LOWER(:name)")
 	Optional<Team> findByNameIgnoreCase(@Param("name") String name);
 }

--- a/src/main/resources/db/migration/V36__Add_member_favorite_league_and_players.sql
+++ b/src/main/resources/db/migration/V36__Add_member_favorite_league_and_players.sql
@@ -1,0 +1,14 @@
+ALTER TABLE member
+    ADD COLUMN favorite_league_name VARCHAR(50);
+
+CREATE TABLE member_favorite_player (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id   BIGINT   NOT NULL,
+    player_id   BIGINT   NOT NULL,
+    created_at  DATETIME NOT NULL DEFAULT NOW(),
+    UNIQUE KEY uq_member_favorite_player (member_id, player_id),
+    CONSTRAINT fk_member_favorite_player_member
+        FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    CONSTRAINT fk_member_favorite_player_player
+        FOREIGN KEY (player_id) REFERENCES players (player_id)
+);


### PR DESCRIPTION
로그인한 사용자의 온보딩 선호값을 리그, 팀, 선수까지 함께 저장할 수 있도록 확장했습니다.

- 온보딩 리그, 팀, 선수 옵션 조회 API를 추가했습니다.

- 온보딩 완료 요청과 내 정보 응답에 선호 리그명과 선호 선수 ID 목록을 포함했습니다.

- 회원 선호 리그 컬럼과 회원-선수 선호 매핑 테이블을 추가했습니다.

- 선택한 리그/팀에 속한 선수만 선호 선수로 저장되도록 검증을 추가했습니다.