### PR TITLE
feat: 솔랭 감지 시 all_solo_rank 토픽으로도 푸시 발송

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/FirebaseMobilePushGateway.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/FirebaseMobilePushGateway.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
@@ -50,6 +51,35 @@ public class FirebaseMobilePushGateway implements MobilePushGateway {
 			collectInvalidTokens(batchTokens, response.getResponses(), invalidTokens);
 		}
 		return new MobilePushResult(successCount, failureCount, List.copyOf(invalidTokens));
+	}
+
+	@Override
+	public void sendToTopic(String topic, MobilePushMessage message) {
+		FirebaseMessaging firebaseMessaging = firebaseMessagingProvider.getIfAvailable();
+		if (firebaseMessaging == null) {
+			throw new IllegalStateException("FCM 발송이 비활성화되어 있습니다.");
+		}
+		Message topicMessage = Message.builder()
+				.setNotification(Notification.builder()
+						.setTitle(message.title())
+						.setBody(message.body())
+						.build())
+				.putAllData(message.data())
+				.setAndroidConfig(AndroidConfig.builder()
+						.setPriority(AndroidConfig.Priority.HIGH)
+						.build())
+				.setApnsConfig(ApnsConfig.builder()
+						.setAps(Aps.builder()
+								.setSound("default")
+								.build())
+						.build())
+				.setTopic(topic)
+				.build();
+		try {
+			firebaseMessaging.send(topicMessage);
+		} catch (FirebaseMessagingException e) {
+			throw new IllegalStateException("FCM 토픽 발송에 실패했습니다.", e);
+		}
 	}
 
 	private BatchResponse sendBatch(

--- a/src/main/java/com/toy/nar/app/mobile/push/MobilePushGateway.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/MobilePushGateway.java
@@ -7,4 +7,10 @@ public interface MobilePushGateway {
 	boolean isAvailable();
 
 	MobilePushResult send(List<String> tokens, MobilePushMessage message);
+
+	/**
+	 * 지정한 FCM 토픽 구독자 전체에게 발송한다(예: 전체 선수 솔랭 알림).
+	 * 토큰 발송과 달리 구독자 집계 없이 토픽 하나로 보낸다.
+	 */
+	void sendToTopic(String topic, MobilePushMessage message);
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -20,6 +20,9 @@ public class PlayerSoloRankPushService {
 
 	private static final String PUSH_TYPE = "PLAYER_SOLO_RANK_STARTED";
 
+	/** '전체 선수 솔랭 알림'(앱에서 구독하는 FCM 토픽) — 모바일과 이름이 일치해야 한다. */
+	private static final String ALL_SOLO_RANK_TOPIC = "all_solo_rank";
+
 	private final MemberDeviceRepository deviceRepository;
 	private final PlayerSoloRankPushDeliveryRepository deliveryRepository;
 	private final MobilePushGateway pushGateway;
@@ -33,6 +36,11 @@ public class PlayerSoloRankPushService {
 			return;
 		}
 
+		MobilePushMessage message = buildMessage(player, gameId, championName, championImageUrl);
+
+		// 전체 선수 솔랭 알림 토픽 구독자에게 발송 (구독 여부와 무관). 게임당 1회.
+		sendToAllSoloRankTopic(player, gameId, message);
+
 		try {
 			List<MemberDevice> devices = deviceRepository.findActiveDevicesBySubscribedPlayerId(player.getId());
 			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
@@ -42,17 +50,23 @@ public class PlayerSoloRankPushService {
 							Collectors.toList()));
 
 			for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
-				sendToMember(
-						entry.getKey(),
-						entry.getValue(),
-						player,
-						gameId,
-						championName,
-						championImageUrl);
+				sendToMember(entry.getKey(), entry.getValue(), player, gameId, message);
 			}
 		} catch (Exception e) {
 			log.warn(
 					"Failed to prepare player solo rank pushes playerId={} gameId={}",
+					player.getId(),
+					gameId,
+					e);
+		}
+	}
+
+	private void sendToAllSoloRankTopic(Player player, String gameId, MobilePushMessage message) {
+		try {
+			pushGateway.sendToTopic(ALL_SOLO_RANK_TOPIC, message);
+		} catch (Exception e) {
+			log.warn(
+					"Failed to send all-solo-rank topic push playerId={} gameId={}",
 					player.getId(),
 					gameId,
 					e);
@@ -64,16 +78,13 @@ public class PlayerSoloRankPushService {
 			List<MemberDevice> devices,
 			Player player,
 			String gameId,
-			String championName,
-			String championImageUrl) {
+			MobilePushMessage message) {
 		try {
 			if (deliveryRepository.reserve(memberId, player.getId(), gameId) == 0) {
 				return;
 			}
 			List<String> tokens = devices.stream().map(MemberDevice::getFcmToken).toList();
-			MobilePushResult result = pushGateway.send(
-					tokens,
-					buildMessage(player, gameId, championName, championImageUrl));
+			MobilePushResult result = pushGateway.send(tokens, message);
 			if (!result.invalidTokens().isEmpty()) {
 				deactivateInvalidTokens(result.invalidTokens(), player.getId(), gameId);
 			}

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
@@ -18,7 +18,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,6 +64,31 @@ class PlayerSoloRankPushServiceTest {
 		verify(deliveryRepository).markSent(7L, 10L, "game-1");
 		verify(deliveryRepository).markFailed(8L, 10L, "game-1", "FCM 전송 성공 기기가 없습니다.");
 		verify(deviceRepository).deactivateByFcmTokenIn(List.of("token-2"));
+	}
+
+	@Test
+	void sendsToAllSoloRankTopicOncePerGame() {
+		Player player = player(10L, "Faker");
+		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of());
+
+		service.notifySubscribers(player, "game-1", "아리", "ahri.png");
+
+		verify(pushGateway, times(1)).sendToTopic(eq("all_solo_rank"), any());
+	}
+
+	@Test
+	void topicSendFailureDoesNotBlockSubscriberPush() {
+		Player player = player(10L, "Faker");
+		MemberDevice device = device(1L, member(7L), "token");
+		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
+		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(1);
+		when(pushGateway.send(any(), any())).thenReturn(new MobilePushResult(1, 0, List.of()));
+		doThrow(new IllegalStateException("topic down"))
+				.when(pushGateway).sendToTopic(any(), any());
+
+		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png"))
+				.doesNotThrowAnyException();
+		verify(deliveryRepository).markSent(7L, 10L, "game-1");
 	}
 
 	@Test


### PR DESCRIPTION
## 개요
선수 솔로 랭크 시작 감지 시, 기존 즐겨찾기 구독자 토큰 발송에 더해
`all_solo_rank` FCM 토픽으로도 발송합니다. 모바일 앱의 '전체 선수 솔랭 알림'
토글(해당 토픽 구독)을 켠 사용자 전체가 대상입니다.

## 변경
- `MobilePushGateway`: `sendToTopic(topic, message)` 추가
- `FirebaseMobilePushGateway`: `Message.setTopic` 으로 토픽 발송 구현
- `PlayerSoloRankPushService`: 메시지 1회 생성 후 토픽+구독자에 재사용,
  `notifySubscribers` 진입 시 토픽 발송 1회 (게임당 1회, 토픽 실패는 구독자 푸시를 막지 않음)
- 테스트 2건 추가 (토픽 1회 호출 / 토픽 실패 시 구독자 푸시 지속)

## 비고
- 모바일 클라이언트(별도 레포)에서 `all_solo_rank` 토픽 구독은 구현·검증 완료(로컬).
- 토픽명 `all_solo_rank` 은 모바일과 일치해야 함.
- 배포 환경(deploy.yml)은 이미 `FIREBASE_MESSAGING_ENABLED=true` +
  `GOOGLE_APPLICATION_CREDENTIALS`(FIREBASE_SERVICE_ACCOUNT_BASE64) 구성 완료 상태.