### PR TITLE
deploy: 경기 리스트 시즌 필터 + league_match 쿼리 최적화

### DIFF
--- a/docs/mobile-api-spec-2026-06-11.md
+++ b/docs/mobile-api-spec-2026-06-11.md
@@ -24,8 +24,18 @@ GET /api/mobile/matches
 |----------|------|--------|------|
 | `league` | String | `LCK` | 리그 필터 |
 | `teamId` | Long | - | 팀 필터 (filters API의 teamId) |
+| `seasonYear` | int | - | 시즌 연도 필터 (filters API의 seasons.year) |
+| `split` | String | - | 스플릿 필터 (filters API의 seasons.split) |
 | `cursor` | String | - | 이전 응답의 `nextCursor`. 첫 페이지는 생략 |
 | `size` | int | 20 | 페이지 크기 (1~50) |
+
+시즌 필터 옵션은 `GET /api/mobile/schedules/filters` 응답에 추가된 `seasons[]`에서 가져온다:
+
+```json
+{ "seasons": [ { "year": 2026, "split": "Spring", "label": "2026 Spring" } ] }
+```
+
+시즌 정보가 아직 매겨지지 않은 경기(`season` 미산정)는 시즌 필터 적용 시 제외된다.
 
 - 정렬: 최신 경기 → 과거 방향 (`matchDate DESC`)
 - 커서는 불투명(opaque) 토큰. 그대로 돌려보내기만 하면 되고, 동시각 경기·실시간 경기 추가에도 중복/누락 없음
@@ -168,5 +178,4 @@ GET /api/mobile/me/ratings?page=0&size=20
 | 항목 | 상태 | 비고 |
 |------|------|------|
 | 4. 구글·네이버 모바일 로그인 (`POST /auth/mobile/google`, `/naver`) | **미구현** | 카카오(`POST /api/auth/mobile/kakao`)만 운영 중. 카카오 패턴 따라 신규 구현 필요 |
-| 경기 리스트 시즌(스플릿) 필터 | 미지원 | `LeagueMatch`에 시즌 컬럼이 없음. 당장은 날짜 범위로 대체, 필요 시 컬럼 추가 검토 |
 | record API의 String gameId 직접 지원 | 검토 | 현재는 `games[].recordGameId`로 변환값을 내려주는 방식으로 해소 |

--- a/src/main/java/com/toy/nar/api/admin/LeagueMatchSeasonAdminController.java
+++ b/src/main/java/com/toy/nar/api/admin/LeagueMatchSeasonAdminController.java
@@ -1,0 +1,35 @@
+package com.toy.nar.api.admin;
+
+import com.toy.nar.app.lolesports.season.LeagueMatchSeasonBackfillService;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({ "local", "dev", "prod" })
+@RestController
+@RequestMapping("/api/admin/league-match-seasons")
+@RequiredArgsConstructor
+@Hidden
+@Slf4j
+public class LeagueMatchSeasonAdminController {
+
+	private final LeagueMatchSeasonBackfillService backfillService;
+
+	/**
+	 * league_match 시즌 백필. 기본 dryRun=true 이므로 실제 갱신은 dryRun=false 를 명시해야 한다.
+	 * dryRun 집계는 기간이 겹치는 토너먼트에서 중복 계산될 수 있다 (실제 갱신은 중복 없음).
+	 */
+	@PostMapping("/backfill")
+	public ResponseEntity<LeagueMatchSeasonBackfillService.BackfillResult> backfill(
+			@RequestParam(defaultValue = "true") boolean dryRun,
+			@RequestParam(defaultValue = "false") boolean force) {
+		log.info("시즌 백필 요청: dryRun={}, force={}", dryRun, force);
+		return ResponseEntity.ok(backfillService.backfill(dryRun, force));
+	}
+}

