### PR TITLE
fix: 클린 체크아웃에서 항상 깨지는 테스트 정리 (H2 폴백 + Flyway V1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ tasks.register('generateJooq', JavaExec) {
 tasks.named('test') {
 	useJUnitPlatform()
 	systemProperties System.properties.findAll { key, _ ->
-		key.startsWith('benchmark.') || key.startsWith('deadlock.')
+		key.startsWith('benchmark.') || key.startsWith('deadlock.') || key.startsWith('dataintegrity.') || key.startsWith('fullcontext.')
 	}
 }
 

--- a/src/test/java/com/toy/nar/GameDataIntegrityTest.java
+++ b/src/test/java/com/toy/nar/GameDataIntegrityTest.java
@@ -5,12 +5,18 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import com.toy.nar.domain.game.repository.GameParticipantRepository;
 
+/**
+ * 실데이터가 적재된 로컬 dev MySQL 전용 데이터 무결성 점검.
+ * 실행: ./gradlew test -Ddataintegrity.local.enabled=true --tests "...GameDataIntegrityTest"
+ */
+@EnabledIfSystemProperty(named = "dataintegrity.local.enabled", matches = "true")
 @Slf4j
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/com/toy/nar/NarApplicationTests.java
+++ b/src/test/java/com/toy/nar/NarApplicationTests.java
@@ -1,8 +1,16 @@
 package com.toy.nar;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.boot.test.context.SpringBootTest;
 
+/**
+ * 로컬 dev 환경 전용 풀 컨텍스트 스모크 테스트.
+ * application-dev.yml, service-account-key.json 등 gitignore된 로컬 설정이 있어야 기동되므로
+ * 클린 체크아웃 기본 빌드에서는 건너뛴다.
+ * 실행: ./gradlew test -Dfullcontext.local.enabled=true --tests "com.toy.nar.NarApplicationTests"
+ */
+@EnabledIfSystemProperty(named = "fullcontext.local.enabled", matches = "true")
 @SpringBootTest
 class NarApplicationTests {
 

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePerformanceBaselineTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePerformanceBaselineTest.java
@@ -13,6 +13,7 @@ import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -27,6 +28,12 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
+/**
+ * 실데이터가 적재된 로컬 dev MySQL(application-dev.yml) 전용 벤치마크.
+ * 클린 체크아웃에는 dev 설정 파일이 없어 H2로 폴백되므로 기본 빌드에서는 건너뛴다.
+ * 실행: ./gradlew test -Dbenchmark.local.enabled=true --tests "...PerformanceBaselineTest"
+ */
+@EnabledIfSystemProperty(named = "benchmark.local.enabled", matches = "true")
 @DataJpaTest
 @ActiveProfiles("dev")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/com/toy/nar/app/schedule/ScheduleServicePerformanceBaselineTest.java
+++ b/src/test/java/com/toy/nar/app/schedule/ScheduleServicePerformanceBaselineTest.java
@@ -14,6 +14,7 @@ import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -31,6 +32,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * 실데이터가 적재된 로컬 dev MySQL(application-dev.yml) 전용 벤치마크.
+ * 클린 체크아웃에는 dev 설정 파일이 없어 H2로 폴백되므로 기본 빌드에서는 건너뛴다.
+ * 실행: ./gradlew test -Dbenchmark.local.enabled=true --tests "...PerformanceBaselineTest"
+ */
+@EnabledIfSystemProperty(named = "benchmark.local.enabled", matches = "true")
 @DataJpaTest
 @ActiveProfiles("dev")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/com/toy/nar/domain/youtube/repository/VideoDataIntegrityTest.java
+++ b/src/test/java/com/toy/nar/domain/youtube/repository/VideoDataIntegrityTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -16,6 +17,11 @@ import org.springframework.context.annotation.Import;
 import com.toy.nar.domain.youtube.Channel;
 import com.toy.nar.domain.youtube.Video;
 
+/**
+ * 실데이터가 적재된 로컬 dev MySQL 전용 데이터 무결성 점검.
+ * 실행: ./gradlew test -Ddataintegrity.local.enabled=true --tests "...VideoDataIntegrityTest"
+ */
+@EnabledIfSystemProperty(named = "dataintegrity.local.enabled", matches = "true")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class VideoDataIntegrityTest {

--- a/src/test/java/com/toy/nar/domain/youtube/repository/VideoRepositoryNPlusOneTest.java
+++ b/src/test/java/com/toy/nar/domain/youtube/repository/VideoRepositoryNPlusOneTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,8 +22,11 @@ import com.toy.nar.domain.youtube.Channel;
 import com.toy.nar.domain.youtube.ChannelType;
 import com.toy.nar.domain.youtube.Video;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// 임베디드 H2에서 격리 실행: 마이그레이션은 MySQL 전용 문법이라 H2에서는 엔티티 기반 스키마를 사용한다.
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
 class VideoRepositoryNPlusOneTest {
 
 	@Autowired

--- a/src/test/java/com/toy/nar/domain/youtube/repository/VideoRepositoryOrderingTest.java
+++ b/src/test/java/com/toy/nar/domain/youtube/repository/VideoRepositoryOrderingTest.java
@@ -22,7 +22,11 @@ import com.toy.nar.domain.youtube.Channel;
 import com.toy.nar.domain.youtube.ChannelType;
 import com.toy.nar.domain.youtube.Video;
 
-@DataJpaTest
+// 임베디드 H2에서 격리 실행: 마이그레이션은 MySQL 전용 문법이라 H2에서는 엔티티 기반 스키마를 사용한다.
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
 class VideoRepositoryOrderingTest {
 
 	@Autowired


### PR DESCRIPTION
## 문제

`ScheduleServicePerformanceBaselineTest`, `LeagueMatchServicePerformanceBaselineTest`를 포함한 7개 테스트가 클린 체크아웃(워크트리·신규 클론)에서 ApplicationContext 로드 실패로 항상 깨짐.

## 근본 원인

보고된 증상(V1 SQLite 문법 → H2 Flyway 실패)의 한 단계 아래에 진짜 원인이 있었습니다.

1. `application-dev.yml`은 `.gitignore`에 등록된 **로컬 전용 파일**이라 클린 체크아웃에는 존재하지 않음
2. 테스트는 `@ActiveProfiles("dev")` 또는 `application.yml`의 기본 프로파일(dev)로 뜨지만 datasource URL이 비어 있음 → Spring Boot가 **임베디드 H2로 폴백**
3. Flyway(기본 enabled)가 빈 H2에 V1부터 실행 → `V1__init.sql`의 SQLite 문법(`INTEGER PRIMARY KEY AUTOINCREMENT`)에서 문법 오류 → 컨텍스트 로드 실패

같은 원인으로 `NarApplicationTests`, `GameDataIntegrityTest`, `VideoDataIntegrityTest`, `VideoRepositoryNPlusOneTest`, `VideoRepositoryOrderingTest`도 깨지고 있었습니다.

## 검토했던 방안 평가

| 방안 | 평가 |
|------|------|
| (1) 테스트에서 Flyway 비활성 + ddl-auto | 자급자족 테스트에는 유효. 단, 벤치마크 테스트는 **실데이터가 없으면 어차피 실패**(`No matches found` 예외)라 이것만으로 해결 불가 |
| (2) H2 전용 마이그레이션 경로 분리 | 스키마 이중 관리 부담 + 역시 데이터 부재 문제 미해결 |
| (3) V1을 공통 문법으로 수정 | 34개 마이그레이션 중 **17개가 MySQL 전용 문법** 사용 → V1만 고치면 실패 지점이 V2+로 이동할 뿐. 전체 체인 H2 호환화는 비현실적 |

두 벤치마크 테스트는 본질적으로 **실데이터가 적재된 로컬 dev MySQL 전용**이므로, 레포의 기존 컨벤션(`@EnabledIfSystemProperty` + `deadlock.local.enabled`)을 따라 옵트인으로 전환하고, 자급자족 테스트만 방안 (1)을 적용했습니다.

## 변경 내용

- **옵트인 게이트 추가** (로컬 dev 환경 전용 테스트)
  - `benchmark.local.enabled`: 두 PerformanceBaselineTest
  - `dataintegrity.local.enabled`: GameDataIntegrityTest, VideoDataIntegrityTest
  - `fullcontext.local.enabled`: NarApplicationTests (Google Drive 키 등 gitignore된 시크릿 필요)
- **임베디드 H2 격리 실행**: VideoRepositoryNPlusOneTest, VideoRepositoryOrderingTest — Flyway 비활성 + `ddl-auto=create-drop` (Replace.NONE 제거로 실 DB를 건드릴 가능성도 차단)
- **build.gradle**: `dataintegrity.*`, `fullcontext.*` 시스템 프로퍼티를 테스트 JVM에 전달

## 검증

- 클린 워크트리에서 `./gradlew test`: **152개 중 실패 8 → 1** (잔여 1건은 본 이슈와 무관한 `TeamProfileServiceTest` 어서션 실패 — 날짜 의존으로 보이며 별도 수정 필요)
- `-Dbenchmark.local.enabled=true` 지정 시 게이트된 테스트가 실제 실행되는 것 확인 (프로퍼티 전달 와이어링 정상)
- 운영 영향 없음: 프로덕션 코드·마이그레이션 파일 무변경, CI는 `-x test` 빌드

🤖 Generated with [Claude Code](https://claude.com/claude-code)