### PR TITLE
[codex] 온보딩 선호 리그와 LCK 선택 기준 분리

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -39,6 +39,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -58,27 +59,27 @@ public class AuthController {
             new OnboardingLeagueOptionResponse(
                     "LCK",
                     "대한민국",
-                    "http://static.lolesports.com/leagues/lck-color-on-black.png"),
+                    "https://static.lolesports.com/leagues/lck-color-on-black.png"),
             new OnboardingLeagueOptionResponse(
                     "LPL",
                     "중국",
-                    "http://static.lolesports.com/leagues/1592516115322_LPL-01-FullonDark.png"),
+                    "https://static.lolesports.com/leagues/1592516115322_LPL-01-FullonDark.png"),
             new OnboardingLeagueOptionResponse(
                     "LEC",
                     "유럽/중동/아프리카",
-                    "http://static.lolesports.com/leagues/1592516184297_LEC-01-FullonDark.png"),
+                    "https://static.lolesports.com/leagues/1592516184297_LEC-01-FullonDark.png"),
             new OnboardingLeagueOptionResponse(
                     "LCS",
                     "북아메리카",
-                    "http://static.lolesports.com/leagues/1706356907418_LCSNew-01-FullonDark.png"),
+                    "https://static.lolesports.com/leagues/1706356907418_LCSNew-01-FullonDark.png"),
             new OnboardingLeagueOptionResponse(
                     "LCP",
                     "아시아 태평양",
-                    "http://static.lolesports.com/leagues/1733468139601_lcp-color-golden.png"),
+                    "https://static.lolesports.com/leagues/1733468139601_lcp-color-golden.png"),
             new OnboardingLeagueOptionResponse(
                     "CBLOL",
                     "남아메리카",
-                    "http://static.lolesports.com/leagues/cblol-logo-symbol-offwhite.png")
+                    "https://static.lolesports.com/leagues/cblol-logo-symbol-offwhite.png")
     );
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -137,14 +138,18 @@ public class AuthController {
 
     @Operation(
             summary = "온보딩용 선수 목록 조회",
-            description = "온보딩 화면에서 선택한 리그/시즌의 선수 목록을 조회합니다. teamId를 전달하면 해당 팀 선수만 조회합니다."
+            description = "온보딩 화면의 2026 LCK 선수 목록을 조회합니다. teamId를 전달하면 해당 팀 선수만 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "선수 목록 조회 성공")
     @GetMapping("/onboarding/players")
     public ResponseEntity<List<OnboardingPlayerOptionResponse>> getOnboardingPlayers(
             @Parameter(description = "연도", example = "2026") @RequestParam(defaultValue = "2026") int year,
             @Parameter(description = "팀 ID", example = "1") @RequestParam(required = false) Long teamId) {
-        List<OnboardingPlayerOptionResponse> players = playerRepository.findOnboardingPlayers("LCK", year, teamId)
+        if (teamId != null) {
+            validateSelectableTeam(teamId);
+        }
+        List<OnboardingPlayerOptionResponse> players = playerRepository
+                .findOnboardingPlayers("LCK", DEFAULT_ONBOARDING_YEAR, teamId)
                 .stream()
                 .map(OnboardingPlayerOptionResponse::from)
                 .toList();
@@ -222,12 +227,15 @@ public class AuthController {
                                                       @Valid @RequestBody OnboardingRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
+        String favoriteLeague = normalizeOnboardingLeague(request.favoriteLeagueName());
         Team team = teamRepository.findById(request.favoriteTeamId())
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "팀을 찾을 수 없습니다"));
         validateSelectableTeam(team.getId());
-        List<Player> favoritePlayers = resolveFavoritePlayers(request.favoritePlayerIds(), team.getId());
+        List<Player> favoritePlayers = resolveFavoritePlayers(
+                request.favoritePlayerIds(),
+                team.getId());
 
-        member.completeOnboarding("LCK", team, favoritePlayers);
+        member.completeOnboarding(favoriteLeague, team, favoritePlayers);
         mobileTeamNotificationService.ensureDefaultSubscription(member, team);
         return ResponseEntity.ok(MemberResponse.from(member));
     }
@@ -250,12 +258,12 @@ public class AuthController {
     }
 
     private List<Team> findSelectableTeams(int year) {
-        return findDefaultLckTeams();
-    }
-
-    private List<Team> findDefaultLckTeams() {
         Map<String, Team> teamsByCode = teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES).stream()
-                .collect(Collectors.toMap(Team::getCode, Function.identity()));
+                .filter(team -> team.getCode() != null)
+                .collect(Collectors.toMap(
+                        Team::getCode,
+                        Function.identity(),
+                        (first, ignored) -> first));
 
         return LckTeamCatalog.TEAM_CODES.stream()
                 .map(teamsByCode::get)
@@ -271,7 +279,9 @@ public class AuthController {
         }
     }
 
