### PR TITLE
feat: 모바일 일정 캘린더 API 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/schedule/MobileScheduleController.java
+++ b/src/main/java/com/toy/nar/api/mobile/schedule/MobileScheduleController.java
@@ -1,0 +1,60 @@
+package com.toy.nar.api.mobile.schedule;
+
+import com.toy.nar.app.mobile.schedule.MobileScheduleService;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleCalendarResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleFilterResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+@Tag(name = "Mobile. 경기 일정", description = "모바일 앱 경기일정/경기리스트 전용 API")
+@RestController
+@RequestMapping("/api/mobile/schedules")
+@RequiredArgsConstructor
+public class MobileScheduleController {
+
+	private final MobileScheduleService mobileScheduleService;
+
+	@Operation(summary = "모바일 일정 필터 조회", description = "모바일 경기일정/경기리스트 화면의 리그와 팀 필터 옵션을 조회합니다.")
+	@GetMapping("/filters")
+	public ResponseEntity<MobileScheduleFilterResponse> getFilters(
+			@Parameter(description = "팀 옵션을 조회할 리그", example = "LCK")
+			@RequestParam(defaultValue = "LCK") String league) {
+		return ResponseEntity.ok(mobileScheduleService.getFilters(league));
+	}
+
+	@Operation(summary = "모바일 월별 캘린더 조회", description = "월별 캘린더 마킹용 경기 날짜와 경기 수를 조회합니다.")
+	@GetMapping("/calendar")
+	public ResponseEntity<MobileScheduleCalendarResponse> getCalendar(
+			@Parameter(description = "조회 월", example = "2026-04")
+			@RequestParam("month") @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
+			@Parameter(description = "리그", example = "LCK")
+			@RequestParam(defaultValue = "LCK") String league,
+			@Parameter(description = "팀 ID", example = "1")
+			@RequestParam(required = false) Long teamId) {
+		return ResponseEntity.ok(mobileScheduleService.getCalendar(month, league, teamId));
+	}
+
+	@Operation(summary = "모바일 일별 경기 리스트 조회", description = "선택 날짜의 모바일 경기 리스트 카드 데이터를 조회합니다.")
+	@GetMapping
+	public ResponseEntity<MobileScheduleListResponse> getDailySchedules(
+			@Parameter(description = "조회 일자", example = "2026-04-01")
+			@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+			@Parameter(description = "리그", example = "LCK")
+			@RequestParam(defaultValue = "LCK") String league,
+			@Parameter(description = "팀 ID", example = "1")
+			@RequestParam(required = false) Long teamId) {
+		return ResponseEntity.ok(mobileScheduleService.getDailySchedules(date, league, teamId));
+	}
+}

