### PR TITLE
deploy: 모바일 경기 리스트 페이지네이션·세트 식별자·내 평가 목록·이메일 API

### DIFF
--- a/docs/mobile-api-spec-2026-06-11.md
+++ b/docs/mobile-api-spec-2026-06-11.md
@@ -1,0 +1,172 @@
+# 모바일 API 변경 명세 (2026-06-11)
+
+모바일 팀 백엔드 요청사항 대응 결과. 요청 항목 1·2·5·6번 구현, 3번은 기존 API 안내, 4번은 미구현(별도 작업 필요).
+
+> 식별자 용어 정리
+>
+> | 필드 | 타입 | 용도 |
+> |------|------|------|
+> | `matchId` | String | 매치(BO3/BO5 단위) 식별자. 일정/리스트 API 공통 |
+> | `gameId` | String | 세트(게임) 단위 esports 식별자. **라이브·선수 평점 API에서 사용** |
+> | `recordGameId` | Long | 세트의 내부 DB 식별자. **기록(record) API에서 사용.** 기록 미적재 시 `null` |
+
+---
+
+## 1. 경기 리스트 커서 페이지네이션 (신규)
+
+무한 스크롤용. 기존처럼 날짜별로 반복 호출할 필요 없이 한 번에 페이지 단위로 조회한다.
+
+```
+GET /api/mobile/matches
+```
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `league` | String | `LCK` | 리그 필터 |
+| `teamId` | Long | - | 팀 필터 (filters API의 teamId) |
+| `cursor` | String | - | 이전 응답의 `nextCursor`. 첫 페이지는 생략 |
+| `size` | int | 20 | 페이지 크기 (1~50) |
+
+- 정렬: 최신 경기 → 과거 방향 (`matchDate DESC`)
+- 커서는 불투명(opaque) 토큰. 그대로 돌려보내기만 하면 되고, 동시각 경기·실시간 경기 추가에도 중복/누락 없음
+- `hasNext: false`(= `nextCursor: null`)면 마지막 페이지
+
+응답 예시:
+
+```json
+{
+  "league": "LCK",
+  "teamId": null,
+  "matches": [
+    {
+      "matchId": "113990000000000001",
+      "date": "2026-04-01",
+      "scheduledTime": "18:00",
+      "matchStatus": "completed",
+      "matchTitle": "T1 vs GEN",
+      "leagueName": "LCK",
+      "blueTeam": { "teamName": "T1", "teamCode": "T1", "teamImageUrl": "...", "score": 2 },
+      "redTeam": { "teamName": "Gen.g", "teamCode": "GEN", "teamImageUrl": "...", "score": 1 },
+      "liveStreamUrl": null,
+      "games": [
+        { "gameOrder": 1, "gameId": "113990000000000011", "recordGameId": 1024 },
+        { "gameOrder": 2, "gameId": "113990000000000012", "recordGameId": 1025 },
+        { "gameOrder": 3, "gameId": "113990000000000013", "recordGameId": null }
+      ]
+    }
+  ],
+  "nextCursor": "MjAyNi0wNC0wMVQwOTowMDowMHwxMTM5OTA...",
+  "hasNext": true
+}
+```
+
+## 2. 게임(세트) 식별자 노출
+
+### 2-1. 경기 카드에 `date` / `games[]` 필드 추가
+
+신규 리스트 API(위)와 **기존 일별 조회** `GET /api/mobile/schedules?date=` 양쪽 모두 경기 카드(`matches[]`)에 다음 필드가 추가됐다. 기존 필드는 그대로이므로 하위 호환.
+
+- `date`: 경기 일자 (KST, `yyyy-MM-dd`)
+- `games[]`: 세트 목록 `{ gameOrder, gameId, recordGameId }`. 세트 미생성 매치는 빈 배열
+
+### 2-2. 매치 → 세트 목록 단독 조회 (신규)
+
+```
+GET /api/mobile/matches/{matchId}/games
+```
+
+```json
+{
+  "matchId": "113990000000000001",
+  "games": [
+    { "gameOrder": 1, "gameId": "113990000000000011", "recordGameId": 1024 }
+  ]
+}
+```
+
+- 매치 없음 → 404
+
+## 3. 경기 상세 탭 데이터 (기존 API 안내)
+
+| 탭 | API | 식별자 |
+|----|-----|--------|
+| 챔피언 밴픽 / 선수 스탯 | `GET /api/games/{recordGameId}/record` | `recordGameId` (Long) |
+| 라이브 이벤트 타임라인 | `GET /api/live/games/{gameId}` (최신 상태 + `objectTimeline`), `GET /api/live/games/{gameId}/minutes` (최근 60분 스냅샷) | `gameId` (String) |
+| 선수 평점 | `GET /api/mobile/live/games/{gameId}/ratings` 외 | `gameId` (String) |
+
+record 응답에는 팀별 밴 목록, 선수 10명 스탯(KDA/CS/골드/데미지/타이밍별), 세트 네비게이션, 피어리스 드래프트가 포함된다.
+
+## 5. 내 리뷰/평점 전체 목록 (신규)
+
+```
+GET /api/mobile/me/ratings?page=0&size=20
+```
+
+- **Bearer 인증 필수** (미로그인 401)
+- 작성 최신순, page/size 페이지네이션 (size 최대 100)
+
+```json
+{
+  "ratings": [
+    {
+      "ratingId": 11,
+      "gameId": "113990000000000011",
+      "participantId": 1,
+      "playerId": 10,
+      "playerName": "Faker",
+      "playerImageUrl": "...",
+      "teamSide": "Red",
+      "role": "mid",
+      "championName": "Ahri",
+      "rating": 5,
+      "comment": "역시 페이커",
+      "createdAt": "2026-06-06T13:00:00",
+      "updatedAt": "2026-06-06T13:00:00",
+      "match": {
+        "matchId": "113990000000000001",
+        "gameOrder": 2,
+        "leagueName": "LCK",
+        "matchTitle": "DNS vs T1",
+        "blueTeamCode": "DNS",
+        "redTeamCode": "T1",
+        "matchDate": "2026-06-06T18:00:00"
+      }
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1
+}
+```
+
+- `match`는 세트-매치 매핑이 없으면 `null` (방어 처리 필요)
+- `match.matchDate`는 KST
+
+## 6. /auth/me 이메일 필드
+
+`GET /api/auth/me` 응답(`MemberResponse`)에 `email` 추가.
+
+```json
+{
+  "id": 12,
+  "nickname": "용맹한바론",
+  "email": "user@example.com",
+  "favoriteLeagueName": "LCK",
+  "favoriteTeamId": 3,
+  "favoritePlayerIds": [10, 11],
+  "isOnboarded": true
+}
+```
+
+- **소셜 로그인 시 이메일 제공에 동의하지 않은 회원은 `null`** — UI에서 null 처리 필요
+
+---
+
+## 남은 작업 (이번 배포 미포함)
+
+| 항목 | 상태 | 비고 |
+|------|------|------|
+| 4. 구글·네이버 모바일 로그인 (`POST /auth/mobile/google`, `/naver`) | **미구현** | 카카오(`POST /api/auth/mobile/kakao`)만 운영 중. 카카오 패턴 따라 신규 구현 필요 |
+| 경기 리스트 시즌(스플릿) 필터 | 미지원 | `LeagueMatch`에 시즌 컬럼이 없음. 당장은 날짜 범위로 대체, 필요 시 컬럼 추가 검토 |
+| record API의 String gameId 직접 지원 | 검토 | 현재는 `games[].recordGameId`로 변환값을 내려주는 방식으로 해소 |