-    private List<Player> resolveFavoritePlayers(List<Long> favoritePlayerIds, Long teamId) {
+    private List<Player> resolveFavoritePlayers(
+            List<Long> favoritePlayerIds,
+            Long teamId) {
         if (favoritePlayerIds == null || favoritePlayerIds.isEmpty()) {
             return List.of();
         }
@@ -282,15 +292,30 @@ public class AuthController {
             throw new ResponseStatusException(NOT_FOUND, "선수를 찾을 수 없습니다");
         }
 
-        Set<Long> selectablePlayerIds = playerRepository.findOnboardingPlayers("LCK", DEFAULT_ONBOARDING_YEAR, teamId).stream()
+        Set<Long> selectablePlayerIds = playerRepository
+                .findOnboardingPlayers("LCK", DEFAULT_ONBOARDING_YEAR, teamId)
+                .stream()
                 .map(Player::getId)
                 .collect(Collectors.toSet());
         boolean hasUnavailablePlayer = requestedIds.stream()
                 .anyMatch(playerId -> !selectablePlayerIds.contains(playerId));
         if (hasUnavailablePlayer) {
-            throw new ResponseStatusException(BAD_REQUEST, "선택한 리그/팀에 속하지 않는 선수가 포함되어 있습니다");
+            throw new ResponseStatusException(BAD_REQUEST, "선택한 LCK 팀에 속하지 않는 선수가 포함되어 있습니다");
         }
 
         return players;
+    }
+
+    private String normalizeOnboardingLeague(String league) {
+        if (league == null || league.isBlank()) {
+            throw new ResponseStatusException(BAD_REQUEST, "리그를 선택해주세요");
+        }
+        String normalized = league.trim().toUpperCase(Locale.ROOT);
+        boolean supported = ONBOARDING_LEAGUES.stream()
+                .anyMatch(option -> option.name().equals(normalized));
+        if (!supported) {
+            throw new ResponseStatusException(BAD_REQUEST, "선택할 수 없는 리그입니다");
+        }
+        return normalized;
     }
 }

