### PR TITLE
feat: CSV 수집 process/write 병렬화

### DIFF
--- a/src/main/java/com/toy/nar/app/data/ingestion/JdbcBatchDataIngestionFacade.java
+++ b/src/main/java/com/toy/nar/app/data/ingestion/JdbcBatchDataIngestionFacade.java
@@ -21,11 +21,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import org.jooq.DSLContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -82,6 +89,15 @@ public class JdbcBatchDataIngestionFacade {
 	private final TransactionTemplate transactionTemplate;
 	private final ReentrantLock ingestionLock = new ReentrantLock();
 
+	@Value("${nar.data.ingestion.jdbc.parallel.enabled:false}")
+	private boolean parallelChunkProcessingEnabled;
+
+	@Value("${nar.data.ingestion.jdbc.parallel.threads:4}")
+	private int parallelChunkThreads;
+
+	@Value("${nar.data.ingestion.jdbc.parallel.max-in-flight:8}")
+	private int maxInFlightChunks;
+
 	public DataIngestionResult ingestFromStream(InputStream csvStream, String lastProcessedGameId) throws Exception {
 		if (!ingestionLock.tryLock()) {
 			throw new IllegalStateException("Data ingestion is already running.");
@@ -100,6 +116,9 @@ public class JdbcBatchDataIngestionFacade {
 			log.info("Delta cursor detected ({}), but full-stream scan is used for consistency.", lastProcessedGameId);
 		}
 
+		boolean parallelProcessing = isParallelChunkProcessingEnabled();
+		log.info("JDBC batch ingestion mode: {}", parallelProcessing ? "parallel_process_write" : "sequential");
+
 		long startTime = System.currentTimeMillis();
 		DataIngestionResult.Builder resultBuilder = DataIngestionResult.builder();
 		entityResolver.clearCaches();
@@ -114,14 +133,18 @@ public class JdbcBatchDataIngestionFacade {
 					.build();
 
 			List<GameDataCsvDto> chunk = new ArrayList<>(ROW_CHUNK_SIZE);
-			for (GameDataCsvDto dto : csvToBean) {
-				chunk.add(dto);
-				lastIdInStream = dto.getGameid();
-				resultBuilder.incrementProcessedRows();
-				flushSafeChunkIfNeeded(chunk, resultBuilder);
-			}
-			if (!chunk.isEmpty()) {
-				resultBuilder.merge(processChunkInTransaction(chunk));
+			if (parallelProcessing) {
+				lastIdInStream = ingestWithParallelProcessWrite(csvToBean, chunk, resultBuilder);
+			} else {
+				for (GameDataCsvDto dto : csvToBean) {
+					chunk.add(dto);
+					lastIdInStream = dto.getGameid();
+					resultBuilder.incrementProcessedRows();
+					flushSafeChunkIfNeeded(chunk, resultBuilder);
+				}
+				if (!chunk.isEmpty()) {
+					resultBuilder.merge(processChunkInTransaction(chunk));
+				}
 			}
 		} finally {
 			entityResolver.clearCaches();
@@ -137,6 +160,70 @@ public class JdbcBatchDataIngestionFacade {
 		recordIngestionResult(result, processingTimeMs);
 		log.info("[Completed] JDBC batch stream ingestion completed. {}", result.getSummary());
 		return result;
+	}
+
+	private String ingestWithParallelProcessWrite(
+			CsvToBean<GameDataCsvDto> csvToBean,
+			List<GameDataCsvDto> chunk,
+			DataIngestionResult.Builder resultBuilder) throws Exception {
+		int workerCount = normalizedParallelism();
+		int maxInFlight = normalizedMaxInFlight(workerCount);
+		ExecutorService executor = Executors.newFixedThreadPool(workerCount);
+		CompletionService<ChunkProcessingResult> completionService = new ExecutorCompletionService<>(executor);
+		int inFlight = 0;
+		String lastIdInStream = null;
+
+		try {
+			for (GameDataCsvDto dto : csvToBean) {
+				chunk.add(dto);
+				lastIdInStream = dto.getGameid();
+				resultBuilder.incrementProcessedRows();
+
+				List<GameDataCsvDto> safeChunk = splitSafeChunkIfNeeded(chunk);
+				if (safeChunk != null) {
+					inFlight = submitResolvedChunk(completionService, safeChunk, inFlight);
+				}
+				if (inFlight >= maxInFlight) {
+					resultBuilder.merge(takeCompletedChunk(completionService));
+					inFlight--;
+				}
+			}
+
+			if (!chunk.isEmpty()) {
+				inFlight = submitResolvedChunk(completionService, new ArrayList<>(chunk), inFlight);
+				chunk.clear();
+			}
+
+			while (inFlight > 0) {
+				resultBuilder.merge(takeCompletedChunk(completionService));
+				inFlight--;
+			}
+			return lastIdInStream;
+		} catch (Exception e) {
+			executor.shutdownNow();
+			throw e;
+		} finally {
+			executor.shutdown();
+		}
+	}
+
+	private int submitResolvedChunk(
+			CompletionService<ChunkProcessingResult> completionService,
+			List<GameDataCsvDto> chunk,
+			int inFlight) {
+		// 공유 캐시에 새 팀/선수/리그를 등록하는 단계는 단일 reader 스레드에서 수행한다.
+		// worker는 이미 resolve된 엔티티를 읽고 game 처리와 DB write만 병렬로 실행한다.
+		long resolveStart = System.nanoTime();
+		entityResolver.resolveEntitiesFromChunk(chunk);
+		long resolveDurationNanos = System.nanoTime() - resolveStart;
+		completionService.submit(() -> processResolvedChunkInTransaction(chunk, resolveDurationNanos));
+		return inFlight + 1;
+	}
+
+	private ChunkProcessingResult takeCompletedChunk(CompletionService<ChunkProcessingResult> completionService)
+			throws InterruptedException, ExecutionException {
+		Future<ChunkProcessingResult> completed = completionService.take();
+		return completed.get();
 	}
 
 	private void flushSafeChunkIfNeeded(List<GameDataCsvDto> chunk, DataIngestionResult.Builder resultBuilder) {
@@ -163,17 +250,49 @@ public class JdbcBatchDataIngestionFacade {
 		chunk.addAll(carryOver);
 	}
 
+	private List<GameDataCsvDto> splitSafeChunkIfNeeded(List<GameDataCsvDto> chunk) {
+		if (chunk.size() < ROW_CHUNK_SIZE) {
+			return null;
+		}
+
+		String tailGameId = chunk.get(chunk.size() - 1).getGameid();
+		int splitIndex = chunk.size() - 1;
+		while (splitIndex >= 0 && Objects.equals(chunk.get(splitIndex).getGameid(), tailGameId)) {
+			splitIndex--;
+		}
+		splitIndex++;
+
+		if (splitIndex == 0) {
+			return null;
+		}
+
+		List<GameDataCsvDto> toProcess = new ArrayList<>(chunk.subList(0, splitIndex));
+		List<GameDataCsvDto> carryOver = new ArrayList<>(chunk.subList(splitIndex, chunk.size()));
+		chunk.clear();
+		chunk.addAll(carryOver);
+		return toProcess;
+	}
+
 	private ChunkProcessingResult processChunkInTransaction(List<GameDataCsvDto> chunk) {
 		return transactionTemplate.execute(status -> processChunk(chunk));
 	}
 
-	public ChunkProcessingResult processChunk(List<GameDataCsvDto> chunk) {
-		int invalidGames = 0;
-		int failedGames = 0;
+	private ChunkProcessingResult processResolvedChunkInTransaction(
+			List<GameDataCsvDto> chunk,
+			long resolveDurationNanos) {
+		return transactionTemplate.execute(status -> processResolvedChunk(chunk, resolveDurationNanos));
+	}
 
+	public ChunkProcessingResult processChunk(List<GameDataCsvDto> chunk) {
 		long resolveStart = System.nanoTime();
 		entityResolver.resolveEntitiesFromChunk(chunk);
 		long resolveDurationNanos = System.nanoTime() - resolveStart;
+		return processResolvedChunk(chunk, resolveDurationNanos);
+	}
+
+	private ChunkProcessingResult processResolvedChunk(List<GameDataCsvDto> chunk, long resolveDurationNanos) {
+		int invalidGames = 0;
+		int failedGames = 0;
 
 		long processStart = System.nanoTime();
 		Map<String, List<GameDataCsvDto>> gamesGroupedById = chunk.stream()
@@ -572,6 +691,18 @@ public class JdbcBatchDataIngestionFacade {
 
 	private String placeholders(int size) {
 		return String.join(",", Collections.nCopies(size, "?"));
+	}
+
+	private boolean isParallelChunkProcessingEnabled() {
+		return parallelChunkProcessingEnabled && normalizedParallelism() > 1;
+	}
+
+	private int normalizedParallelism() {
+		return Math.max(1, parallelChunkThreads);
+	}
+
+	private int normalizedMaxInFlight(int workerCount) {
+		return Math.max(workerCount, maxInFlightChunks);
 	}
 
 	private void set(PreparedStatement ps, int index, Object value) throws SQLException {

--- a/src/main/java/com/toy/nar/app/data/source/DriveTestService.java
+++ b/src/main/java/com/toy/nar/app/data/source/DriveTestService.java
@@ -5,6 +5,7 @@ import com.google.api.services.drive.model.File;
 import com.opencsv.CSVReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Profile({ "local", "dev", "prod" })
 @RequiredArgsConstructor
 @Slf4j
 public class DriveTestService {

--- a/src/main/java/com/toy/nar/app/data/source/GoogleDriveDataSyncService.java
+++ b/src/main/java/com/toy/nar/app/data/source/GoogleDriveDataSyncService.java
@@ -4,14 +4,15 @@ import java.io.InputStream;
 import java.time.LocalDateTime;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.google.api.services.drive.Drive;
 import com.toy.nar.app.analysis.service.CombinationService;
+import com.toy.nar.app.data.ingestion.JdbcBatchDataIngestionFacade;
 import com.toy.nar.app.data.ingestion.dto.DataIngestionResult;
 import com.toy.nar.app.data.source.dto.DataSyncResult;
-import com.toy.nar.app.data.ingestion.DataIngestionFacade;
 import com.toy.nar.app.monitor.SchedulerAlertService;
 import com.toy.nar.app.schedule.CacheEvictionService;
 import com.toy.nar.domain.sync.SyncStatusRepository;
@@ -20,17 +21,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Profile({ "local", "dev", "prod" })
 @RequiredArgsConstructor
 @Slf4j
 public class GoogleDriveDataSyncService {
 
 	private final Drive drive;
-	private final DataIngestionFacade dataIngestionFacade;
+	private final JdbcBatchDataIngestionFacade dataIngestionFacade;
 	private final SchedulerAlertService schedulerAlertService;
 	private final CombinationService combinationService;
 	private final CacheEvictionService cacheEvictionService;
 	private final SyncStatusRepository syncStatusRepository;
 
+	@Value("${google.drive.csv-file-id:1hnpbrUpBMS1TZI7IovfpKeZfWJH1Aptm}")
 	private String csvFileId = "1hnpbrUpBMS1TZI7IovfpKeZfWJH1Aptm";
 
 	@Scheduled(cron = "0 30 4,10,16,22 * * ?", zone = "Asia/Seoul")

--- a/src/main/java/com/toy/nar/config/GoogleDriveConfig.java
+++ b/src/main/java/com/toy/nar/config/GoogleDriveConfig.java
@@ -9,6 +9,7 @@ import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -18,6 +19,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collections;
 
 @Configuration
+@Profile({ "local", "dev", "prod" })
 public class GoogleDriveConfig {
 
 	private static final String APPLICATION_NAME = "NAR Game Data Importer";

--- a/src/main/resources/application-benchmark.yml
+++ b/src/main/resources/application-benchmark.yml
@@ -28,6 +28,15 @@ spring:
   elasticsearch:
     uris: ${ELASTICSEARCH_URI:http://127.0.0.1:9200}
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: benchmark-client-id
+            client-secret: benchmark-client-secret
+            scope: email, profile
+
 jwt:
   secret: ${JWT_SECRET:dev-secret-key-must-be-at-least-32-characters-long}
 
@@ -65,5 +74,16 @@ riot:
     enabled: false
 
 lolesports:
+  riot-api:
+    key: ${LOL_ESPORTS_KEY:benchmark-dummy-key}
   live:
     enabled: false
+
+nar:
+  data:
+    ingestion:
+      jdbc:
+        parallel:
+          enabled: ${NAR_DATA_INGESTION_JDBC_PARALLEL_ENABLED:true}
+          threads: ${NAR_DATA_INGESTION_JDBC_PARALLEL_THREADS:4}
+          max-in-flight: ${NAR_DATA_INGESTION_JDBC_PARALLEL_MAX_IN_FLIGHT:8}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,6 +7,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      data-source-properties:
+        rewriteBatchedStatements: true
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
@@ -128,3 +131,12 @@ lolesports:
     queue:
       snapshot-capacity: ${LOL_LIVE_SNAPSHOT_QUEUE_CAPACITY:600}
       object-capacity: ${LOL_LIVE_OBJECT_QUEUE_CAPACITY:1200}
+
+nar:
+  data:
+    ingestion:
+      jdbc:
+        parallel:
+          enabled: ${NAR_DATA_INGESTION_JDBC_PARALLEL_ENABLED:false}
+          threads: ${NAR_DATA_INGESTION_JDBC_PARALLEL_THREADS:4}
+          max-in-flight: ${NAR_DATA_INGESTION_JDBC_PARALLEL_MAX_IN_FLIGHT:8}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,12 @@ app:
         - "UCORzxHO2quCHbE2fTo_snEg" # 롤뻔뻔
         - "UCBjjh72yM1KoMHfFhNBQr8w" # 대유쾌마운틴
         - "UCwvk_uRd0w-n0O1I4QRdM0g" # 롤꺾마
+
+nar:
+  data:
+    ingestion:
+      jdbc:
+        parallel:
+          enabled: ${NAR_DATA_INGESTION_JDBC_PARALLEL_ENABLED:false}
+          threads: ${NAR_DATA_INGESTION_JDBC_PARALLEL_THREADS:4}
+          max-in-flight: ${NAR_DATA_INGESTION_JDBC_PARALLEL_MAX_IN_FLIGHT:8}


### PR DESCRIPTION
## Summary
대용량 CSV 수집에서 단일 reader는 유지하면서 청크별 process/write를 병렬화해 처리량을 개선합니다. 병렬 실행 여부와 스레드 수는 환경별 설정으로 제어할 수 있게 했습니다.

## Changes

- JdbcBatchDataIngestionFacade에 병렬 process/write 실행 경로와 bounded in-flight 처리를 추가

- gameId가 청크 경계에서 잘리지 않도록 안전 분할 로직을 추가

- Google Drive 동기화가 JDBC batch ingestion facade를 사용하도록 연결

- benchmark 프로필에서 Google Drive 인증 없이 로컬 CSV 벤치마크가 가능하도록 프로필과 더미 설정을 분리

- prod/default 설정에 JDBC 병렬 옵션과 MySQL batch rewrite 설정을 추가