### PR TITLE
fix: 온보딩 팀 목록을 LCK 코드로 제한

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -244,11 +244,7 @@ public class AuthController {
     }
 
     private List<Team> findSelectableTeams(int year) {
-        List<Team> onboardingTeams = teamRepository.findOnboardingTeams("LCK", year);
-        if (onboardingTeams.isEmpty()) {
-            return findDefaultLckTeams();
-        }
-        return onboardingTeams;
+        return findDefaultLckTeams();
     }
 
     private List<Team> findDefaultLckTeams() {


### PR DESCRIPTION
## Summary
운영 DB의 리그-팀 매핑이 전체 팀을 포함할 수 있어 온보딩 팀 목록에 LCK 외 팀이 노출되는 문제를 수정했습니다.

## Changes

- 온보딩 팀 목록 조회가 league_teams 매핑 대신 LCK 10개 팀 코드 화이트리스트만 사용하도록 변경했습니다.

- 팀 목록 응답 순서는 LCK 온보딩 팀 코드 순서를 따르도록 유지했습니다.