--- a/src/main/java/com/toy/nar/api/v1/ScheduleController.java
+++ b/src/main/java/com/toy/nar/api/v1/ScheduleController.java
@@ -48,8 +48,12 @@ public class ScheduleController {
 	@GetMapping("/calendar")
 	public ResponseEntity<ScheduleCalendarResponseDto> getMonthlyScheduleCalendar(
 			@Parameter(description = "조회 월 (예: 2026-04)", example = "2026-04")
-			@RequestParam("month") @DateTimeFormat(pattern = "yyyy-MM") YearMonth month) {
-		ScheduleCalendarResponseDto calendar = scheduleService.getMonthlyScheduleCalendar(month);
+			@RequestParam("month") @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
+			@Parameter(description = "리그 필터 (예: LCK)", example = "LCK")
+			@RequestParam(required = false) String league,
+			@Parameter(description = "팀 ID", example = "1")
+			@RequestParam(required = false) Long teamId) {
+		ScheduleCalendarResponseDto calendar = scheduleService.getMonthlyScheduleCalendar(month, league, teamId);
 		return ResponseEntity.ok(calendar);
 	}
 

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -41,6 +41,40 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("SELECT m FROM LeagueMatch m WHERE m.matchDate >= :start AND m.matchDate <= :end ORDER BY m.matchDate DESC")
 	List<LeagueMatch> findByDateRange(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
+	@Query("""
+			SELECT m
+			FROM LeagueMatch m
+			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			  AND m.matchDate >= :start
+			  AND m.matchDate < :end
+			ORDER BY m.matchDate ASC
+			""")
+	List<LeagueMatch> findMobileMatchesInRange(
+			@Param("leagueName") String leagueName,
+			@Param("start") LocalDateTime start,
+			@Param("end") LocalDateTime end);
+
+	@Query("""
+			SELECT m
+			FROM LeagueMatch m
+			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			  AND m.matchDate >= :start
+			  AND m.matchDate < :end
+			  AND (
+					LOWER(m.blueTeamName) = LOWER(:teamName)
+					OR LOWER(m.redTeamName) = LOWER(:teamName)
+					OR (:teamCode IS NOT NULL AND m.blueTeamCode IS NOT NULL AND LOWER(m.blueTeamCode) = LOWER(:teamCode))
+					OR (:teamCode IS NOT NULL AND m.redTeamCode IS NOT NULL AND LOWER(m.redTeamCode) = LOWER(:teamCode))
+			  )
+			ORDER BY m.matchDate ASC
+			""")
+	List<LeagueMatch> findMobileTeamMatchesInRange(
+			@Param("leagueName") String leagueName,
+			@Param("teamName") String teamName,
+			@Param("teamCode") String teamCode,
+			@Param("start") LocalDateTime start,
+			@Param("end") LocalDateTime end);
+
 	@Query(value = """
 			SELECT DATE(m.match_date) AS matchDay,
 			       COUNT(*) AS matchCount

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -1,0 +1,262 @@
+package com.toy.nar.app.mobile.schedule;
+
+import com.toy.nar.app.lolesports.LeagueConstants;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleCalendarResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleFilterResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
+import com.toy.nar.common.error.ErrorCode;
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.common.util.NameNormalizer;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.function.Function;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MobileScheduleService {
+
+	private static final String DEFAULT_LEAGUE = "LCK";
+	private static final int DEFAULT_TEAM_YEAR = 2026;
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final ZoneId UTC = ZoneId.of("UTC");
+	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+	private static final List<String> LCK_TEAM_CODES = List.of(
+			"T1", "HLE", "GEN", "DK", "KT",
+			"DNS", "BFX", "NS", "BRO", "KRX"
+	);
+
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final TeamRepository teamRepository;
+
+	public MobileScheduleFilterResponse getFilters(String league) {
+		String normalizedLeague = normalizeLeague(league);
+		List<MobileScheduleFilterResponse.LeagueOption> leagues = LeagueConstants.ALLOWED_LEAGUES.stream()
+				.sorted()
+				.map(code -> new MobileScheduleFilterResponse.LeagueOption(code, code))
+				.toList();
+		List<MobileScheduleFilterResponse.TeamOption> teams = findFilterTeams(normalizedLeague).stream()
+				.map(this::toTeamOption)
+				.toList();
+
+		return new MobileScheduleFilterResponse(DEFAULT_LEAGUE, leagues, teams);
+	}
+
+	public MobileScheduleCalendarResponse getCalendar(YearMonth month, String league, Long teamId) {
+		if (month == null) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+		String normalizedLeague = normalizeLeague(league);
+		TeamFilter teamFilter = resolveTeamFilter(teamId);
+		LocalDateTime startUtc = toUtc(month.atDay(1).atStartOfDay());
+		LocalDateTime endUtc = toUtc(month.plusMonths(1).atDay(1).atStartOfDay());
+		List<LeagueMatch> matches = findMatches(normalizedLeague, teamFilter, startUtc, endUtc);
+
+		Map<String, MobileScheduleCalendarResponse.DateSummary> summaries = new LinkedHashMap<>();
+		for (LeagueMatch match : matches) {
+			String date = toKstDate(match).toString();
+			MobileScheduleCalendarResponse.DateSummary existing = summaries.get(date);
+			if (existing == null) {
+				summaries.put(date, new MobileScheduleCalendarResponse.DateSummary(
+						date,
+						1,
+						new ArrayList<>(List.of(toCalendarMatch(match)))));
+				continue;
+			}
+			List<MobileScheduleCalendarResponse.CalendarMatch> dayMatches = new ArrayList<>(existing.matches());
+			dayMatches.add(toCalendarMatch(match));
+			summaries.put(date, new MobileScheduleCalendarResponse.DateSummary(
+					date,
+					existing.matchCount() + 1,
+					dayMatches));
+		}
+
+		return new MobileScheduleCalendarResponse(
+				month.toString(),
+				normalizedLeague,
+				teamId,
+				new ArrayList<>(summaries.values()));
+	}
+
+	public MobileScheduleListResponse getDailySchedules(LocalDate date, String league, Long teamId) {
+		if (date == null) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+		String normalizedLeague = normalizeLeague(league);
+		TeamFilter teamFilter = resolveTeamFilter(teamId);
+		LocalDateTime startUtc = toUtc(date.atStartOfDay());
+		LocalDateTime endUtc = toUtc(date.plusDays(1).atStartOfDay());
+		List<MobileScheduleListResponse.MobileMatchSummary> matches = findMatches(
+				normalizedLeague,
+				teamFilter,
+				startUtc,
+				endUtc).stream()
+				.map(this::toMatchSummary)
+				.toList();
+
+		return new MobileScheduleListResponse(date.toString(), normalizedLeague, teamId, matches);
+	}
+
+	private List<LeagueMatch> findMatches(
+			String league,
+			TeamFilter teamFilter,
+			LocalDateTime startUtc,
+			LocalDateTime endUtc) {
+		if (teamFilter == null) {
+			return leagueMatchRepository.findMobileMatchesInRange(league, startUtc, endUtc);
+		}
+		return leagueMatchRepository.findMobileTeamMatchesInRange(
+				league,
+				teamFilter.name(),
+				teamFilter.code(),
+				startUtc,
+				endUtc);
+	}
+
+	private MobileScheduleFilterResponse.TeamOption toTeamOption(Team team) {
+		return new MobileScheduleFilterResponse.TeamOption(
+				team.getId(),
+				team.getName(),
+				team.getCode(),
+				team.getImageUrl());
+	}
+
+	private List<Team> findFilterTeams(String league) {
+		if (DEFAULT_LEAGUE.equals(league)) {
+			Map<String, Team> teamsByCode = teamRepository.findAllByCodeIn(LCK_TEAM_CODES).stream()
+					.collect(Collectors.toMap(Team::getCode, Function.identity(), (left, right) -> left));
+			return LCK_TEAM_CODES.stream()
+					.map(teamsByCode::get)
+					.filter(team -> team != null)
+					.toList();
+		}
+
+		return teamRepository.findOnboardingTeams(league, DEFAULT_TEAM_YEAR).stream()
+				.sorted(Comparator.comparing(Team::getName))
+				.toList();
+	}
+
+	private MobileScheduleListResponse.MobileMatchSummary toMatchSummary(LeagueMatch match) {
+		return new MobileScheduleListResponse.MobileMatchSummary(
+				match.getId(),
+				toScheduledTime(match),
+				match.getState(),
+				match.getMatchTitle(),
+				normalizeLeague(match.getLeagueName()),
+				toTeamResult(
+						match.getBlueTeamName(),
+						match.getBlueTeamCode(),
+						match.getBlueTeamImageUrl(),
+						match.getBlueScore()),
+				toTeamResult(
+						match.getRedTeamName(),
+						match.getRedTeamCode(),
+						match.getRedTeamImageUrl(),
+						match.getRedScore()),
+				liveStreamUrl(match));
+	}
+
+	private MobileScheduleCalendarResponse.CalendarMatch toCalendarMatch(LeagueMatch match) {
+		String blueTeamCode = match.getBlueTeamCode();
+		String redTeamCode = match.getRedTeamCode();
+		String blueTeamName = NameNormalizer.normalizeTeamName(match.getBlueTeamName());
+		String redTeamName = NameNormalizer.normalizeTeamName(match.getRedTeamName());
+		return new MobileScheduleCalendarResponse.CalendarMatch(
+				match.getId(),
+				blueTeamCode,
+				redTeamCode,
+				blueTeamName,
+				redTeamName,
+				displayTeam(blueTeamCode, blueTeamName) + " vs " + displayTeam(redTeamCode, redTeamName));
+	}
+
+	private String displayTeam(String teamCode, String teamName) {
+		if (teamCode != null && !teamCode.isBlank()) {
+			return teamCode;
+		}
+		return teamName;
+	}
+
+	private MobileScheduleListResponse.MobileTeamResult toTeamResult(
+			String teamName,
+			String teamCode,
+			String teamImageUrl,
+			Integer score) {
+		return new MobileScheduleListResponse.MobileTeamResult(
+				NameNormalizer.normalizeTeamName(teamName),
+				teamCode,
+				teamImageUrl,
+				score != null ? score : 0);
+	}
+
+	private String liveStreamUrl(LeagueMatch match) {
+		if ("inProgress".equalsIgnoreCase(match.getState())) {
+			return LeagueConstants.getLiveStreamUrl(match.getLeagueName());
+		}
+		return null;
+	}
+
+	private String toScheduledTime(LeagueMatch match) {
+		if (match.getMatchDate() == null) {
+			return "";
+		}
+		return match.getMatchDate()
+				.atZone(UTC)
+				.withZoneSameInstant(KST)
+				.toLocalTime()
+				.format(TIME_FORMATTER);
+	}
+
+	private LocalDate toKstDate(LeagueMatch match) {
+		return match.getMatchDate()
+				.atZone(UTC)
+				.withZoneSameInstant(KST)
+				.toLocalDate();
+	}
+
+	private LocalDateTime toUtc(LocalDateTime kstDateTime) {
+		return kstDateTime.atZone(KST)
+				.withZoneSameInstant(UTC)
+				.toLocalDateTime();
+	}
+
+	private TeamFilter resolveTeamFilter(Long teamId) {
+		if (teamId == null) {
+			return null;
+		}
+		Team team = teamRepository.findById(teamId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+		return new TeamFilter(team.getName(), team.getCode());
+	}
+
+	private String normalizeLeague(String league) {
+		String normalized = league == null || league.isBlank()
+				? DEFAULT_LEAGUE
+				: league.trim().toUpperCase(Locale.ROOT);
+		if (!LeagueConstants.ALLOWED_LEAGUES.contains(normalized)) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+		return normalized;
+	}
+
+	private record TeamFilter(String name, String code) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleCalendarResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleCalendarResponse.java
@@ -1,0 +1,25 @@
+package com.toy.nar.app.mobile.schedule.dto;
+
+import java.util.List;
+
+public record MobileScheduleCalendarResponse(
+		String month,
+		String league,
+		Long teamId,
+		List<DateSummary> dates) {
+
+	public record DateSummary(
+			String date,
+			long matchCount,
+			List<CalendarMatch> matches) {
+	}
+
+	public record CalendarMatch(
+			String matchId,
+			String blueTeamCode,
+			String redTeamCode,
+			String blueTeamName,
+			String redTeamName,
+			String displayText) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleFilterResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleFilterResponse.java
@@ -1,0 +1,21 @@
+package com.toy.nar.app.mobile.schedule.dto;
+
+import java.util.List;
+
+public record MobileScheduleFilterResponse(
+		String defaultLeague,
+		List<LeagueOption> leagues,
+		List<TeamOption> teams) {
+
+	public record LeagueOption(
+			String code,
+			String name) {
+	}
+
+	public record TeamOption(
+			Long teamId,
+			String teamName,
+			String teamCode,
+			String teamImageUrl) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
@@ -1,0 +1,28 @@
+package com.toy.nar.app.mobile.schedule.dto;
+
+import java.util.List;
+
+public record MobileScheduleListResponse(
+		String date,
+		String league,
+		Long teamId,
+		List<MobileMatchSummary> matches) {
+
+	public record MobileMatchSummary(
+			String matchId,
+			String scheduledTime,
+			String matchStatus,
+			String matchTitle,
+			String leagueName,
+			MobileTeamResult blueTeam,
+			MobileTeamResult redTeam,
+			String liveStreamUrl) {
+	}
+
+	public record MobileTeamResult(
+			String teamName,
+			String teamCode,
+			String teamImageUrl,
+			int score) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/schedule/ScheduleService.java
+++ b/src/main/java/com/toy/nar/app/schedule/ScheduleService.java
@@ -13,6 +13,8 @@ import com.toy.nar.domain.game.entity.Game;
 import com.toy.nar.domain.game.entity.GameParticipant;
 import com.toy.nar.domain.game.repository.GameParticipantRepository;
 import com.toy.nar.domain.game.repository.GameRepository;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +44,7 @@ public class ScheduleService {
 	private final LeagueMatchRepository leagueMatchRepository;
 	private final LeagueMatchGameRepository leagueMatchGameRepository;
 	private final MatchDetailFinder matchDetailFinder;
+	private final TeamRepository teamRepository;
 
 	/**
 	 * 일정 조회 공개 메서드.
@@ -59,35 +62,123 @@ public class ScheduleService {
 	}
 
 	public ScheduleCalendarResponseDto getMonthlyScheduleCalendar(YearMonth month) {
+		return getMonthlyScheduleCalendar(month, null, null);
+	}
+
+	public ScheduleCalendarResponseDto getMonthlyScheduleCalendar(YearMonth month, String league, Long teamId) {
 		if (month == null) {
 			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
 		}
 
+		String leagueFilter = normalizeLeagueFilter(league);
+		Team teamFilter = resolveTeamFilter(teamId);
 		LocalDateTime start = month.atDay(1).atStartOfDay();
 		LocalDateTime end = month.plusMonths(1).atDay(1).atStartOfDay();
 
-		List<LeagueMatchRepository.MonthlyMatchLeagueRow> rows = leagueMatchRepository
-				.findMonthlyMatchCountsWithLeagues(start, end,
-						new ArrayList<>(com.toy.nar.app.lolesports.LeagueConstants.ALLOWED_LEAGUES));
+		List<com.toy.nar.app.lolesports.repository.LeagueMatch> matches = leagueMatchRepository
+				.findByDateRange(start, end.minusNanos(1)).stream()
+				.filter(match -> match.getLeagueName() != null)
+				.filter(match -> isAllowedLeague(match.getLeagueName()))
+				.filter(match -> leagueFilter == null || leagueFilter.equalsIgnoreCase(match.getLeagueName()))
+				.filter(match -> teamFilter == null || matchesTeam(match, teamFilter))
+				.sorted(Comparator.comparing(com.toy.nar.app.lolesports.repository.LeagueMatch::getMatchDate,
+						Comparator.nullsLast(Comparator.naturalOrder())))
+				.toList();
 
-		// 날짜별로 그룹핑: matchCount 합산 + leagues 수집
 		Map<String, ScheduleCalendarResponseDto.ScheduleDateSummaryDto> dateMap = new LinkedHashMap<>();
-		for (var row : rows) {
-			String dateKey = row.getMatchDay().toString();
+		for (var match : matches) {
+			if (match.getMatchDate() == null) {
+				continue;
+			}
+			String dateKey = match.getMatchDate().toLocalDate().toString();
 			ScheduleCalendarResponseDto.ScheduleDateSummaryDto existing = dateMap.get(dateKey);
 			if (existing == null) {
 				List<String> leagues = new ArrayList<>();
-				leagues.add(row.getLeagueName());
+				leagues.add(match.getLeagueName().toUpperCase());
 				dateMap.put(dateKey, new ScheduleCalendarResponseDto.ScheduleDateSummaryDto(
-						dateKey, row.getMatchCount(), leagues));
+						dateKey,
+						1,
+						leagues,
+						new ArrayList<>(List.of(toCalendarMatchDto(match)))));
 			} else {
-				existing.leagues().add(row.getLeagueName());
+				List<String> leagues = new ArrayList<>(existing.leagues());
+				String leagueName = match.getLeagueName().toUpperCase();
+				if (!leagues.contains(leagueName)) {
+					leagues.add(leagueName);
+				}
+				List<ScheduleCalendarResponseDto.CalendarMatchDto> dayMatches = new ArrayList<>(existing.matches());
+				dayMatches.add(toCalendarMatchDto(match));
 				dateMap.put(dateKey, new ScheduleCalendarResponseDto.ScheduleDateSummaryDto(
-						dateKey, existing.matchCount() + row.getMatchCount(), existing.leagues()));
+						dateKey,
+						existing.matchCount() + 1,
+						leagues,
+						dayMatches));
 			}
 		}
 
 		return new ScheduleCalendarResponseDto(month.toString(), new ArrayList<>(dateMap.values()));
+	}
+
+	private String normalizeLeagueFilter(String league) {
+		if (league == null || league.isBlank()) {
+			return null;
+		}
+		String normalized = league.trim().toUpperCase(Locale.ROOT);
+		if (!com.toy.nar.app.lolesports.LeagueConstants.ALLOWED_LEAGUES.contains(normalized)) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+		return normalized;
+	}
+
+	private Team resolveTeamFilter(Long teamId) {
+		if (teamId == null) {
+			return null;
+		}
+		return teamRepository.findById(teamId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+	}
+
+	private boolean isAllowedLeague(String leagueName) {
+		return com.toy.nar.app.lolesports.LeagueConstants.ALLOWED_LEAGUES
+				.contains(leagueName.toUpperCase(Locale.ROOT));
+	}
+
+	private boolean matchesTeam(
+			com.toy.nar.app.lolesports.repository.LeagueMatch match,
+			Team team) {
+		return equalsIgnoreCase(match.getBlueTeamName(), team.getName())
+				|| equalsIgnoreCase(match.getRedTeamName(), team.getName())
+				|| equalsIgnoreCase(match.getBlueTeamCode(), team.getCode())
+				|| equalsIgnoreCase(match.getRedTeamCode(), team.getCode());
+	}
+
+	private boolean equalsIgnoreCase(String left, String right) {
+		if (left == null || right == null) {
+			return false;
+		}
+		return left.equalsIgnoreCase(right);
+	}
+
+	private ScheduleCalendarResponseDto.CalendarMatchDto toCalendarMatchDto(
+			com.toy.nar.app.lolesports.repository.LeagueMatch match) {
+		String blueTeamCode = match.getBlueTeamCode();
+		String redTeamCode = match.getRedTeamCode();
+		String blueTeamName = com.toy.nar.common.util.NameNormalizer.normalizeTeamName(match.getBlueTeamName());
+		String redTeamName = com.toy.nar.common.util.NameNormalizer.normalizeTeamName(match.getRedTeamName());
+		return new ScheduleCalendarResponseDto.CalendarMatchDto(
+				match.getId(),
+				blueTeamCode,
+				redTeamCode,
+				blueTeamName,
+				redTeamName,
+				displayTeam(blueTeamCode, blueTeamName) + " vs " + displayTeam(redTeamCode, redTeamName));
+	}
+
+	private String displayTeam(String teamCode, String teamName) {
+		if (teamCode != null && !teamCode.isBlank()) {
+			return teamCode;
+		}
+		return teamName;
 	}
 
 	/**

--- a/src/main/java/com/toy/nar/app/schedule/dto/ScheduleCalendarResponseDto.java
+++ b/src/main/java/com/toy/nar/app/schedule/dto/ScheduleCalendarResponseDto.java
@@ -21,6 +21,30 @@ public record ScheduleCalendarResponseDto(
 			long matchCount,
 			
 			@Schema(description = "해당 날짜에 경기가 있는 리그 이름 목록", example = "[\"LCK\", \"LPL\"]")
-			List<String> leagues) {
+			List<String> leagues,
+
+			@Schema(description = "캘린더 칸 표시용 매치업 목록")
+			List<CalendarMatchDto> matches) {
+	}
+
+	@Schema(description = "캘린더 칸 표시용 매치업")
+	public record CalendarMatchDto(
+			@Schema(description = "매치 ID", example = "115654899804988513")
+			String matchId,
+
+			@Schema(description = "블루/좌측 팀 코드", example = "HLE")
+			String blueTeamCode,
+
+			@Schema(description = "레드/우측 팀 코드", example = "BRO")
+			String redTeamCode,
+
+			@Schema(description = "블루/좌측 팀명", example = "Hanwha Life Esports")
+			String blueTeamName,
+
+			@Schema(description = "레드/우측 팀명", example = "Hanjin Brion")
+			String redTeamName,
+
+			@Schema(description = "캘린더 표시 문자열", example = "HLE vs BRO")
+			String displayText) {
 	}
 }

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -1,0 +1,114 @@
+package com.toy.nar.api.mobile.schedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.mobile.schedule.MobileScheduleService;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleCalendarResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleFilterResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MobileScheduleControllerTest {
+
+	private MobileScheduleService mobileScheduleService;
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		mobileScheduleService = mock(MobileScheduleService.class);
+		mockMvc = MockMvcBuilders
+				.standaloneSetup(new MobileScheduleController(mobileScheduleService))
+				.setMessageConverters(new MappingJackson2HttpMessageConverter(new ObjectMapper()))
+				.build();
+	}
+
+	@Test
+	void getFiltersReturnsMobileFilterShape() throws Exception {
+		when(mobileScheduleService.getFilters("LCK")).thenReturn(new MobileScheduleFilterResponse(
+				"LCK",
+				List.of(new MobileScheduleFilterResponse.LeagueOption("LCK", "LCK")),
+				List.of(new MobileScheduleFilterResponse.TeamOption(1L, "T1", "T1", "https://example.com/t1.png"))));
+
+		mockMvc.perform(get("/api/mobile/schedules/filters"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.defaultLeague").value("LCK"))
+				.andExpect(jsonPath("$.leagues[0].code").value("LCK"))
+				.andExpect(jsonPath("$.teams[0].teamId").value(1L))
+				.andExpect(jsonPath("$.teams[0].teamName").value("T1"));
+	}
+
+	@Test
+	void getCalendarReturnsMobileCalendarShape() throws Exception {
+		when(mobileScheduleService.getCalendar(YearMonth.of(2026, 4), "LCK", 1L))
+				.thenReturn(new MobileScheduleCalendarResponse(
+						"2026-04",
+						"LCK",
+						1L,
+						List.of(new MobileScheduleCalendarResponse.DateSummary(
+								"2026-04-01",
+								2,
+								List.of(new MobileScheduleCalendarResponse.CalendarMatch(
+										"match-1",
+										"HLE",
+										"BRO",
+										"HLE",
+										"Hanjin Brion",
+										"HLE vs BRO"))))));
+
+		mockMvc.perform(get("/api/mobile/schedules/calendar")
+						.param("month", "2026-04")
+						.param("league", "LCK")
+						.param("teamId", "1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.month").value("2026-04"))
+				.andExpect(jsonPath("$.league").value("LCK"))
+				.andExpect(jsonPath("$.teamId").value(1L))
+				.andExpect(jsonPath("$.dates[0].date").value("2026-04-01"))
+				.andExpect(jsonPath("$.dates[0].matchCount").value(2))
+				.andExpect(jsonPath("$.dates[0].matches[0].matchId").value("match-1"))
+				.andExpect(jsonPath("$.dates[0].matches[0].blueTeamCode").value("HLE"))
+				.andExpect(jsonPath("$.dates[0].matches[0].redTeamCode").value("BRO"))
+				.andExpect(jsonPath("$.dates[0].matches[0].displayText").value("HLE vs BRO"));
+	}
+
+	@Test
+	void getDailySchedulesReturnsMobileListShape() throws Exception {
+		when(mobileScheduleService.getDailySchedules(LocalDate.of(2026, 4, 1), "LCK", null))
+				.thenReturn(new MobileScheduleListResponse(
+						"2026-04-01",
+						"LCK",
+						null,
+						List.of(new MobileScheduleListResponse.MobileMatchSummary(
+								"match-1",
+								"18:00",
+								"unstarted",
+								"T1 vs GEN",
+								"LCK",
+								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 0),
+								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 0),
+								null))));
+
+		mockMvc.perform(get("/api/mobile/schedules")
+						.param("date", "2026-04-01")
+						.param("league", "LCK"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.date").value("2026-04-01"))
+				.andExpect(jsonPath("$.league").value("LCK"))
+				.andExpect(jsonPath("$.matches[0].matchId").value("match-1"))
+				.andExpect(jsonPath("$.matches[0].blueTeam.teamCode").value("T1"))
+				.andExpect(jsonPath("$.matches[0].redTeam.teamName").value("Gen.G"));
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -1,0 +1,197 @@
+package com.toy.nar.app.mobile.schedule;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleCalendarResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleFilterResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
+import com.toy.nar.common.error.ErrorCode;
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class MobileScheduleServiceTest {
+
+	private LeagueMatchRepository leagueMatchRepository;
+	private TeamRepository teamRepository;
+	private MobileScheduleService service;
+
+	@BeforeEach
+	void setUp() {
+		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		teamRepository = mock(TeamRepository.class);
+		service = new MobileScheduleService(leagueMatchRepository, teamRepository);
+	}
+
+	@Test
+	void getFiltersReturnsDefaultLeagueAndTeamsForSelectedLeague() {
+		Team t1 = team(1L, "T1", "T1", "https://example.com/t1.png");
+		when(teamRepository.findAllByCodeIn(List.of(
+				"T1", "HLE", "GEN", "DK", "KT",
+				"DNS", "BFX", "NS", "BRO", "KRX"
+		))).thenReturn(List.of(t1));
+
+		MobileScheduleFilterResponse response = service.getFilters(null);
+
+		assertThat(response.defaultLeague()).isEqualTo("LCK");
+		assertThat(response.leagues()).extracting(MobileScheduleFilterResponse.LeagueOption::code)
+				.contains("LCK", "LPL");
+		assertThat(response.teams()).singleElement()
+				.extracting(MobileScheduleFilterResponse.TeamOption::teamId,
+						MobileScheduleFilterResponse.TeamOption::teamName,
+						MobileScheduleFilterResponse.TeamOption::teamCode)
+				.containsExactly(1L, "T1", "T1");
+	}
+
+	@Test
+	void getCalendarGroupsLeagueMatchesByKstDate() {
+		LocalDateTime startUtc = LocalDateTime.of(2026, 3, 31, 15, 0);
+		LocalDateTime endUtc = LocalDateTime.of(2026, 4, 30, 15, 0);
+		when(leagueMatchRepository.findMobileMatchesInRange("LCK", startUtc, endUtc))
+				.thenReturn(List.of(
+						match("match-1", "LCK", LocalDateTime.of(2026, 3, 31, 15, 30), "T1", "GEN", "unstarted"),
+						match("match-2", "LCK", LocalDateTime.of(2026, 4, 1, 10, 0), "DK", "HLE", "unstarted")));
+
+		MobileScheduleCalendarResponse response = service.getCalendar(YearMonth.of(2026, 4), "lck", null);
+
+		assertThat(response.month()).isEqualTo("2026-04");
+		assertThat(response.league()).isEqualTo("LCK");
+		assertThat(response.dates()).hasSize(1);
+		assertThat(response.dates()).extracting(MobileScheduleCalendarResponse.DateSummary::date)
+				.containsExactly("2026-04-01");
+		assertThat(response.dates()).extracting(MobileScheduleCalendarResponse.DateSummary::matchCount)
+				.containsExactly(2L);
+		assertThat(response.dates().getFirst().matches()).hasSize(2);
+		assertThat(response.dates().getFirst().matches()).extracting(MobileScheduleCalendarResponse.CalendarMatch::matchId)
+				.containsExactly("match-1", "match-2");
+		assertThat(response.dates().getFirst().matches().getFirst().blueTeamCode()).isEqualTo("T1");
+		assertThat(response.dates().getFirst().matches().getFirst().redTeamCode()).isEqualTo("GEN");
+		assertThat(response.dates().getFirst().matches().getFirst().displayText()).isEqualTo("T1 vs GEN");
+	}
+
+	@Test
+	void getDailySchedulesUsesTeamFilterWhenTeamIdExists() {
+		Team t1 = team(1L, "T1", "T1", "https://example.com/t1.png");
+		when(teamRepository.findById(1L)).thenReturn(Optional.of(t1));
+		when(leagueMatchRepository.findMobileTeamMatchesInRange(
+				"LCK",
+				"T1",
+				"T1",
+				LocalDateTime.of(2026, 3, 31, 15, 0),
+				LocalDateTime.of(2026, 4, 1, 15, 0)))
+				.thenReturn(List.of(match(
+						"match-1",
+						"LCK",
+						LocalDateTime.of(2026, 4, 1, 9, 0),
+						"T1",
+						"Gen.G",
+						"inProgress")));
+
+		MobileScheduleListResponse response = service.getDailySchedules(
+				LocalDate.of(2026, 4, 1),
+				"LCK",
+				1L);
+
+		assertThat(response.date()).isEqualTo("2026-04-01");
+		assertThat(response.teamId()).isEqualTo(1L);
+		assertThat(response.matches()).singleElement()
+				.satisfies(match -> {
+					assertThat(match.matchId()).isEqualTo("match-1");
+					assertThat(match.scheduledTime()).isEqualTo("18:00");
+					assertThat(match.matchStatus()).isEqualTo("inProgress");
+					assertThat(match.blueTeam().teamName()).isEqualTo("T1");
+					assertThat(match.redTeam().teamName()).isEqualTo("Gen.g");
+					assertThat(match.liveStreamUrl()).isEqualTo("https://play.sooplive.co.kr/aflol");
+				});
+	}
+
+	@Test
+	void getDailySchedulesQueriesOneKstDayAsUtcRange() {
+		when(leagueMatchRepository.findMobileMatchesInRange(
+				"LCK",
+				LocalDateTime.of(2026, 3, 31, 15, 0),
+				LocalDateTime.of(2026, 4, 1, 15, 0)))
+				.thenReturn(List.of());
+
+		service.getDailySchedules(LocalDate.of(2026, 4, 1), null, null);
+
+		ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+		ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+		verify(leagueMatchRepository).findMobileMatchesInRange(
+				org.mockito.ArgumentMatchers.eq("LCK"),
+				startCaptor.capture(),
+				endCaptor.capture());
+		assertThat(startCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 3, 31, 15, 0));
+		assertThat(endCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 4, 1, 15, 0));
+	}
+
+	@Test
+	void invalidLeagueThrowsInvalidInput() {
+		assertThatThrownBy(() -> service.getDailySchedules(LocalDate.of(2026, 4, 1), "abc", null))
+				.isInstanceOf(CustomException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+		verifyNoInteractions(leagueMatchRepository);
+	}
+
+	@Test
+	void unknownTeamThrowsDataNotFound() {
+		when(teamRepository.findById(999L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.getCalendar(YearMonth.of(2026, 4), "LCK", 999L))
+				.isInstanceOf(CustomException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.DATA_NOT_FOUND);
+	}
+
+	private LeagueMatch match(
+			String id,
+			String league,
+			LocalDateTime matchDate,
+			String blueTeam,
+			String redTeam,
+			String state) {
+		return LeagueMatch.builder()
+				.id(id)
+				.leagueName(league)
+				.matchTitle(blueTeam + " vs " + redTeam)
+				.matchDate(matchDate)
+				.state(state)
+				.blueTeamName(blueTeam)
+				.blueTeamCode(blueTeam)
+				.blueTeamImageUrl("https://example.com/" + blueTeam + ".png")
+				.blueScore(1)
+				.redTeamName(redTeam)
+				.redTeamCode(redTeam)
+				.redTeamImageUrl("https://example.com/" + redTeam + ".png")
+				.redScore(0)
+				.build();
+	}
+
+	private Team team(Long id, String name, String code, String imageUrl) {
+		Team team = Team.builder()
+				.name(name)
+				.code(code)
+				.imageUrl(imageUrl)
+				.build();
+		ReflectionTestUtils.setField(team, "id", id);
+		return team;
+	}
+}

--- a/src/test/java/com/toy/nar/app/schedule/ScheduleServiceCalendarTest.java
+++ b/src/test/java/com/toy/nar/app/schedule/ScheduleServiceCalendarTest.java
@@ -1,0 +1,128 @@
+package com.toy.nar.app.schedule;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.schedule.dto.ScheduleCalendarResponseDto;
+import com.toy.nar.common.error.ErrorCode;
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ScheduleServiceCalendarTest {
+
+	private LeagueMatchRepository leagueMatchRepository;
+	private TeamRepository teamRepository;
+	private ScheduleService scheduleService;
+
+	@BeforeEach
+	void setUp() {
+		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		teamRepository = mock(TeamRepository.class);
+		scheduleService = new ScheduleService(
+				null,
+				null,
+				null,
+				null,
+				null,
+				leagueMatchRepository,
+				null,
+				null,
+				teamRepository);
+	}
+
+	@Test
+	void monthlyCalendarReturnsDisplayMatchesForExistingApi() {
+		when(leagueMatchRepository.findByDateRange(
+				LocalDateTime.of(2026, 4, 1, 0, 0),
+				LocalDateTime.of(2026, 4, 30, 23, 59, 59, 999999999)))
+				.thenReturn(List.of(
+						match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 17, 0), "BRO", "DNS"),
+						match("match-2", "LCK", LocalDateTime.of(2026, 4, 1, 19, 0), "HLE", "T1"),
+						match("match-3", "LPL", LocalDateTime.of(2026, 4, 2, 17, 0), "BLG", "JDG")));
+
+		ScheduleCalendarResponseDto response = scheduleService.getMonthlyScheduleCalendar(YearMonth.of(2026, 4));
+
+		assertThat(response.month()).isEqualTo("2026-04");
+		assertThat(response.dates()).hasSize(2);
+		assertThat(response.dates().getFirst().date()).isEqualTo("2026-04-01");
+		assertThat(response.dates().getFirst().matchCount()).isEqualTo(2);
+		assertThat(response.dates().getFirst().leagues()).containsExactly("LCK");
+		assertThat(response.dates().getFirst().matches())
+				.extracting(ScheduleCalendarResponseDto.CalendarMatchDto::displayText)
+				.containsExactly("BRO vs DNS", "HLE vs T1");
+	}
+
+	@Test
+	void monthlyCalendarAppliesLeagueAndTeamFilters() {
+		Team t1 = team(1L, "T1", "T1");
+		when(teamRepository.findById(1L)).thenReturn(Optional.of(t1));
+		when(leagueMatchRepository.findByDateRange(
+				LocalDateTime.of(2026, 4, 1, 0, 0),
+				LocalDateTime.of(2026, 4, 30, 23, 59, 59, 999999999)))
+				.thenReturn(List.of(
+						match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 17, 0), "BRO", "DNS"),
+						match("match-2", "LCK", LocalDateTime.of(2026, 4, 1, 19, 0), "HLE", "T1"),
+						match("match-3", "LPL", LocalDateTime.of(2026, 4, 2, 17, 0), "T1", "JDG")));
+
+		ScheduleCalendarResponseDto response = scheduleService.getMonthlyScheduleCalendar(
+				YearMonth.of(2026, 4),
+				"LCK",
+				1L);
+
+		assertThat(response.dates()).singleElement()
+				.satisfies(date -> {
+					assertThat(date.date()).isEqualTo("2026-04-01");
+					assertThat(date.matchCount()).isEqualTo(1);
+					assertThat(date.matches()).singleElement()
+							.extracting(ScheduleCalendarResponseDto.CalendarMatchDto::displayText)
+							.isEqualTo("HLE vs T1");
+				});
+	}
+
+	@Test
+	void invalidLeagueThrowsInvalidInput() {
+		assertThatThrownBy(() -> scheduleService.getMonthlyScheduleCalendar(YearMonth.of(2026, 4), "abc", null))
+				.isInstanceOf(CustomException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	private LeagueMatch match(
+			String id,
+			String league,
+			LocalDateTime matchDate,
+			String blueTeam,
+			String redTeam) {
+		return LeagueMatch.builder()
+				.id(id)
+				.leagueName(league)
+				.matchDate(matchDate)
+				.blueTeamName(blueTeam)
+				.blueTeamCode(blueTeam)
+				.redTeamName(redTeam)
+				.redTeamCode(redTeam)
+				.build();
+	}
+
+	private Team team(Long id, String name, String code) {
+		Team team = Team.builder()
+				.name(name)
+				.code(code)
+				.build();
+		ReflectionTestUtils.setField(team, "id", id);
+		return team;
+	}
+}

--- a/src/test/java/com/toy/nar/app/schedule/ScheduleServicePerformanceBaselineTest.java
+++ b/src/test/java/com/toy/nar/app/schedule/ScheduleServicePerformanceBaselineTest.java
@@ -68,7 +68,8 @@ class ScheduleServicePerformanceBaselineTest {
                 gameParticipantRepository,
                 leagueMatchRepository,
                 leagueMatchGameRepository,
-                matchDetailFinder);
+                matchDetailFinder,
+                null);
         sessionFactory = entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
         sessionFactory.getStatistics().setStatisticsEnabled(true);
     }


### PR DESCRIPTION
## Summary
모바일 앱 캘린더와 경기 리스트 화면에서 월별 매치업 표시, 리그 필터, 팀 필터를 한 번에 사용할 수 있도록 일정 API 경계를 추가하고 기존 캘린더 응답도 확장합니다.

## Changes

- /api/mobile/schedules 하위에 필터, 월별 캘린더, 일별 경기 리스트 API를 추가했습니다.

- 기존 /api/schedule/calendar에 리그 및 팀 필터를 추가하고 날짜별 표시용 매치업 목록을 포함하도록 확장했습니다.

- LeagueMatch 기반 모바일 조회 쿼리와 캘린더 응답 DTO를 추가했습니다.

- 모바일 일정 서비스/컨트롤러 테스트와 기존 캘린더 서비스 테스트를 추가했습니다.