--- a/src/main/java/com/toy/nar/api/auth/dto/OnboardingRequest.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/OnboardingRequest.java
@@ -1,6 +1,7 @@
 package com.toy.nar.api.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.List;
 @Schema(description = "온보딩 완료 요청")
 public record OnboardingRequest(
 		@Schema(description = "선호 리그명", example = "LCK")
+		@NotBlank
 		String favoriteLeagueName,
 		@Schema(description = "선호 팀 ID", example = "1")
 		@NotNull Long favoriteTeamId,

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -9,6 +9,8 @@ import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.RefreshTokenRepository;
+import com.toy.nar.domain.participant.LckTeamCatalog;
+import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,7 +55,7 @@ class AuthControllerOnboardingNotificationTest {
 		ReflectionTestUtils.setField(team, "id", 1L);
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
 		when(teamRepository.findById(1L)).thenReturn(Optional.of(team));
-		when(teamRepository.findAllByCodeIn(anyCollection())).thenReturn(List.of(team));
+		when(teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
 
 		var response = controller.onboarding(7L, new OnboardingRequest("LCK", 1L, List.of()));
 
@@ -61,7 +64,153 @@ class AuthControllerOnboardingNotificationTest {
 		verify(notificationService).ensureDefaultSubscription(member, team);
 	}
 
-	private static <T> java.util.Collection<T> anyCollection() {
-		return org.mockito.ArgumentMatchers.anyCollection();
+	@Test
+	void onboardingStoresSelectedLeagueIndependentlyFromLckTeamAndPlayers() {
+		TestContext context = context();
+		Member member = member(7L);
+		Team team = team(1L, "T1", "T1");
+		when(context.memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(context.teamRepository.findById(1L)).thenReturn(Optional.of(team));
+		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
+
+		var response = context.controller.onboarding(
+				7L,
+				new OnboardingRequest("lpl", 1L, List.of()));
+
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().favoriteLeagueName()).isEqualTo("LPL");
+		assertThat(response.getBody().favoriteTeamId()).isEqualTo(1L);
+		verify(context.notificationService).ensureDefaultSubscription(member, team);
+	}
+
+	@Test
+	void onboardingRejectsNonLckTeamRegardlessOfPreferredLeague() {
+		TestContext context = context();
+		Member member = member(7L);
+		Team lplTeam = team(2L, "Bilibili Gaming", "BLG");
+		when(context.memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(context.teamRepository.findById(2L)).thenReturn(Optional.of(lplTeam));
+		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of());
+
+		assertThatThrownBy(() -> context.controller.onboarding(
+				7L,
+				new OnboardingRequest("LEC", 2L, List.of())))
+				.isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+				.hasMessageContaining("LCK에 속하지 않는 팀");
+	}
+
+	@Test
+	void onboardingAllowsMoreThanThreePlayers() {
+		TestContext context = context();
+		Member member = member(7L);
+		Team team = team(1L, "T1", "T1");
+		List<Player> players = List.of(
+				player(10L, "Player1"),
+				player(11L, "Player2"),
+				player(12L, "Player3"),
+				player(13L, "Player4"));
+		when(context.memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(context.teamRepository.findById(1L)).thenReturn(Optional.of(team));
+		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
+		when(context.playerRepository.findAllById(java.util.Set.of(10L, 11L, 12L, 13L)))
+				.thenReturn(players);
+		when(context.playerRepository.findOnboardingPlayers("LCK", 2026, 1L))
+				.thenReturn(players);
+
+		var response = context.controller.onboarding(
+				7L,
+				new OnboardingRequest("LCK", 1L, List.of(10L, 11L, 12L, 13L)));
+
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().favoritePlayerIds())
+				.containsExactlyInAnyOrder(10L, 11L, 12L, 13L);
+	}
+
+	@Test
+	void onboardingRejectsPlayerOutsideSelectedLckTeam() {
+		TestContext context = context();
+		Member member = member(7L);
+		Team team = team(1L, "T1", "T1");
+		Player player = player(10L, "Faker");
+		when(context.memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(context.teamRepository.findById(1L)).thenReturn(Optional.of(team));
+		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
+		when(context.playerRepository.findAllById(java.util.Set.of(10L))).thenReturn(List.of(player));
+		when(context.playerRepository.findOnboardingPlayers("LCK", 2026, 1L)).thenReturn(List.of());
+
+		assertThatThrownBy(() -> context.controller.onboarding(
+				7L,
+				new OnboardingRequest("LPL", 1L, List.of(10L))))
+				.isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+				.hasMessageContaining("선택한 LCK 팀에 속하지 않는 선수");
+	}
+
+	@Test
+	void onboardingTeamsAndPlayersAlwaysUseLck() {
+		TestContext context = context();
+		Team t1 = team(1L, "T1", "T1");
+		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(t1));
+		when(context.playerRepository.findOnboardingPlayers("LCK", 2026, 1L)).thenReturn(List.of());
+
+		var teams = context.controller.getOnboardingTeams(2026);
+		context.controller.getOnboardingPlayers(2026, 1L);
+
+		assertThat(teams.getBody()).isNotNull();
+		assertThat(teams.getBody()).extracting("code").containsExactly("T1");
+		verify(context.playerRepository).findOnboardingPlayers("LCK", 2026, 1L);
+	}
+
+	private TestContext context() {
+		JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+		KakaoUserClient kakaoUserClient = mock(KakaoUserClient.class);
+		SocialLoginService socialLoginService = mock(SocialLoginService.class);
+		MemberRepository memberRepository = mock(MemberRepository.class);
+		RefreshTokenRepository refreshTokenRepository = mock(RefreshTokenRepository.class);
+		TeamRepository teamRepository = mock(TeamRepository.class);
+		PlayerRepository playerRepository = mock(PlayerRepository.class);
+		MobileDeviceService mobileDeviceService = mock(MobileDeviceService.class);
+		MobileTeamNotificationService notificationService = mock(MobileTeamNotificationService.class);
+		AuthController controller = new AuthController(
+				jwtTokenProvider,
+				kakaoUserClient,
+				socialLoginService,
+				memberRepository,
+				refreshTokenRepository,
+				teamRepository,
+				playerRepository,
+				mobileDeviceService,
+				notificationService);
+		return new TestContext(
+				controller,
+				memberRepository,
+				teamRepository,
+				playerRepository,
+				notificationService);
+	}
+
+	private Member member(Long id) {
+		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		ReflectionTestUtils.setField(member, "id", id);
+		return member;
+	}
+
+	private Team team(Long id, String name, String code) {
+		Team team = Team.builder().name(name).code(code).imageUrl(code + ".png").build();
+		ReflectionTestUtils.setField(team, "id", id);
+		return team;
+	}
+
+	private Player player(Long id, String name) {
+		Player player = Player.builder().name(name).imageUrl(name + ".png").build();
+		ReflectionTestUtils.setField(player, "id", id);
+		return player;
+	}
+
+	private record TestContext(
+			AuthController controller,
+			MemberRepository memberRepository,
+			TeamRepository teamRepository,
+			PlayerRepository playerRepository,
+			MobileTeamNotificationService notificationService) {
 	}
 }


### PR DESCRIPTION
## 변경 내용

- 선호 리그를 취향 정보로 독립 검증하고 저장합니다.
- 팀 선택은 2026 LCK 팀 1개로 제한합니다.
- 선수 선택은 선택한 LCK 팀 소속으로 검증하며 인원 제한을 두지 않습니다.
- 온보딩 리그 이미지 URL을 HTTPS로 변경합니다.

## 영향

온보딩에서 리그 선택과 팀/선수 선택 기준이 분리되어 기획 의도대로 동작합니다.

## 검증

- AuthControllerOnboardingNotificationTest
- SocialLoginServiceTest
- MobileTeamNotificationServiceTest