--- a/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
@@ -12,6 +12,8 @@ public record MemberResponse(
 		Long id,
 		@Schema(description = "랜덤 생성 또는 사용 중인 닉네임", example = "용맹한바론")
 		String nickname,
+		@Schema(description = "소셜 로그인 이메일. 동의하지 않은 경우 null", example = "user@example.com", nullable = true)
+		String email,
 		@Schema(description = "선호 리그명", example = "LCK", nullable = true)
 		String favoriteLeagueName,
 		@Schema(description = "선호 팀 ID", example = "3", nullable = true)
@@ -25,6 +27,7 @@ public record MemberResponse(
         return new MemberResponse(
                 member.getId(),
                 member.getNickname(),
+                member.getEmail(),
                 member.getFavoriteLeagueName(),
                 member.getFavoriteTeam() != null ? member.getFavoriteTeam().getId() : null,
                 member.getFavoritePlayers().stream()

--- a/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
+++ b/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
@@ -1,0 +1,53 @@
+package com.toy.nar.api.mobile.match;
+
+import com.toy.nar.app.mobile.schedule.MobileScheduleService;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchGamesResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mobile. 경기 리스트", description = "모바일 경기 리스트 무한 스크롤 및 세트(게임) 조회 전용 API")
+@RestController
+@RequestMapping("/api/mobile/matches")
+@RequiredArgsConstructor
+public class MobileMatchController {
+
+	private final MobileScheduleService mobileScheduleService;
+
+	@Operation(
+			summary = "모바일 경기 리스트 커서 페이지 조회",
+			description = "최신 경기부터 과거 방향으로 커서 기반 페이지네이션 조회합니다. "
+					+ "첫 페이지는 cursor 없이 호출하고, 이후 응답의 nextCursor를 cursor로 전달하면 이어서 조회됩니다. "
+					+ "각 경기에는 세트(games) 식별자 목록이 포함됩니다.")
+	@GetMapping
+	public ResponseEntity<MobileMatchPageResponse> getMatches(
+			@Parameter(description = "리그", example = "LCK")
+			@RequestParam(defaultValue = "LCK") String league,
+			@Parameter(description = "팀 ID", example = "1")
+			@RequestParam(required = false) Long teamId,
+			@Parameter(description = "이전 응답의 nextCursor. 첫 페이지는 생략")
+			@RequestParam(required = false) String cursor,
+			@Parameter(description = "페이지 크기(1~50)", example = "20")
+			@RequestParam(defaultValue = "20") Integer size) {
+		return ResponseEntity.ok(mobileScheduleService.getMatchPage(league, teamId, cursor, size));
+	}
+
+	@Operation(
+			summary = "매치 세트(게임) 목록 조회",
+			description = "matchId로 해당 매치의 세트 목록을 조회합니다. "
+					+ "gameId는 라이브/선수 평점 API용, recordGameId는 기록(record) API용 식별자입니다.")
+	@GetMapping("/{matchId}/games")
+	public ResponseEntity<MobileMatchGamesResponse> getMatchGames(
+			@Parameter(description = "매치 ID", example = "113990000000000001")
+			@PathVariable String matchId) {
+		return ResponseEntity.ok(mobileScheduleService.getMatchGames(matchId));
+	}
+}

--- a/src/main/java/com/toy/nar/api/mobile/rating/MobileMyRatingController.java
+++ b/src/main/java/com/toy/nar/api/mobile/rating/MobileMyRatingController.java
@@ -1,0 +1,33 @@
+package com.toy.nar.api.mobile.rating;
+
+import com.toy.nar.app.mobile.rating.MobileLivePlayerRatingService;
+import com.toy.nar.app.mobile.rating.dto.MyRatingListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mobile. 내 평가", description = "모바일 마이페이지 내 선수 평가 모아보기 API")
+@RestController
+@RequestMapping("/api/mobile/me/ratings")
+@RequiredArgsConstructor
+public class MobileMyRatingController {
+
+	private final MobileLivePlayerRatingService ratingService;
+
+	@Operation(summary = "내 선수 평가 전체 목록 조회", description = "로그인한 회원이 작성한 모든 선수 평가를 최신순으로 조회합니다.")
+	@SecurityRequirement(name = "bearerAuth")
+	@GetMapping
+	public ResponseEntity<MyRatingListResponse> getMyRatings(
+			@AuthenticationPrincipal Long memberId,
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "20") int size) {
+		return ResponseEntity.ok(ratingService.getMyRatings(memberId, page, size));
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchGameRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchGameRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,8 @@ public interface LeagueMatchGameRepository extends JpaRepository<LeagueMatchGame
 		String getMatchId();
 
 		Integer getGameOrder();
+
+		String getExternalGameId();
 
 		Long getInternalGameId();
 	}
@@ -46,6 +49,7 @@ public interface LeagueMatchGameRepository extends JpaRepository<LeagueMatchGame
 	@Query(value = """
 			SELECT lmg.match_id AS matchId,
 			       lmg.game_order AS gameOrder,
+			       lmg.game_id AS externalGameId,
 			       gei.game_id AS internalGameId
 			FROM league_match_game lmg
 			LEFT JOIN game_external_identity gei
@@ -59,6 +63,7 @@ public interface LeagueMatchGameRepository extends JpaRepository<LeagueMatchGame
 	@Query(value = """
 			SELECT lmg.match_id AS matchId,
 			       lmg.game_order AS gameOrder,
+			       lmg.game_id AS externalGameId,
 			       gei.game_id AS internalGameId
 			FROM league_match_game lmg
 			LEFT JOIN game_external_identity gei
@@ -68,4 +73,12 @@ public interface LeagueMatchGameRepository extends JpaRepository<LeagueMatchGame
 			ORDER BY lmg.match_id ASC, lmg.game_order ASC
 			""", nativeQuery = true)
 	List<MappedGameRow> findMappedGameRowsByMatchIds(@Param("matchIds") List<String> matchIds, @Param("source") String source);
+
+	@Query("""
+			SELECT g
+			FROM LeagueMatchGame g
+			JOIN FETCH g.leagueMatch
+			WHERE g.gameId IN :gameIds
+			""")
+	List<LeagueMatchGame> findAllWithMatchByGameIdIn(@Param("gameIds") Collection<String> gameIds);
 }

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -75,6 +75,44 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 			@Param("start") LocalDateTime start,
 			@Param("end") LocalDateTime end);
 
+	@Query("""
+			SELECT m
+			FROM LeagueMatch m
+			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			  AND (:cursorId IS NULL
+					OR m.matchDate < :cursorDate
+					OR (m.matchDate = :cursorDate AND m.id < :cursorId))
+			ORDER BY m.matchDate DESC, m.id DESC
+			""")
+	List<LeagueMatch> findMobileMatchPage(
+			@Param("leagueName") String leagueName,
+			@Param("cursorDate") LocalDateTime cursorDate,
+			@Param("cursorId") String cursorId,
+			Pageable pageable);
+
+	@Query("""
+			SELECT m
+			FROM LeagueMatch m
+			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			  AND (
+					LOWER(m.blueTeamName) = LOWER(:teamName)
+					OR LOWER(m.redTeamName) = LOWER(:teamName)
+					OR (:teamCode IS NOT NULL AND m.blueTeamCode IS NOT NULL AND LOWER(m.blueTeamCode) = LOWER(:teamCode))
+					OR (:teamCode IS NOT NULL AND m.redTeamCode IS NOT NULL AND LOWER(m.redTeamCode) = LOWER(:teamCode))
+			  )
+			  AND (:cursorId IS NULL
+					OR m.matchDate < :cursorDate
+					OR (m.matchDate = :cursorDate AND m.id < :cursorId))
+			ORDER BY m.matchDate DESC, m.id DESC
+			""")
+	List<LeagueMatch> findMobileTeamMatchPage(
+			@Param("leagueName") String leagueName,
+			@Param("teamName") String teamName,
+			@Param("teamCode") String teamCode,
+			@Param("cursorDate") LocalDateTime cursorDate,
+			@Param("cursorId") String cursorId,
+			Pageable pageable);
+
 	@Query(value = """
 			SELECT DATE(m.match_date) AS matchDay,
 			       COUNT(*) AS matchCount

--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -8,6 +8,7 @@ import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingDetailResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingListResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingRequest;
+import com.toy.nar.app.mobile.rating.dto.MyRatingListResponse;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.entity.Player;
@@ -23,12 +24,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -36,6 +40,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MobileLivePlayerRatingService {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final ZoneId UTC = ZoneId.of("UTC");
 
 	private final LiveStateQueryService liveStateQueryService;
 	private final LivePlayerRatingRepository ratingRepository;
@@ -160,6 +167,34 @@ public class MobileLivePlayerRatingService {
 						request.comment()));
 		rating.update(request.rating(), request.comment());
 		return toMyRating(ratingRepository.save(rating));
+	}
+
+	public MyRatingListResponse getMyRatings(Long memberId, int page, int size) {
+		if (memberId == null) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+		}
+		int safePage = Math.max(0, page);
+		int safeSize = Math.max(1, Math.min(size, 100));
+		Page<LivePlayerRating> ratings = ratingRepository.findByMember_IdOrderByCreatedAtDesc(
+				memberId,
+				PageRequest.of(safePage, safeSize));
+
+		Set<String> gameIds = ratings.getContent().stream()
+				.map(LivePlayerRating::getLiveGameId)
+				.collect(Collectors.toSet());
+		Map<String, LeagueMatchGame> matchGamesByGameId = gameIds.isEmpty()
+				? Map.of()
+				: leagueMatchGameRepository.findAllWithMatchByGameIdIn(gameIds).stream()
+						.collect(Collectors.toMap(LeagueMatchGame::getGameId, Function.identity(), (left, right) -> left));
+
+		return new MyRatingListResponse(
+				ratings.getContent().stream()
+						.map(rating -> toMyRatingItem(rating, matchGamesByGameId.get(rating.getLiveGameId())))
+						.toList(),
+				ratings.getNumber(),
+				ratings.getSize(),
+				ratings.getTotalElements(),
+				ratings.getTotalPages());
 	}
 
 	@Transactional
@@ -290,6 +325,46 @@ public class MobileLivePlayerRatingService {
 				.mapToDouble(value -> value.getRating() * value.getRatingCount())
 				.sum();
 		return sum / count;
+	}
+
+	private MyRatingListResponse.MyRatingItem toMyRatingItem(LivePlayerRating rating, LeagueMatchGame matchGame) {
+		Player player = rating.getPlayer();
+		return new MyRatingListResponse.MyRatingItem(
+				rating.getId(),
+				rating.getLiveGameId(),
+				rating.getLiveParticipantId(),
+				player != null ? player.getId() : null,
+				rating.getPlayerName(),
+				player != null ? player.getImageUrl() : null,
+				rating.getTeamSide(),
+				rating.getRole(),
+				rating.getChampionName(),
+				rating.getRating(),
+				rating.getComment(),
+				rating.getCreatedAt(),
+				rating.getUpdatedAt(),
+				toMatchInfo(matchGame));
+	}
+
+	private MyRatingListResponse.MatchInfo toMatchInfo(LeagueMatchGame matchGame) {
+		if (matchGame == null) {
+			return null;
+		}
+		return new MyRatingListResponse.MatchInfo(
+				matchGame.getLeagueMatch().getId(),
+				matchGame.getGameOrder(),
+				matchGame.getLeagueMatch().getLeagueName(),
+				matchGame.getLeagueMatch().getMatchTitle(),
+				matchGame.getLeagueMatch().getBlueTeamCode(),
+				matchGame.getLeagueMatch().getRedTeamCode(),
+				toKst(matchGame.getLeagueMatch().getMatchDate()));
+	}
+
+	private LocalDateTime toKst(LocalDateTime utcDateTime) {
+		if (utcDateTime == null) {
+			return null;
+		}
+		return utcDateTime.atZone(UTC).withZoneSameInstant(KST).toLocalDateTime();
 	}
 
 	private LivePlayerRatingDetailResponse.MyRating toMyRating(LivePlayerRating rating) {

--- a/src/main/java/com/toy/nar/app/mobile/rating/dto/MyRatingListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/dto/MyRatingListResponse.java
@@ -1,0 +1,46 @@
+package com.toy.nar.app.mobile.rating.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "내가 작성한 선수 평가 전체 목록 응답")
+public record MyRatingListResponse(
+		List<MyRatingItem> ratings,
+		int page,
+		int size,
+		long totalElements,
+		int totalPages) {
+
+	public record MyRatingItem(
+			Long ratingId,
+			@Schema(description = "평가 대상 세트의 esports gameId", example = "113990000000000001")
+			String gameId,
+			Integer participantId,
+			Long playerId,
+			String playerName,
+			String playerImageUrl,
+			String teamSide,
+			String role,
+			String championName,
+			int rating,
+			String comment,
+			LocalDateTime createdAt,
+			LocalDateTime updatedAt,
+			@Schema(description = "세트가 속한 매치 정보. 매핑이 없으면 null", nullable = true)
+			MatchInfo match) {
+	}
+
+	public record MatchInfo(
+			String matchId,
+			@Schema(description = "세트 순서(1부터 시작)", example = "2")
+			Integer gameOrder,
+			String leagueName,
+			String matchTitle,
+			String blueTeamCode,
+			String redTeamCode,
+			@Schema(description = "경기 일시(KST)", example = "2026-04-01T18:00:00")
+			LocalDateTime matchDate) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -2,7 +2,10 @@ package com.toy.nar.app.mobile.schedule;
 
 import com.toy.nar.app.lolesports.LeagueConstants;
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchGamesResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchPageResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileScheduleCalendarResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileScheduleFilterResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
@@ -12,15 +15,18 @@ import com.toy.nar.common.util.NameNormalizer;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.function.Function;
 import java.util.LinkedHashMap;
@@ -43,8 +49,13 @@ public class MobileScheduleService {
 			"T1", "HLE", "GEN", "DK", "KT",
 			"DNS", "BFX", "NS", "BRO", "KRX"
 	);
+	private static final String LOLESPORTS_SOURCE = "LOLESPORTS";
+	private static final String CURSOR_DELIMITER = "|";
+	private static final int DEFAULT_PAGE_SIZE = 20;
+	private static final int MAX_PAGE_SIZE = 50;
 
 	private final LeagueMatchRepository leagueMatchRepository;
+	private final LeagueMatchGameRepository leagueMatchGameRepository;
 	private final TeamRepository teamRepository;
 
 	public MobileScheduleFilterResponse getFilters(String league) {
@@ -104,15 +115,56 @@ public class MobileScheduleService {
 		TeamFilter teamFilter = resolveTeamFilter(teamId);
 		LocalDateTime startUtc = toUtc(date.atStartOfDay());
 		LocalDateTime endUtc = toUtc(date.plusDays(1).atStartOfDay());
-		List<MobileScheduleListResponse.MobileMatchSummary> matches = findMatches(
-				normalizedLeague,
-				teamFilter,
-				startUtc,
-				endUtc).stream()
-				.map(this::toMatchSummary)
+		List<LeagueMatch> found = findMatches(normalizedLeague, teamFilter, startUtc, endUtc);
+		Map<String, List<MobileScheduleListResponse.MobileGameSummary>> gamesByMatchId = loadGames(found);
+		List<MobileScheduleListResponse.MobileMatchSummary> matches = found.stream()
+				.map(match -> toMatchSummary(match, gamesByMatchId))
 				.toList();
 
 		return new MobileScheduleListResponse(date.toString(), normalizedLeague, teamId, matches);
+	}
+
+	public MobileMatchPageResponse getMatchPage(String league, Long teamId, String cursor, Integer size) {
+		String normalizedLeague = normalizeLeague(league);
+		TeamFilter teamFilter = resolveTeamFilter(teamId);
+		int pageSize = size == null
+				? DEFAULT_PAGE_SIZE
+				: Math.max(1, Math.min(size, MAX_PAGE_SIZE));
+		MatchCursor matchCursor = decodeCursor(cursor);
+		PageRequest fetchLimit = PageRequest.of(0, pageSize + 1);
+
+		List<LeagueMatch> fetched = teamFilter == null
+				? leagueMatchRepository.findMobileMatchPage(
+						normalizedLeague,
+						matchCursor != null ? matchCursor.matchDate() : null,
+						matchCursor != null ? matchCursor.matchId() : null,
+						fetchLimit)
+				: leagueMatchRepository.findMobileTeamMatchPage(
+						normalizedLeague,
+						teamFilter.name(),
+						teamFilter.code(),
+						matchCursor != null ? matchCursor.matchDate() : null,
+						matchCursor != null ? matchCursor.matchId() : null,
+						fetchLimit);
+
+		List<LeagueMatch> page = fetched.size() > pageSize ? fetched.subList(0, pageSize) : fetched;
+		Map<String, List<MobileScheduleListResponse.MobileGameSummary>> gamesByMatchId = loadGames(page);
+		List<MobileScheduleListResponse.MobileMatchSummary> matches = page.stream()
+				.map(match -> toMatchSummary(match, gamesByMatchId))
+				.toList();
+		String nextCursor = fetched.size() > pageSize ? encodeCursor(page.getLast()) : null;
+
+		return new MobileMatchPageResponse(normalizedLeague, teamId, matches, nextCursor, nextCursor != null);
+	}
+
+	public MobileMatchGamesResponse getMatchGames(String matchId) {
+		LeagueMatch match = leagueMatchRepository.findById(matchId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+		List<MobileScheduleListResponse.MobileGameSummary> games = leagueMatchGameRepository
+				.findMappedGameRowsByMatchId(match.getId(), LOLESPORTS_SOURCE).stream()
+				.map(this::toGameSummary)
+				.toList();
+		return new MobileMatchGamesResponse(match.getId(), games);
 	}
 
 	private List<LeagueMatch> findMatches(
@@ -154,9 +206,12 @@ public class MobileScheduleService {
 				.toList();
 	}
 
-	private MobileScheduleListResponse.MobileMatchSummary toMatchSummary(LeagueMatch match) {
+	private MobileScheduleListResponse.MobileMatchSummary toMatchSummary(
+			LeagueMatch match,
+			Map<String, List<MobileScheduleListResponse.MobileGameSummary>> gamesByMatchId) {
 		return new MobileScheduleListResponse.MobileMatchSummary(
 				match.getId(),
+				match.getMatchDate() != null ? toKstDate(match).toString() : null,
 				toScheduledTime(match),
 				match.getState(),
 				match.getMatchTitle(),
@@ -171,7 +226,60 @@ public class MobileScheduleService {
 						match.getRedTeamCode(),
 						match.getRedTeamImageUrl(),
 						match.getRedScore()),
-				liveStreamUrl(match));
+				liveStreamUrl(match),
+				gamesByMatchId.getOrDefault(match.getId(), List.of()));
+	}
+
+	private Map<String, List<MobileScheduleListResponse.MobileGameSummary>> loadGames(List<LeagueMatch> matches) {
+		if (matches.isEmpty()) {
+			return Map.of();
+		}
+		List<String> matchIds = matches.stream().map(LeagueMatch::getId).toList();
+		return leagueMatchGameRepository.findMappedGameRowsByMatchIds(matchIds, LOLESPORTS_SOURCE).stream()
+				.collect(Collectors.groupingBy(
+						LeagueMatchGameRepository.MappedGameRow::getMatchId,
+						LinkedHashMap::new,
+						Collectors.mapping(this::toGameSummary, Collectors.toList())));
+	}
+
+	private MobileScheduleListResponse.MobileGameSummary toGameSummary(LeagueMatchGameRepository.MappedGameRow row) {
+		return new MobileScheduleListResponse.MobileGameSummary(
+				row.getGameOrder(),
+				row.getExternalGameId(),
+				row.getInternalGameId());
+	}
+
+	private MatchCursor decodeCursor(String cursor) {
+		if (cursor == null || cursor.isBlank()) {
+			return null;
+		}
+		try {
+			String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+			int delimiterIndex = decoded.lastIndexOf(CURSOR_DELIMITER);
+			LocalDateTime matchDate = LocalDateTime.parse(
+					decoded.substring(0, delimiterIndex),
+					DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+			String matchId = decoded.substring(delimiterIndex + 1);
+			if (matchId.isBlank()) {
+				throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+			}
+			return new MatchCursor(matchDate, matchId);
+		} catch (CustomException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+	}
+
+	private String encodeCursor(LeagueMatch match) {
+		if (match.getMatchDate() == null) {
+			// matchDate가 null인 행은 정렬 마지막에 위치해 커서 기준점이 될 수 없다
+			return null;
+		}
+		String raw = match.getMatchDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+				+ CURSOR_DELIMITER
+				+ match.getId();
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private MobileScheduleCalendarResponse.CalendarMatch toCalendarMatch(LeagueMatch match) {
@@ -258,5 +366,8 @@ public class MobileScheduleService {
 	}
 
 	private record TeamFilter(String name, String code) {
+	}
+
+	private record MatchCursor(LocalDateTime matchDate, String matchId) {
 	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileMatchGamesResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileMatchGamesResponse.java
@@ -1,0 +1,11 @@
+package com.toy.nar.app.mobile.schedule.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "매치 세트(게임) 목록 응답")
+public record MobileMatchGamesResponse(
+		String matchId,
+		List<MobileScheduleListResponse.MobileGameSummary> games) {
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileMatchPageResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileMatchPageResponse.java
@@ -1,0 +1,17 @@
+package com.toy.nar.app.mobile.schedule.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "모바일 경기 리스트 커서 페이지 응답")
+public record MobileMatchPageResponse(
+		String league,
+		Long teamId,
+		@Schema(description = "최신순(과거 방향) 경기 목록")
+		List<MobileScheduleListResponse.MobileMatchSummary> matches,
+		@Schema(description = "다음 페이지 조회용 커서. 마지막 페이지면 null", nullable = true)
+		String nextCursor,
+		@Schema(description = "다음 페이지 존재 여부")
+		boolean hasNext) {
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
@@ -1,5 +1,7 @@
 package com.toy.nar.app.mobile.schedule.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record MobileScheduleListResponse(
@@ -10,13 +12,26 @@ public record MobileScheduleListResponse(
 
 	public record MobileMatchSummary(
 			String matchId,
+			@Schema(description = "경기 일자(KST)", example = "2026-04-01")
+			String date,
 			String scheduledTime,
 			String matchStatus,
 			String matchTitle,
 			String leagueName,
 			MobileTeamResult blueTeam,
 			MobileTeamResult redTeam,
-			String liveStreamUrl) {
+			String liveStreamUrl,
+			@Schema(description = "매치에 속한 세트(게임) 목록. 아직 세트가 생성되지 않은 매치는 빈 배열")
+			List<MobileGameSummary> games) {
+	}
+
+	public record MobileGameSummary(
+			@Schema(description = "세트 순서(1부터 시작)", example = "1")
+			Integer gameOrder,
+			@Schema(description = "라이브/선수 평점 API에서 사용하는 esports gameId", example = "113990000000000001")
+			String gameId,
+			@Schema(description = "기록(record) API에서 사용하는 내부 gameId. 기록 미적재 시 null", example = "1024", nullable = true)
+			Long recordGameId) {
 	}
 
 	public record MobileTeamResult(

--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/mobile/me/player-subscriptions/**",
-                                "/api/mobile/me/devices/**"
+                                "/api/mobile/me/devices/**",
+                                "/api/mobile/me/ratings"
                         ).authenticated()
                         .requestMatchers(
                                 HttpMethod.PUT,

--- a/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
+++ b/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
@@ -20,6 +20,9 @@ public interface LivePlayerRatingRepository extends JpaRepository<LivePlayerRati
 
 	List<LivePlayerRating> findByLiveGameIdAndMember_Id(String liveGameId, Long memberId);
 
+	@EntityGraph(attributePaths = "player")
+	Page<LivePlayerRating> findByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
 	@EntityGraph(attributePaths = "member")
 	Page<LivePlayerRating> findByLiveGameIdAndLiveParticipantIdOrderByCreatedAtDesc(
 			String liveGameId,

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -1,0 +1,85 @@
+package com.toy.nar.api.mobile.match;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.mobile.schedule.MobileScheduleService;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchGamesResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchPageResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MobileMatchControllerTest {
+
+	private MobileScheduleService mobileScheduleService;
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		mobileScheduleService = mock(MobileScheduleService.class);
+		mockMvc = MockMvcBuilders
+				.standaloneSetup(new MobileMatchController(mobileScheduleService))
+				.setMessageConverters(new MappingJackson2HttpMessageConverter(new ObjectMapper()))
+				.build();
+	}
+
+	@Test
+	void getMatchesReturnsCursorPageShape() throws Exception {
+		when(mobileScheduleService.getMatchPage("LCK", null, null, 20))
+				.thenReturn(new MobileMatchPageResponse(
+						"LCK",
+						null,
+						List.of(new MobileScheduleListResponse.MobileMatchSummary(
+								"match-1",
+								"2026-04-01",
+								"18:00",
+								"completed",
+								"T1 vs GEN",
+								"LCK",
+								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 2),
+								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 1),
+								null,
+								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L)))),
+						"cursor-token",
+						true));
+
+		mockMvc.perform(get("/api/mobile/matches").param("league", "LCK"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.league").value("LCK"))
+				.andExpect(jsonPath("$.matches[0].matchId").value("match-1"))
+				.andExpect(jsonPath("$.matches[0].date").value("2026-04-01"))
+				.andExpect(jsonPath("$.matches[0].games[0].gameOrder").value(1))
+				.andExpect(jsonPath("$.matches[0].games[0].gameId").value("game-1"))
+				.andExpect(jsonPath("$.matches[0].games[0].recordGameId").value(100L))
+				.andExpect(jsonPath("$.nextCursor").value("cursor-token"))
+				.andExpect(jsonPath("$.hasNext").value(true));
+	}
+
+	@Test
+	void getMatchGamesReturnsGameIdentifiers() throws Exception {
+		when(mobileScheduleService.getMatchGames("match-1"))
+				.thenReturn(new MobileMatchGamesResponse(
+						"match-1",
+						List.of(
+								new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L),
+								new MobileScheduleListResponse.MobileGameSummary(2, "game-2", null))));
+
+		mockMvc.perform(get("/api/mobile/matches/match-1/games"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.matchId").value("match-1"))
+				.andExpect(jsonPath("$.games[0].gameId").value("game-1"))
+				.andExpect(jsonPath("$.games[0].recordGameId").value(100L))
+				.andExpect(jsonPath("$.games[1].gameOrder").value(2))
+				.andExpect(jsonPath("$.games[1].recordGameId").doesNotExist());
+	}
+}

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -93,13 +93,15 @@ class MobileScheduleControllerTest {
 						null,
 						List.of(new MobileScheduleListResponse.MobileMatchSummary(
 								"match-1",
+								"2026-04-01",
 								"18:00",
 								"unstarted",
 								"T1 vs GEN",
 								"LCK",
 								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 0),
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 0),
-								null))));
+								null,
+								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L))))));
 
 		mockMvc.perform(get("/api/mobile/schedules")
 						.param("date", "2026-04-01")
@@ -108,7 +110,10 @@ class MobileScheduleControllerTest {
 				.andExpect(jsonPath("$.date").value("2026-04-01"))
 				.andExpect(jsonPath("$.league").value("LCK"))
 				.andExpect(jsonPath("$.matches[0].matchId").value("match-1"))
+				.andExpect(jsonPath("$.matches[0].date").value("2026-04-01"))
 				.andExpect(jsonPath("$.matches[0].blueTeam.teamCode").value("T1"))
-				.andExpect(jsonPath("$.matches[0].redTeam.teamName").value("Gen.G"));
+				.andExpect(jsonPath("$.matches[0].redTeam.teamName").value("Gen.G"))
+				.andExpect(jsonPath("$.matches[0].games[0].gameId").value("game-1"))
+				.andExpect(jsonPath("$.matches[0].games[0].recordGameId").value(100L));
 	}
 }

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -187,6 +187,66 @@ class MobileLivePlayerRatingServiceTest {
 		verify(ratingRepository).delete(existing);
 	}
 
+	@Test
+	void getMyRatingsRequiresLogin() {
+		assertThatThrownBy(() -> service.getMyRatings(null, 0, 20))
+				.isInstanceOf(ResponseStatusException.class)
+				.hasMessageContaining("401 UNAUTHORIZED");
+	}
+
+	@Test
+	void getMyRatingsReturnsItemsWithMatchInfo() {
+		Member member = member(7L, "용맹한바론");
+		LivePlayerRating myRating = rating(member, 5, "역시 페이커");
+		ReflectionTestUtils.setField(myRating, "id", 11L);
+		ReflectionTestUtils.setField(myRating, "createdAt", LocalDateTime.of(2026, 6, 6, 13, 0));
+		ReflectionTestUtils.setField(myRating, "updatedAt", LocalDateTime.of(2026, 6, 6, 13, 0));
+		LeagueMatch match = LeagueMatch.builder()
+				.id("match-1")
+				.leagueName("LCK")
+				.matchTitle("DNS vs T1")
+				.matchDate(LocalDateTime.of(2026, 6, 6, 9, 0))
+				.state("completed")
+				.blueTeamCode("DNS")
+				.redTeamCode("T1")
+				.build();
+		when(ratingRepository.findByMember_IdOrderByCreatedAtDesc(7L, PageRequest.of(0, 20)))
+				.thenReturn(new PageImpl<>(List.of(myRating), PageRequest.of(0, 20), 1));
+		when(leagueMatchGameRepository.findAllWithMatchByGameIdIn(java.util.Set.of("game-1")))
+				.thenReturn(List.of(new LeagueMatchGame(match, "game-1", 2)));
+
+		var response = service.getMyRatings(7L, 0, 20);
+
+		assertThat(response.totalElements()).isEqualTo(1);
+		assertThat(response.ratings()).singleElement().satisfies(item -> {
+			assertThat(item.ratingId()).isEqualTo(11L);
+			assertThat(item.gameId()).isEqualTo("game-1");
+			assertThat(item.playerName()).isEqualTo("Faker");
+			assertThat(item.championName()).isEqualTo("Ahri");
+			assertThat(item.rating()).isEqualTo(5);
+			assertThat(item.comment()).isEqualTo("역시 페이커");
+			assertThat(item.match().matchId()).isEqualTo("match-1");
+			assertThat(item.match().gameOrder()).isEqualTo(2);
+			assertThat(item.match().blueTeamCode()).isEqualTo("DNS");
+			assertThat(item.match().matchDate()).isEqualTo(LocalDateTime.of(2026, 6, 6, 18, 0));
+		});
+	}
+
+	@Test
+	void getMyRatingsReturnsNullMatchWhenMappingMissing() {
+		Member member = member(7L, "용맹한바론");
+		LivePlayerRating myRating = rating(member, 4, null);
+		when(ratingRepository.findByMember_IdOrderByCreatedAtDesc(7L, PageRequest.of(0, 20)))
+				.thenReturn(new PageImpl<>(List.of(myRating), PageRequest.of(0, 20), 1));
+		when(leagueMatchGameRepository.findAllWithMatchByGameIdIn(java.util.Set.of("game-1")))
+				.thenReturn(List.of());
+
+		var response = service.getMyRatings(7L, 0, 20);
+
+		assertThat(response.ratings()).singleElement()
+				.satisfies(item -> assertThat(item.match()).isNull());
+	}
+
 	private Member member(Long id, String nickname) {
 		Member member = Member.builder().nickname(nickname).email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -1,7 +1,10 @@
 package com.toy.nar.app.mobile.schedule;
 
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchGamesResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchPageResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileScheduleCalendarResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileScheduleFilterResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
@@ -12,6 +15,7 @@ import com.toy.nar.domain.participant.repository.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -30,14 +34,16 @@ import static org.mockito.Mockito.when;
 class MobileScheduleServiceTest {
 
 	private LeagueMatchRepository leagueMatchRepository;
+	private LeagueMatchGameRepository leagueMatchGameRepository;
 	private TeamRepository teamRepository;
 	private MobileScheduleService service;
 
 	@BeforeEach
 	void setUp() {
 		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		leagueMatchGameRepository = mock(LeagueMatchGameRepository.class);
 		teamRepository = mock(TeamRepository.class);
-		service = new MobileScheduleService(leagueMatchRepository, teamRepository);
+		service = new MobileScheduleService(leagueMatchRepository, leagueMatchGameRepository, teamRepository);
 	}
 
 	@Test
@@ -143,6 +149,135 @@ class MobileScheduleServiceTest {
 	}
 
 	@Test
+	void getDailySchedulesAttachesGamesPerMatch() {
+		when(leagueMatchRepository.findMobileMatchesInRange(
+				"LCK",
+				LocalDateTime.of(2026, 3, 31, 15, 0),
+				LocalDateTime.of(2026, 4, 1, 15, 0)))
+				.thenReturn(List.of(match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed")));
+		when(leagueMatchGameRepository.findMappedGameRowsByMatchIds(List.of("match-1"), "LOLESPORTS"))
+				.thenReturn(List.of(
+						new MappedRow("match-1", 1, "game-1", 100L),
+						new MappedRow("match-1", 2, "game-2", null)));
+
+		MobileScheduleListResponse response = service.getDailySchedules(LocalDate.of(2026, 4, 1), "LCK", null);
+
+		assertThat(response.matches()).singleElement()
+				.satisfies(match -> {
+					assertThat(match.date()).isEqualTo("2026-04-01");
+					assertThat(match.games()).extracting(
+									MobileScheduleListResponse.MobileGameSummary::gameOrder,
+									MobileScheduleListResponse.MobileGameSummary::gameId,
+									MobileScheduleListResponse.MobileGameSummary::recordGameId)
+							.containsExactly(
+									org.assertj.core.groups.Tuple.tuple(1, "game-1", 100L),
+									org.assertj.core.groups.Tuple.tuple(2, "game-2", null));
+				});
+	}
+
+	@Test
+	void getMatchPageReturnsNextCursorWhenMoreRowsExist() {
+		LeagueMatch first = match("match-2", "LCK", LocalDateTime.of(2026, 4, 2, 9, 0), "T1", "GEN", "completed");
+		LeagueMatch second = match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "DK", "HLE", "completed");
+		LeagueMatch overflow = match("match-0", "LCK", LocalDateTime.of(2026, 3, 31, 9, 0), "KT", "NS", "completed");
+		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, PageRequest.of(0, 3)))
+				.thenReturn(List.of(first, second, overflow));
+
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, 2);
+
+		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
+				.containsExactly("match-2", "match-1");
+		assertThat(response.hasNext()).isTrue();
+		String decoded = new String(
+				java.util.Base64.getUrlDecoder().decode(response.nextCursor()),
+				java.nio.charset.StandardCharsets.UTF_8);
+		assertThat(decoded).isEqualTo("2026-04-01T09:00:00|match-1");
+	}
+
+	@Test
+	void getMatchPageReturnsNoCursorOnLastPage() {
+		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, PageRequest.of(0, 21)))
+				.thenReturn(List.of(match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed")));
+
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null);
+
+		assertThat(response.matches()).hasSize(1);
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.nextCursor()).isNull();
+	}
+
+	@Test
+	void getMatchPagePassesDecodedCursorToRepository() {
+		String cursor = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(
+				"2026-04-01T09:00:00|match-1".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		when(leagueMatchRepository.findMobileMatchPage(
+				"LCK",
+				LocalDateTime.of(2026, 4, 1, 9, 0),
+				"match-1",
+				PageRequest.of(0, 21)))
+				.thenReturn(List.of());
+
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, cursor, null);
+
+		assertThat(response.matches()).isEmpty();
+		assertThat(response.hasNext()).isFalse();
+		verify(leagueMatchRepository).findMobileMatchPage(
+				"LCK",
+				LocalDateTime.of(2026, 4, 1, 9, 0),
+				"match-1",
+				PageRequest.of(0, 21));
+	}
+
+	@Test
+	void getMatchPageUsesTeamFilterWhenTeamIdExists() {
+		Team t1 = team(1L, "T1", "T1", "https://example.com/t1.png");
+		when(teamRepository.findById(1L)).thenReturn(Optional.of(t1));
+		when(leagueMatchRepository.findMobileTeamMatchPage("LCK", "T1", "T1", null, null, PageRequest.of(0, 21)))
+				.thenReturn(List.of());
+
+		MobileMatchPageResponse response = service.getMatchPage("LCK", 1L, null, null);
+
+		assertThat(response.teamId()).isEqualTo(1L);
+		verify(leagueMatchRepository).findMobileTeamMatchPage("LCK", "T1", "T1", null, null, PageRequest.of(0, 21));
+	}
+
+	@Test
+	void getMatchPageWithInvalidCursorThrowsInvalidInput() {
+		assertThatThrownBy(() -> service.getMatchPage("LCK", null, "not-a-cursor", null))
+				.isInstanceOf(CustomException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+	}
+
+	@Test
+	void getMatchGamesReturnsMappedGames() {
+		when(leagueMatchRepository.findById("match-1"))
+				.thenReturn(Optional.of(match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed")));
+		when(leagueMatchGameRepository.findMappedGameRowsByMatchId("match-1", "LOLESPORTS"))
+				.thenReturn(List.of(new MappedRow("match-1", 1, "game-1", 100L)));
+
+		MobileMatchGamesResponse response = service.getMatchGames("match-1");
+
+		assertThat(response.matchId()).isEqualTo("match-1");
+		assertThat(response.games()).singleElement()
+				.satisfies(game -> {
+					assertThat(game.gameOrder()).isEqualTo(1);
+					assertThat(game.gameId()).isEqualTo("game-1");
+					assertThat(game.recordGameId()).isEqualTo(100L);
+				});
+	}
+
+	@Test
+	void getMatchGamesWithUnknownMatchThrowsDataNotFound() {
+		when(leagueMatchRepository.findById("missing")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.getMatchGames("missing"))
+				.isInstanceOf(CustomException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.DATA_NOT_FOUND);
+	}
+
+	@Test
 	void invalidLeagueThrowsInvalidInput() {
 		assertThatThrownBy(() -> service.getDailySchedules(LocalDate.of(2026, 4, 1), "abc", null))
 				.isInstanceOf(CustomException.class)
@@ -159,6 +294,33 @@ class MobileScheduleServiceTest {
 				.isInstanceOf(CustomException.class)
 				.extracting("errorCode")
 				.isEqualTo(ErrorCode.DATA_NOT_FOUND);
+	}
+
+	private record MappedRow(
+			String rowMatchId,
+			Integer rowGameOrder,
+			String rowExternalGameId,
+			Long rowInternalGameId) implements LeagueMatchGameRepository.MappedGameRow {
+
+		@Override
+		public String getMatchId() {
+			return rowMatchId;
+		}
+
+		@Override
+		public Integer getGameOrder() {
+			return rowGameOrder;
+		}
+
+		@Override
+		public String getExternalGameId() {
+			return rowExternalGameId;
+		}
+
+		@Override
+		public Long getInternalGameId() {
+			return rowInternalGameId;
+		}
 	}
 
 	private LeagueMatch match(

--- a/src/test/java/com/toy/nar/app/schedule/ScheduleFinderTest.java
+++ b/src/test/java/com/toy/nar/app/schedule/ScheduleFinderTest.java
@@ -139,6 +139,11 @@ class ScheduleFinderTest {
 			}
 
 			@Override
+			public String getExternalGameId() {
+				return matchId + "-game-" + gameOrder;
+			}
+
+			@Override
 			public Long getInternalGameId() {
 				return internalGameId;
 			}


### PR DESCRIPTION
## 배포 내용
모바일 팀 요청 API 4건 (PR #175)

- `GET /api/mobile/matches`: 커서 기반 경기 리스트 무한 스크롤 (리그/팀 필터)
- `GET /api/mobile/matches/{matchId}/games`: 매치 세트 목록 (gameId + recordGameId)
- 일별 경기 리스트 응답에 date/games 필드 추가 (하위 호환)
- `GET /api/mobile/me/ratings`: 내 선수 평가 전체 목록 (인증 필요)
- `/api/auth/me` 응답에 email 필드 추가
- 명세서: docs/mobile-api-spec-2026-06-11.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)