### PR TITLE
feat: 솔랭 푸시 페이로드에 선수명·큐타입·OP.GG 링크 추가

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -31,12 +31,15 @@ public class PlayerSoloRankPushService {
 			Player player,
 			String gameId,
 			String championName,
-			String championImageUrl) {
+			String championImageUrl,
+			String queueDisplayName,
+			String opggUrl) {
 		if (player == null || player.getId() == null || gameId == null || !pushGateway.isAvailable()) {
 			return;
 		}
 
-		MobilePushMessage message = buildMessage(player, gameId, championName, championImageUrl);
+		MobilePushMessage message = buildMessage(
+				player, gameId, championName, championImageUrl, queueDisplayName, opggUrl);
 
 		// 전체 선수 솔랭 알림 토픽 구독자에게 발송 (구독 여부와 무관). 게임당 1회.
 		sendToAllSoloRankTopic(player, gameId, message);
@@ -145,22 +148,32 @@ public class PlayerSoloRankPushService {
 			Player player,
 			String gameId,
 			String championName,
-			String championImageUrl) {
+			String championImageUrl,
+			String queueDisplayName,
+			String opggUrl) {
 		String normalizedChampionName = championName == null || championName.isBlank()
 				? "챔피언 정보 확인 중"
 				: championName;
+		String normalizedQueue = queueDisplayName == null || queueDisplayName.isBlank()
+				? "솔로 랭크"
+				: queueDisplayName;
 		Map<String, String> data = new LinkedHashMap<>();
 		data.put("type", PUSH_TYPE);
 		data.put("playerId", String.valueOf(player.getId()));
+		data.put("playerName", player.getName());
 		data.put("gameId", gameId);
 		data.put("championName", normalizedChampionName);
+		data.put("queueType", normalizedQueue);
 		data.put("deepLink", "nar://players/" + player.getId());
 		if (championImageUrl != null && !championImageUrl.isBlank()) {
 			data.put("championImageUrl", championImageUrl);
 		}
+		if (opggUrl != null && !opggUrl.isBlank()) {
+			data.put("opggUrl", opggUrl);
+		}
 		return new MobilePushMessage(
 				player.getName() + " 선수가 솔랭을 시작했어요",
-				normalizedChampionName + "로 솔로 랭크 플레이 중",
+				normalizedChampionName + "로 " + normalizedQueue + " 플레이 중",
 				Map.copyOf(data));
 	}
 

--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -111,7 +113,9 @@ public class PlayerSoloRankMonitorService {
 								account.getPlayer(),
 								currentGameId,
 								champion == null ? null : champion.getChampionNameKr(),
-								champion == null ? null : champion.getImageUrl());
+								champion == null ? null : champion.getImageUrl(),
+								queueDisplayName,
+								buildOpggUrl(account.getGameName(), account.getTagLine()));
 					}
 					account.markAlertSent(currentGameId);
 					alertsSentCount++;
@@ -203,6 +207,15 @@ public class PlayerSoloRankMonitorService {
 				championName,
 				championIconUrl,
 				"ALERT_SENT");
+	}
+
+	/** OP.GG 소환사 페이지 URL (디스코드 알림과 동일 포맷). 정보 부족 시 빈 문자열. */
+	private String buildOpggUrl(String gameName, String tagLine) {
+		if (gameName == null || gameName.isBlank() || tagLine == null || tagLine.isBlank()) {
+			return "";
+		}
+		String path = URLEncoder.encode(gameName + "-" + tagLine, StandardCharsets.UTF_8);
+		return "https://www.op.gg/summoners/kr/" + path;
 	}
 
 	private boolean isRankedSolo(RiotCurrentGameResponse currentGame) {

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
@@ -59,7 +59,7 @@ class PlayerSoloRankPushServiceTest {
 				.thenReturn(new MobilePushResult(1, 0, List.of()))
 				.thenReturn(new MobilePushResult(0, 1, List.of("token-2")));
 
-		service.notifySubscribers(player, "game-1", "아리", "ahri.png");
+		service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1");
 
 		verify(deliveryRepository).markSent(7L, 10L, "game-1");
 		verify(deliveryRepository).markFailed(8L, 10L, "game-1", "FCM 전송 성공 기기가 없습니다.");
@@ -71,7 +71,7 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of());
 
-		service.notifySubscribers(player, "game-1", "아리", "ahri.png");
+		service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1");
 
 		verify(pushGateway, times(1)).sendToTopic(eq("all_solo_rank"), any());
 	}
@@ -86,7 +86,7 @@ class PlayerSoloRankPushServiceTest {
 		doThrow(new IllegalStateException("topic down"))
 				.when(pushGateway).sendToTopic(any(), any());
 
-		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png"))
+		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1"))
 				.doesNotThrowAnyException();
 		verify(deliveryRepository).markSent(7L, 10L, "game-1");
 	}
@@ -98,7 +98,7 @@ class PlayerSoloRankPushServiceTest {
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
 		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(0);
 
-		service.notifySubscribers(player, "game-1", "아리", "ahri.png");
+		service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1");
 
 		verify(pushGateway, never()).send(any(), any());
 	}
@@ -111,7 +111,7 @@ class PlayerSoloRankPushServiceTest {
 		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(1);
 		when(pushGateway.send(any(), any())).thenThrow(new IllegalStateException("firebase down"));
 
-		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png"))
+		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1"))
 				.doesNotThrowAnyException();
 		verify(deliveryRepository).markFailed(7L, 10L, "game-1", "firebase down");
 	}

--- a/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMonitorServiceTest.java
+++ b/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMonitorServiceTest.java
@@ -117,7 +117,9 @@ class PlayerSoloRankMonitorServiceTest {
 				player,
 				"222",
 				"야스오",
-				"https://ddragon.leagueoflegends.com/cdn/15.13.1/img/champion/Yasuo.png");
+				"https://ddragon.leagueoflegends.com/cdn/15.13.1/img/champion/Yasuo.png",
+				"솔로 랭크",
+				"https://www.op.gg/summoners/kr/Hide+on+bush-KR1");
 	}
 
 	@Test
@@ -316,6 +318,8 @@ class PlayerSoloRankMonitorServiceTest {
 		verify(playerSoloRankPushService, never()).notifySubscribers(
 				org.mockito.ArgumentMatchers.any(),
 				anyString(),
+				org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.any(),
 				org.mockito.ArgumentMatchers.any(),
 				org.mockito.ArgumentMatchers.any());
 	}


### PR DESCRIPTION
모바일 마이구독 피드용으로 FCM data 페이로드에 playerName·queueType·opggUrl 추가. OP.GG URL은 디스코드 알림과 동일 포맷. 테스트 갱신.