--- a/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
+++ b/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
@@ -26,18 +26,23 @@ public class MobileMatchController {
 			summary = "모바일 경기 리스트 커서 페이지 조회",
 			description = "최신 경기부터 과거 방향으로 커서 기반 페이지네이션 조회합니다. "
 					+ "첫 페이지는 cursor 없이 호출하고, 이후 응답의 nextCursor를 cursor로 전달하면 이어서 조회됩니다. "
-					+ "각 경기에는 세트(games) 식별자 목록이 포함됩니다.")
+					+ "각 경기에는 세트(games) 식별자 목록이 포함됩니다. "
+					+ "시즌 필터 옵션은 /api/mobile/schedules/filters 응답의 seasons에서 가져옵니다.")
 	@GetMapping
 	public ResponseEntity<MobileMatchPageResponse> getMatches(
 			@Parameter(description = "리그", example = "LCK")
 			@RequestParam(defaultValue = "LCK") String league,
 			@Parameter(description = "팀 ID", example = "1")
 			@RequestParam(required = false) Long teamId,
+			@Parameter(description = "시즌 연도", example = "2026")
+			@RequestParam(required = false) Integer seasonYear,
+			@Parameter(description = "스플릿 (filters의 seasons.split 값)", example = "Spring")
+			@RequestParam(required = false) String split,
 			@Parameter(description = "이전 응답의 nextCursor. 첫 페이지는 생략")
 			@RequestParam(required = false) String cursor,
 			@Parameter(description = "페이지 크기(1~50)", example = "20")
 			@RequestParam(defaultValue = "20") Integer size) {
-		return ResponseEntity.ok(mobileScheduleService.getMatchPage(league, teamId, cursor, size));
+		return ResponseEntity.ok(mobileScheduleService.getMatchPage(league, teamId, seasonYear, split, cursor, size));
 	}
 
 	@Operation(

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -26,6 +26,20 @@ public final class LeagueConstants {
             "LCK", "LPL", "LCP", "LEC", "LCS", "CBLOL", "MSI", "WORLDS", "FIRST_STAND");
 
     /**
+     * lolesports API의 리그 ID 매핑
+     */
+    public static final Map<String, String> LEAGUE_IDS = Map.ofEntries(
+            Map.entry("LCK", "98767991310872058"),
+            Map.entry("LPL", "98767991314006698"),
+            Map.entry("LEC", "98767991302996019"),
+            Map.entry("LCS", "98767991299243165"),
+            Map.entry("LCP", "113476371197627891"),
+            Map.entry("CBLOL", "98767991332355509"),
+            Map.entry("FIRST_STAND", "113464388705111224"),
+            Map.entry("WORLDS", "98767975604431411"),
+            Map.entry("MSI", "98767991325878492"));
+
+    /**
      * 리그별 기본 라이브 스트림 URL
      */
     public static final Map<String, String> LIVE_STREAM_URLS = Map.of(

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -62,6 +62,7 @@ public class LeagueMatchService {
 
 	private final LeagueMatchRepository leagueMatchRepository;
 	private final LeagueMatchGameRepository leagueMatchGameRepository;
+	private final com.toy.nar.app.lolesports.season.LeagueSeasonResolver leagueSeasonResolver;
 	private final com.toy.nar.domain.participant.repository.TeamRepository teamRepository;
 	private final TeamExternalIdentityRepository teamExternalIdentityRepository;
 	private final GameExternalIdentityRepository gameExternalIdentityRepository;
@@ -714,6 +715,7 @@ public class LeagueMatchService {
 		for (MatchResultDto dto : matches) {
 			try {
 				LeagueMatch incoming = convertToEntity(dto, leagueSlug);
+				applySeasonIfResolvable(incoming);
 				LeagueMatch existing = existingMatchesById.get(dto.getMatchId());
 
 				if (existing == null) {
@@ -724,6 +726,13 @@ public class LeagueMatchService {
 				}
 
 				if (!hasRealtimeRelevantChange(existing, incoming)) {
+					// 시즌만 비어 있으면 채운다 (dirtyMatchIds에는 넣지 않아 게임 ID 재동기화는 트리거하지 않음)
+					if (existing.getSeasonYear() == null) {
+						applySeasonIfResolvable(existing);
+						if (existing.getSeasonYear() != null) {
+							dirtyMatches.add(existing);
+						}
+					}
 					skipped++;
 					continue;
 				}
@@ -746,6 +755,7 @@ public class LeagueMatchService {
 						incoming.isHasVod(),
 						incoming.getMatchDetailsJson(),
 						incoming.getLastUpdated());
+				applySeasonIfResolvable(existing);
 				dirtyMatches.add(existing);
 				dirtyMatchIds.add(existing.getId());
 				updated++;
@@ -759,6 +769,14 @@ public class LeagueMatchService {
 		}
 
 		return new MatchSyncUpsertResult(dirtyMatchIds, inserted, updated, skipped);
+	}
+
+	private void applySeasonIfResolvable(LeagueMatch match) {
+		if (match.getMatchDate() == null) {
+			return;
+		}
+		leagueSeasonResolver.resolve(match.getLeagueName(), match.getMatchDate())
+				.ifPresent(season -> match.applySeason(season.year(), season.split()));
 	}
 
 	private MatchGameIdSyncResult syncLeagueMatchGameIdsForMatches(List<LeagueMatch> matches) {

--- a/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
@@ -28,16 +28,7 @@ public class WorldsService {
 	@Qualifier("applicationTaskExecutor")
 	private final Executor applicationTaskExecutor;
 
-	private static final java.util.Map<String, String> LEAGUE_IDS = java.util.Map.ofEntries(
-			java.util.Map.entry("LCK", "98767991310872058"),
-			java.util.Map.entry("LPL", "98767991314006698"),
-			java.util.Map.entry("LEC", "98767991302996019"),
-			java.util.Map.entry("LCS", "98767991299243165"),
-			java.util.Map.entry("LCP", "113476371197627891"),
-			java.util.Map.entry("CBLOL", "98767991332355509"),
-			java.util.Map.entry("FIRST_STAND", "113464388705111224"),
-			java.util.Map.entry("WORLDS", "98767975604431411"),
-			java.util.Map.entry("MSI", "98767991325878492"));
+	private static final java.util.Map<String, String> LEAGUE_IDS = LeagueConstants.LEAGUE_IDS;
 
 	@Value("${lolesports.riot-api.key}")
 	private String RIOT_API_KEY;

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatch.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatch.java
@@ -47,6 +47,11 @@ public class LeagueMatch {
 	@Column(columnDefinition = "TEXT")
 	private String matchDetailsJson;
 
+	private Integer seasonYear;
+
+	@Column(length = 20)
+	private String seasonSplit;
+
 	private LocalDateTime lastUpdated;
 
 	public void update(String leagueName, String matchTitle, LocalDateTime matchDate, String state,
@@ -70,6 +75,11 @@ public class LeagueMatch {
 		this.hasVod = hasVod;
 		this.matchDetailsJson = matchDetailsJson;
 		this.lastUpdated = lastUpdated;
+	}
+
+	public void applySeason(Integer seasonYear, String seasonSplit) {
+		this.seasonYear = seasonYear;
+		this.seasonSplit = seasonSplit;
 	}
 
 	public void updateExternalTeamIds(String blueExternalTeamId, String redExternalTeamId) {

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.lolesports.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -44,7 +45,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			WHERE m.leagueName = :leagueName
 			  AND m.matchDate >= :start
 			  AND m.matchDate < :end
 			ORDER BY m.matchDate ASC
@@ -57,7 +58,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			WHERE m.leagueName = :leagueName
 			  AND m.matchDate >= :start
 			  AND m.matchDate < :end
 			  AND (
@@ -78,7 +79,9 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			WHERE m.leagueName = :leagueName
+			  AND (:seasonYear IS NULL OR m.seasonYear = :seasonYear)
+			  AND (:seasonSplit IS NULL OR m.seasonSplit = :seasonSplit)
 			  AND (:cursorId IS NULL
 					OR m.matchDate < :cursorDate
 					OR (m.matchDate = :cursorDate AND m.id < :cursorId))
@@ -86,6 +89,8 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 			""")
 	List<LeagueMatch> findMobileMatchPage(
 			@Param("leagueName") String leagueName,
+			@Param("seasonYear") Integer seasonYear,
+			@Param("seasonSplit") String seasonSplit,
 			@Param("cursorDate") LocalDateTime cursorDate,
 			@Param("cursorId") String cursorId,
 			Pageable pageable);
@@ -93,7 +98,9 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE UPPER(m.leagueName) = UPPER(:leagueName)
+			WHERE m.leagueName = :leagueName
+			  AND (:seasonYear IS NULL OR m.seasonYear = :seasonYear)
+			  AND (:seasonSplit IS NULL OR m.seasonSplit = :seasonSplit)
 			  AND (
 					LOWER(m.blueTeamName) = LOWER(:teamName)
 					OR LOWER(m.redTeamName) = LOWER(:teamName)
@@ -109,9 +116,65 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 			@Param("leagueName") String leagueName,
 			@Param("teamName") String teamName,
 			@Param("teamCode") String teamCode,
+			@Param("seasonYear") Integer seasonYear,
+			@Param("seasonSplit") String seasonSplit,
 			@Param("cursorDate") LocalDateTime cursorDate,
 			@Param("cursorId") String cursorId,
 			Pageable pageable);
+
+	interface SeasonOptionRow {
+		Integer getSeasonYear();
+
+		String getSeasonSplit();
+	}
+
+	@Query("""
+			SELECT DISTINCT m.seasonYear AS seasonYear, m.seasonSplit AS seasonSplit
+			FROM LeagueMatch m
+			WHERE m.leagueName = :leagueName
+			  AND m.seasonYear IS NOT NULL
+			  AND m.seasonSplit IS NOT NULL
+			ORDER BY m.seasonYear DESC, m.seasonSplit ASC
+			""")
+	List<SeasonOptionRow> findSeasonOptions(@Param("leagueName") String leagueName);
+
+	@Query("SELECT DISTINCT m.leagueName FROM LeagueMatch m")
+	List<String> findDistinctLeagueNames();
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+			UPDATE LeagueMatch m
+			SET m.seasonYear = :seasonYear, m.seasonSplit = :seasonSplit
+			WHERE m.leagueName = :leagueName
+			  AND m.matchDate >= :start
+			  AND m.matchDate < :end
+			  AND m.seasonYear IS NULL
+			""")
+	int fillSeasonForRange(
+			@Param("leagueName") String leagueName,
+			@Param("start") LocalDateTime start,
+			@Param("end") LocalDateTime end,
+			@Param("seasonYear") Integer seasonYear,
+			@Param("seasonSplit") String seasonSplit);
+
+	@Query("""
+			SELECT COUNT(m)
+			FROM LeagueMatch m
+			WHERE m.leagueName = :leagueName
+			  AND m.matchDate >= :start
+			  AND m.matchDate < :end
+			  AND m.seasonYear IS NULL
+			""")
+	long countSeasonFillTargets(
+			@Param("leagueName") String leagueName,
+			@Param("start") LocalDateTime start,
+			@Param("end") LocalDateTime end);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("UPDATE LeagueMatch m SET m.seasonYear = NULL, m.seasonSplit = NULL WHERE m.leagueName = :leagueName")
+	int clearSeasonForLeague(@Param("leagueName") String leagueName);
+
+	long countByLeagueNameAndSeasonYearIsNull(String leagueName);
 
 	@Query(value = """
 			SELECT DATE(m.match_date) AS matchDay,

--- a/src/main/java/com/toy/nar/app/lolesports/season/LeagueMatchSeasonBackfillService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/season/LeagueMatchSeasonBackfillService.java
@@ -1,0 +1,102 @@
+package com.toy.nar.app.lolesports.season;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * league_match의 시즌 컬럼(season_year/season_split)을 토너먼트 기간 기준으로 채우는 백필.
+ *
+ * 안전 설계:
+ * - season_year IS NULL 인 행만 갱신한다 (기존 값 보존, 멱등)
+ * - 겹치는 토너먼트 기간은 짧은(더 구체적인) 기간부터 적용한다
+ * - force=true 면 해당 리그의 시즌 값을 먼저 비우고 다시 채운다 (재계산)
+ * - dryRun=true 면 갱신 없이 대상 건수만 집계한다
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LeagueMatchSeasonBackfillService {
+
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final LeagueSeasonResolver seasonResolver;
+
+	public record WindowResult(
+			String tournamentSlug,
+			Integer seasonYear,
+			String seasonSplit,
+			String startDate,
+			String endDate,
+			long matchedCount) {
+	}
+
+	public record LeagueResult(
+			String league,
+			List<WindowResult> windows,
+			long remainingWithoutSeason) {
+	}
+
+	public record BackfillResult(
+			boolean dryRun,
+			boolean force,
+			long totalMatched,
+			List<LeagueResult> leagues) {
+	}
+
+	@Transactional
+	public BackfillResult backfill(boolean dryRun, boolean force) {
+		List<String> leagues = leagueMatchRepository.findDistinctLeagueNames();
+		List<LeagueResult> leagueResults = new ArrayList<>();
+		long totalMatched = 0;
+
+		for (String league : leagues) {
+			List<LeagueSeasonResolver.SeasonWindow> windows = seasonResolver.windowsFor(league).stream()
+					.sorted(Comparator.comparingLong(LeagueSeasonResolver.SeasonWindow::durationDays))
+					.toList();
+			if (windows.isEmpty()) {
+				log.warn("시즌 백필 - 토너먼트 정보를 찾지 못해 건너뜀: {}", league);
+				leagueResults.add(new LeagueResult(
+						league,
+						List.of(),
+						leagueMatchRepository.countByLeagueNameAndSeasonYearIsNull(league)));
+				continue;
+			}
+
+			if (force && !dryRun) {
+				int cleared = leagueMatchRepository.clearSeasonForLeague(league);
+				log.info("시즌 백필 - {} 시즌 값 초기화: {}건", league, cleared);
+			}
+
+			List<WindowResult> windowResults = new ArrayList<>();
+			for (LeagueSeasonResolver.SeasonWindow window : windows) {
+				LocalDateTime start = window.startDate().atStartOfDay();
+				LocalDateTime end = window.endDate().plusDays(1).atStartOfDay();
+				long matched = dryRun
+						? leagueMatchRepository.countSeasonFillTargets(league, start, end)
+						: leagueMatchRepository.fillSeasonForRange(
+								league, start, end, window.season().year(), window.season().split());
+				totalMatched += matched;
+				windowResults.add(new WindowResult(
+						window.tournamentSlug(),
+						window.season().year(),
+						window.season().split(),
+						window.startDate().toString(),
+						window.endDate().toString(),
+						matched));
+			}
+
+			long remaining = leagueMatchRepository.countByLeagueNameAndSeasonYearIsNull(league);
+			leagueResults.add(new LeagueResult(league, windowResults, remaining));
+			log.info("시즌 백필 - {} 완료 (dryRun={}): 미해석 잔여 {}건", league, dryRun, remaining);
+		}
+
+		return new BackfillResult(dryRun, force, totalMatched, leagueResults);
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/season/LeagueSeasonResolver.java
+++ b/src/main/java/com/toy/nar/app/lolesports/season/LeagueSeasonResolver.java
@@ -1,0 +1,196 @@
+package com.toy.nar.app.lolesports.season;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.lolesports.LeagueConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * lolesports 토너먼트 기간(getTournamentsForLeague)을 기준으로
+ * 매치 일시 → 시즌(연도/스플릿)을 해석한다. 외부 API 실패 시 빈 결과를 돌려주고 동기화를 막지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LeagueSeasonResolver {
+
+	private static final Duration CACHE_TTL = Duration.ofHours(6);
+	private static final Pattern YEAR_PATTERN = Pattern.compile("(20\\d{2})");
+	private static final Map<String, String> SPLIT_KEYWORDS = Map.ofEntries(
+			Map.entry("spring", "Spring"),
+			Map.entry("summer", "Summer"),
+			Map.entry("winter", "Winter"),
+			Map.entry("fall", "Fall"),
+			Map.entry("autumn", "Fall"),
+			Map.entry("msi", "MSI"),
+			Map.entry("worlds", "Worlds"),
+			Map.entry("first_stand", "First Stand"),
+			Map.entry("firststand", "First Stand"),
+			Map.entry("cup", "Cup"),
+			Map.entry("playoffs", "Playoffs"),
+			Map.entry("regional", "Regional"));
+	private static final int MAX_SPLIT_LENGTH = 20;
+
+	private final WebClient webClient;
+
+	@Value("${lolesports.riot-api.key}")
+	private String riotApiKey;
+
+	private final Map<String, CachedWindows> cacheByLeague = new ConcurrentHashMap<>();
+
+	public record LeagueSeason(Integer year, String split) {
+	}
+
+	public record SeasonWindow(String tournamentSlug, LocalDate startDate, LocalDate endDate, LeagueSeason season) {
+		public long durationDays() {
+			return ChronoUnit.DAYS.between(startDate, endDate);
+		}
+	}
+
+	public Optional<LeagueSeason> resolve(String leagueName, LocalDateTime matchDateUtc) {
+		if (leagueName == null || matchDateUtc == null) {
+			return Optional.empty();
+		}
+		LocalDate matchDay = matchDateUtc.toLocalDate();
+		// 기간이 겹치면 더 짧은(더 구체적인) 토너먼트를 우선한다
+		return windowsFor(leagueName).stream()
+				.filter(window -> !matchDay.isBefore(window.startDate()) && !matchDay.isAfter(window.endDate()))
+				.min(Comparator.comparingLong(SeasonWindow::durationDays))
+				.map(SeasonWindow::season);
+	}
+
+	public List<SeasonWindow> windowsFor(String leagueName) {
+		String normalized = leagueName.trim().toUpperCase(Locale.ROOT);
+		CachedWindows cached = cacheByLeague.get(normalized);
+		if (cached != null && cached.fetchedAt().plus(CACHE_TTL).isAfter(Instant.now())) {
+			return cached.windows();
+		}
+		List<SeasonWindow> windows = fetchWindows(normalized);
+		if (!windows.isEmpty()) {
+			cacheByLeague.put(normalized, new CachedWindows(Instant.now(), windows));
+		}
+		return windows;
+	}
+
+	private List<SeasonWindow> fetchWindows(String leagueName) {
+		String leagueId = LeagueConstants.LEAGUE_IDS.get(leagueName);
+		if (leagueId == null) {
+			return List.of();
+		}
+		try {
+			JsonNode root = webClient.get()
+					.uri(uri -> uri
+							.scheme("https")
+							.host("esports-api.lolesports.com")
+							.path("/persisted/gw/getTournamentsForLeague")
+							.queryParam("hl", "ko-KR")
+							.queryParam("leagueId", leagueId)
+							.build())
+					.header("x-api-key", riotApiKey)
+					.header("Referer", "https://lolesports.com/")
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+			return parseWindows(leagueName, root);
+		} catch (Exception e) {
+			log.warn("리그 토너먼트 조회 실패 - 시즌 해석을 건너뜁니다: {}", leagueName, e);
+			return List.of();
+		}
+	}
+
+	private List<SeasonWindow> parseWindows(String leagueName, JsonNode root) {
+		if (root == null) {
+			return List.of();
+		}
+		List<SeasonWindow> windows = new ArrayList<>();
+		for (JsonNode league : root.path("data").path("leagues")) {
+			for (JsonNode tournament : league.path("tournaments")) {
+				String slug = tournament.path("slug").asText("");
+				LocalDate start = parseDate(tournament.path("startDate").asText(null));
+				LocalDate end = parseDate(tournament.path("endDate").asText(null));
+				if (slug.isBlank() || start == null || end == null) {
+					continue;
+				}
+				LeagueSeason season = parseSeason(leagueName, slug, start);
+				if (season != null) {
+					windows.add(new SeasonWindow(slug, start, end, season));
+				}
+			}
+		}
+		return List.copyOf(windows);
+	}
+
+	private LocalDate parseDate(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		try {
+			return LocalDate.parse(value);
+		} catch (RuntimeException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * 토너먼트 슬러그에서 시즌을 파싱한다. 예: "lck_spring_2026" → (2026, "Spring").
+	 * 알려진 키워드가 없으면 리그/연도 토큰을 제외한 나머지를 정리해 스플릿명으로 쓰고,
+	 * 남는 토큰이 없으면 "Season"으로 둔다.
+	 */
+	static LeagueSeason parseSeason(String leagueName, String slug, LocalDate startDate) {
+		String lowerSlug = slug.toLowerCase(Locale.ROOT);
+		Integer year = null;
+		Matcher yearMatcher = YEAR_PATTERN.matcher(lowerSlug);
+		if (yearMatcher.find()) {
+			year = Integer.parseInt(yearMatcher.group(1));
+		} else if (startDate != null) {
+			year = startDate.getYear();
+		}
+		if (year == null) {
+			return null;
+		}
+
+		for (Map.Entry<String, String> keyword : SPLIT_KEYWORDS.entrySet()) {
+			if (lowerSlug.contains(keyword.getKey())) {
+				return new LeagueSeason(year, keyword.getValue());
+			}
+		}
+
+		String leagueToken = leagueName == null ? "" : leagueName.toLowerCase(Locale.ROOT);
+		StringBuilder remainder = new StringBuilder();
+		for (String token : lowerSlug.split("_")) {
+			if (token.isBlank() || token.equals(leagueToken) || token.matches("20\\d{2}")) {
+				continue;
+			}
+			if (!remainder.isEmpty()) {
+				remainder.append(' ');
+			}
+			remainder.append(Character.toUpperCase(token.charAt(0))).append(token.substring(1));
+		}
+		String split = remainder.isEmpty() ? "Season" : remainder.toString();
+		if (split.length() > MAX_SPLIT_LENGTH) {
+			split = split.substring(0, MAX_SPLIT_LENGTH).trim();
+		}
+		return new LeagueSeason(year, split);
+	}
+
+	private record CachedWindows(Instant fetchedAt, List<SeasonWindow> windows) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -67,8 +67,15 @@ public class MobileScheduleService {
 		List<MobileScheduleFilterResponse.TeamOption> teams = findFilterTeams(normalizedLeague).stream()
 				.map(this::toTeamOption)
 				.toList();
+		List<MobileScheduleFilterResponse.SeasonOption> seasons = leagueMatchRepository
+				.findSeasonOptions(normalizedLeague).stream()
+				.map(row -> new MobileScheduleFilterResponse.SeasonOption(
+						row.getSeasonYear(),
+						row.getSeasonSplit(),
+						row.getSeasonYear() + " " + row.getSeasonSplit()))
+				.toList();
 
-		return new MobileScheduleFilterResponse(DEFAULT_LEAGUE, leagues, teams);
+		return new MobileScheduleFilterResponse(DEFAULT_LEAGUE, leagues, teams, seasons);
 	}
 
 	public MobileScheduleCalendarResponse getCalendar(YearMonth month, String league, Long teamId) {
@@ -124,9 +131,16 @@ public class MobileScheduleService {
 		return new MobileScheduleListResponse(date.toString(), normalizedLeague, teamId, matches);
 	}
 
-	public MobileMatchPageResponse getMatchPage(String league, Long teamId, String cursor, Integer size) {
+	public MobileMatchPageResponse getMatchPage(
+			String league,
+			Long teamId,
+			Integer seasonYear,
+			String seasonSplit,
+			String cursor,
+			Integer size) {
 		String normalizedLeague = normalizeLeague(league);
 		TeamFilter teamFilter = resolveTeamFilter(teamId);
+		String normalizedSplit = seasonSplit == null || seasonSplit.isBlank() ? null : seasonSplit.trim();
 		int pageSize = size == null
 				? DEFAULT_PAGE_SIZE
 				: Math.max(1, Math.min(size, MAX_PAGE_SIZE));
@@ -136,6 +150,8 @@ public class MobileScheduleService {
 		List<LeagueMatch> fetched = teamFilter == null
 				? leagueMatchRepository.findMobileMatchPage(
 						normalizedLeague,
+						seasonYear,
+						normalizedSplit,
 						matchCursor != null ? matchCursor.matchDate() : null,
 						matchCursor != null ? matchCursor.matchId() : null,
 						fetchLimit)
@@ -143,6 +159,8 @@ public class MobileScheduleService {
 						normalizedLeague,
 						teamFilter.name(),
 						teamFilter.code(),
+						seasonYear,
+						normalizedSplit,
 						matchCursor != null ? matchCursor.matchDate() : null,
 						matchCursor != null ? matchCursor.matchId() : null,
 						fetchLimit);

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleFilterResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleFilterResponse.java
@@ -1,11 +1,15 @@
 package com.toy.nar.app.mobile.schedule.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record MobileScheduleFilterResponse(
 		String defaultLeague,
 		List<LeagueOption> leagues,
-		List<TeamOption> teams) {
+		List<TeamOption> teams,
+		@Schema(description = "선택한 리그에서 필터로 쓸 수 있는 시즌 목록 (최신순)")
+		List<SeasonOption> seasons) {
 
 	public record LeagueOption(
 			String code,
@@ -17,5 +21,14 @@ public record MobileScheduleFilterResponse(
 			String teamName,
 			String teamCode,
 			String teamImageUrl) {
+	}
+
+	public record SeasonOption(
+			@Schema(description = "시즌 연도", example = "2026")
+			int year,
+			@Schema(description = "스플릿", example = "Spring")
+			String split,
+			@Schema(description = "표시용 라벨", example = "2026 Spring")
+			String label) {
 	}
 }

--- a/src/main/resources/db/migration/V41__Add_season_to_league_match.sql
+++ b/src/main/resources/db/migration/V41__Add_season_to_league_match.sql
@@ -1,0 +1,11 @@
+-- league_match에 시즌 정보 컬럼 추가 (lolesports 토너먼트 기간으로 채움, 미해석 시 NULL)
+ALTER TABLE league_match
+    ADD COLUMN season_year INT NULL,
+    ADD COLUMN season_split VARCHAR(20) NULL;
+
+-- 시즌 필터 + 커서 페이지네이션용 인덱스
+CREATE INDEX idx_league_match_season_date ON league_match (league_name, season_year, season_split, match_date DESC);
+
+-- 커서 정렬(match_date DESC, id DESC)이 filesort 없이 인덱스를 타도록 기존 인덱스에 id 포함
+DROP INDEX idx_league_match_name_date ON league_match;
+CREATE INDEX idx_league_match_name_date_id ON league_match (league_name, match_date DESC, id DESC);

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -35,7 +35,7 @@ class MobileMatchControllerTest {
 
 	@Test
 	void getMatchesReturnsCursorPageShape() throws Exception {
-		when(mobileScheduleService.getMatchPage("LCK", null, null, 20))
+		when(mobileScheduleService.getMatchPage("LCK", null, null, null, null, 20))
 				.thenReturn(new MobileMatchPageResponse(
 						"LCK",
 						null,

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -40,14 +40,18 @@ class MobileScheduleControllerTest {
 		when(mobileScheduleService.getFilters("LCK")).thenReturn(new MobileScheduleFilterResponse(
 				"LCK",
 				List.of(new MobileScheduleFilterResponse.LeagueOption("LCK", "LCK")),
-				List.of(new MobileScheduleFilterResponse.TeamOption(1L, "T1", "T1", "https://example.com/t1.png"))));
+				List.of(new MobileScheduleFilterResponse.TeamOption(1L, "T1", "T1", "https://example.com/t1.png")),
+				List.of(new MobileScheduleFilterResponse.SeasonOption(2026, "Spring", "2026 Spring"))));
 
 		mockMvc.perform(get("/api/mobile/schedules/filters"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.defaultLeague").value("LCK"))
 				.andExpect(jsonPath("$.leagues[0].code").value("LCK"))
 				.andExpect(jsonPath("$.teams[0].teamId").value(1L))
-				.andExpect(jsonPath("$.teams[0].teamName").value("T1"));
+				.andExpect(jsonPath("$.teams[0].teamName").value("T1"))
+				.andExpect(jsonPath("$.seasons[0].year").value(2026))
+				.andExpect(jsonPath("$.seasons[0].split").value("Spring"))
+				.andExpect(jsonPath("$.seasons[0].label").value("2026 Spring"));
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceLeagueNameTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceLeagueNameTest.java
@@ -35,6 +35,8 @@ class LeagueMatchServiceLeagueNameTest {
 	@Mock
 	private LeagueMatchGameRepository leagueMatchGameRepository;
 	@Mock
+	private com.toy.nar.app.lolesports.season.LeagueSeasonResolver leagueSeasonResolver;
+	@Mock
 	private TeamRepository teamRepository;
 	@Mock
 	private TeamExternalIdentityRepository teamExternalIdentityRepository;
@@ -54,6 +56,7 @@ class LeagueMatchServiceLeagueNameTest {
 		leagueMatchService = new LeagueMatchService(
 				leagueMatchRepository,
 				leagueMatchGameRepository,
+				leagueSeasonResolver,
 				teamRepository,
 				teamExternalIdentityRepository,
 				gameExternalIdentityRepository,

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePerformanceBaselineTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePerformanceBaselineTest.java
@@ -58,6 +58,7 @@ class LeagueMatchServicePerformanceBaselineTest {
         leagueMatchService = new LeagueMatchService(
                 leagueMatchRepository,
                 leagueMatchGameRepository,
+                null,
                 teamRepository,
                 teamExternalIdentityRepository,
                 null,

--- a/src/test/java/com/toy/nar/app/lolesports/season/LeagueMatchSeasonBackfillServiceTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/season/LeagueMatchSeasonBackfillServiceTest.java
@@ -1,0 +1,117 @@
+package com.toy.nar.app.lolesports.season;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LeagueMatchSeasonBackfillServiceTest {
+
+	private LeagueMatchRepository leagueMatchRepository;
+	private LeagueSeasonResolver seasonResolver;
+	private LeagueMatchSeasonBackfillService service;
+
+	@BeforeEach
+	void setUp() {
+		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		seasonResolver = mock(LeagueSeasonResolver.class);
+		service = new LeagueMatchSeasonBackfillService(leagueMatchRepository, seasonResolver);
+	}
+
+	@Test
+	void dryRunCountsTargetsWithoutUpdating() {
+		when(leagueMatchRepository.findDistinctLeagueNames()).thenReturn(List.of("LCK"));
+		when(seasonResolver.windowsFor("LCK")).thenReturn(List.of(window(
+				"lck_spring_2026", LocalDate.of(2026, 1, 10), LocalDate.of(2026, 4, 20), 2026, "Spring")));
+		when(leagueMatchRepository.countSeasonFillTargets(
+				"LCK",
+				LocalDateTime.of(2026, 1, 10, 0, 0),
+				LocalDateTime.of(2026, 4, 21, 0, 0)))
+				.thenReturn(42L);
+		when(leagueMatchRepository.countByLeagueNameAndSeasonYearIsNull("LCK")).thenReturn(42L);
+
+		LeagueMatchSeasonBackfillService.BackfillResult result = service.backfill(true, false);
+
+		assertThat(result.dryRun()).isTrue();
+		assertThat(result.totalMatched()).isEqualTo(42);
+		assertThat(result.leagues()).singleElement().satisfies(league -> {
+			assertThat(league.league()).isEqualTo("LCK");
+			assertThat(league.windows()).singleElement()
+					.satisfies(window -> assertThat(window.matchedCount()).isEqualTo(42));
+		});
+		verify(leagueMatchRepository, never()).fillSeasonForRange(anyString(), any(), any(), any(), any());
+		verify(leagueMatchRepository, never()).clearSeasonForLeague(anyString());
+	}
+
+	@Test
+	void appliesShorterWindowsFirstSoSpecificTournamentWins() {
+		when(leagueMatchRepository.findDistinctLeagueNames()).thenReturn(List.of("LCK"));
+		// 전체 시즌(긴 기간)과 그 안에 포함된 컵(짧은 기간)이 겹치는 상황
+		when(seasonResolver.windowsFor("LCK")).thenReturn(List.of(
+				window("lck_2026", LocalDate.of(2026, 1, 1), LocalDate.of(2026, 8, 31), 2026, "Season"),
+				window("lck_cup_2026", LocalDate.of(2026, 1, 10), LocalDate.of(2026, 2, 10), 2026, "Cup")));
+		when(leagueMatchRepository.fillSeasonForRange(anyString(), any(), any(), any(), any())).thenReturn(10);
+		when(leagueMatchRepository.countByLeagueNameAndSeasonYearIsNull("LCK")).thenReturn(0L);
+
+		service.backfill(false, false);
+
+		org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(leagueMatchRepository);
+		inOrder.verify(leagueMatchRepository).fillSeasonForRange(
+				"LCK",
+				LocalDateTime.of(2026, 1, 10, 0, 0),
+				LocalDateTime.of(2026, 2, 11, 0, 0),
+				2026,
+				"Cup");
+		inOrder.verify(leagueMatchRepository).fillSeasonForRange(
+				"LCK",
+				LocalDateTime.of(2026, 1, 1, 0, 0),
+				LocalDateTime.of(2026, 9, 1, 0, 0),
+				2026,
+				"Season");
+	}
+
+	@Test
+	void forceClearsSeasonsBeforeRefilling() {
+		when(leagueMatchRepository.findDistinctLeagueNames()).thenReturn(List.of("LCK"));
+		when(seasonResolver.windowsFor("LCK")).thenReturn(List.of(window(
+				"lck_spring_2026", LocalDate.of(2026, 1, 10), LocalDate.of(2026, 4, 20), 2026, "Spring")));
+		when(leagueMatchRepository.fillSeasonForRange(anyString(), any(), any(), any(), any())).thenReturn(5);
+		when(leagueMatchRepository.countByLeagueNameAndSeasonYearIsNull("LCK")).thenReturn(0L);
+
+		service.backfill(false, true);
+
+		verify(leagueMatchRepository).clearSeasonForLeague("LCK");
+	}
+
+	@Test
+	void leagueWithoutTournamentInfoIsSkippedSafely() {
+		when(leagueMatchRepository.findDistinctLeagueNames()).thenReturn(List.of("UNKNOWN"));
+		when(seasonResolver.windowsFor("UNKNOWN")).thenReturn(List.of());
+		when(leagueMatchRepository.countByLeagueNameAndSeasonYearIsNull("UNKNOWN")).thenReturn(7L);
+
+		LeagueMatchSeasonBackfillService.BackfillResult result = service.backfill(false, false);
+
+		assertThat(result.leagues()).singleElement().satisfies(league -> {
+			assertThat(league.windows()).isEmpty();
+			assertThat(league.remainingWithoutSeason()).isEqualTo(7);
+		});
+		verify(leagueMatchRepository, never()).fillSeasonForRange(anyString(), any(), any(), any(), any());
+	}
+
+	private LeagueSeasonResolver.SeasonWindow window(
+			String slug, LocalDate start, LocalDate end, int year, String split) {
+		return new LeagueSeasonResolver.SeasonWindow(
+				slug, start, end, new LeagueSeasonResolver.LeagueSeason(year, split));
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/season/LeagueSeasonResolverTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/season/LeagueSeasonResolverTest.java
@@ -1,0 +1,64 @@
+package com.toy.nar.app.lolesports.season;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LeagueSeasonResolverTest {
+
+	@Test
+	void parsesStandardSplitSlugs() {
+		assertSeason("LCK", "lck_spring_2026", 2026, "Spring");
+		assertSeason("LCK", "lck_summer_2025", 2025, "Summer");
+		assertSeason("LEC", "lec_winter_2026", 2026, "Winter");
+		assertSeason("WORLDS", "worlds_2025", 2025, "Worlds");
+		assertSeason("MSI", "msi_2026", 2026, "MSI");
+	}
+
+	@Test
+	void parsesFirstStandAndCupSlugs() {
+		assertSeason("FIRST_STAND", "first_stand_2026", 2026, "First Stand");
+		assertSeason("LCK", "lck_cup_2026", 2026, "Cup");
+	}
+
+	@Test
+	void fallsBackToStartDateYearWhenSlugHasNoYear() {
+		LeagueSeasonResolver.LeagueSeason season = LeagueSeasonResolver.parseSeason(
+				"LCK", "lck_spring", LocalDate.of(2026, 1, 15));
+		assertThat(season.year()).isEqualTo(2026);
+		assertThat(season.split()).isEqualTo("Spring");
+	}
+
+	@Test
+	void unknownSlugUsesPrettifiedRemainderAsSplit() {
+		LeagueSeasonResolver.LeagueSeason season = LeagueSeasonResolver.parseSeason(
+				"LCK", "lck_2026_rounds_1_2", LocalDate.of(2026, 1, 15));
+		assertThat(season.year()).isEqualTo(2026);
+		assertThat(season.split()).isEqualTo("Rounds 1 2");
+	}
+
+	@Test
+	void slugWithOnlyLeagueAndYearFallsBackToSeasonLabel() {
+		LeagueSeasonResolver.LeagueSeason season = LeagueSeasonResolver.parseSeason(
+				"LCK", "lck_2026", LocalDate.of(2026, 1, 15));
+		assertThat(season.year()).isEqualTo(2026);
+		assertThat(season.split()).isEqualTo("Season");
+	}
+
+	@Test
+	void splitIsTruncatedToColumnLength() {
+		LeagueSeasonResolver.LeagueSeason season = LeagueSeasonResolver.parseSeason(
+				"LCK", "lck_2026_super_long_tournament_stage_name_overflow", LocalDate.of(2026, 1, 15));
+		assertThat(season.split().length()).isLessThanOrEqualTo(20);
+	}
+
+	private void assertSeason(String league, String slug, int expectedYear, String expectedSplit) {
+		LeagueSeasonResolver.LeagueSeason season = LeagueSeasonResolver.parseSeason(
+				league, slug, LocalDate.of(expectedYear, 1, 1));
+		assertThat(season).isNotNull();
+		assertThat(season.year()).isEqualTo(expectedYear);
+		assertThat(season.split()).isEqualTo(expectedSplit);
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -180,10 +180,10 @@ class MobileScheduleServiceTest {
 		LeagueMatch first = match("match-2", "LCK", LocalDateTime.of(2026, 4, 2, 9, 0), "T1", "GEN", "completed");
 		LeagueMatch second = match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "DK", "HLE", "completed");
 		LeagueMatch overflow = match("match-0", "LCK", LocalDateTime.of(2026, 3, 31, 9, 0), "KT", "NS", "completed");
-		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, PageRequest.of(0, 3)))
+		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, null, null, PageRequest.of(0, 3)))
 				.thenReturn(List.of(first, second, overflow));
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, 2);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, null, 2);
 
 		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
 				.containsExactly("match-2", "match-1");
@@ -196,10 +196,10 @@ class MobileScheduleServiceTest {
 
 	@Test
 	void getMatchPageReturnsNoCursorOnLastPage() {
-		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, PageRequest.of(0, 21)))
+		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, null, null, PageRequest.of(0, 21)))
 				.thenReturn(List.of(match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed")));
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, null, null);
 
 		assertThat(response.matches()).hasSize(1);
 		assertThat(response.hasNext()).isFalse();
@@ -212,17 +212,21 @@ class MobileScheduleServiceTest {
 				"2026-04-01T09:00:00|match-1".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 		when(leagueMatchRepository.findMobileMatchPage(
 				"LCK",
+				null,
+				null,
 				LocalDateTime.of(2026, 4, 1, 9, 0),
 				"match-1",
 				PageRequest.of(0, 21)))
 				.thenReturn(List.of());
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", null, cursor, null);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, cursor, null);
 
 		assertThat(response.matches()).isEmpty();
 		assertThat(response.hasNext()).isFalse();
 		verify(leagueMatchRepository).findMobileMatchPage(
 				"LCK",
+				null,
+				null,
 				LocalDateTime.of(2026, 4, 1, 9, 0),
 				"match-1",
 				PageRequest.of(0, 21));
@@ -232,18 +236,46 @@ class MobileScheduleServiceTest {
 	void getMatchPageUsesTeamFilterWhenTeamIdExists() {
 		Team t1 = team(1L, "T1", "T1", "https://example.com/t1.png");
 		when(teamRepository.findById(1L)).thenReturn(Optional.of(t1));
-		when(leagueMatchRepository.findMobileTeamMatchPage("LCK", "T1", "T1", null, null, PageRequest.of(0, 21)))
+		when(leagueMatchRepository.findMobileTeamMatchPage("LCK", "T1", "T1", null, null, null, null, PageRequest.of(0, 21)))
 				.thenReturn(List.of());
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", 1L, null, null);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", 1L, null, null, null, null);
 
 		assertThat(response.teamId()).isEqualTo(1L);
-		verify(leagueMatchRepository).findMobileTeamMatchPage("LCK", "T1", "T1", null, null, PageRequest.of(0, 21));
+		verify(leagueMatchRepository).findMobileTeamMatchPage("LCK", "T1", "T1", null, null, null, null, PageRequest.of(0, 21));
+	}
+
+	@Test
+	void getMatchPagePassesSeasonFilterToRepository() {
+		when(leagueMatchRepository.findMobileMatchPage("LCK", 2026, "Spring", null, null, PageRequest.of(0, 21)))
+				.thenReturn(List.of());
+
+		service.getMatchPage("LCK", null, 2026, "Spring", null, null);
+
+		verify(leagueMatchRepository).findMobileMatchPage("LCK", 2026, "Spring", null, null, PageRequest.of(0, 21));
+	}
+
+	@Test
+	void getFiltersIncludesSeasonOptions() {
+		when(teamRepository.findAllByCodeIn(org.mockito.ArgumentMatchers.anyList())).thenReturn(List.of());
+		LeagueMatchRepository.SeasonOptionRow row = mock(LeagueMatchRepository.SeasonOptionRow.class);
+		when(row.getSeasonYear()).thenReturn(2026);
+		when(row.getSeasonSplit()).thenReturn("Spring");
+		when(leagueMatchRepository.findSeasonOptions("LCK")).thenReturn(List.of(row));
+
+		MobileScheduleFilterResponse response = service.getFilters("LCK");
+
+		assertThat(response.seasons()).singleElement()
+				.satisfies(season -> {
+					assertThat(season.year()).isEqualTo(2026);
+					assertThat(season.split()).isEqualTo("Spring");
+					assertThat(season.label()).isEqualTo("2026 Spring");
+				});
 	}
 
 	@Test
 	void getMatchPageWithInvalidCursorThrowsInvalidInput() {
-		assertThatThrownBy(() -> service.getMatchPage("LCK", null, "not-a-cursor", null))
+		assertThatThrownBy(() -> service.getMatchPage("LCK", null, null, null, "not-a-cursor", null))
 				.isInstanceOf(CustomException.class)
 				.extracting("errorCode")
 				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);


### PR DESCRIPTION
## 배포 내용
시즌 필터 및 DB 최적화 (PR #178)

- V41 마이그레이션: season_year/season_split 컬럼 + 인덱스 재구성
- GET /api/mobile/matches에 seasonYear/split 필터, filters에 seasons 목록
- 동기화 시 시즌 자동 스탬핑
- 시즌 백필 admin API (배포 후 dry-run → 실행 1회 필요)
- league_match 쿼리 인덱스 최적화

🤖 Generated with [Claude Code](https://claude.com/claude-code)