### PR TITLE
feat: LCK 라이브 디스코드 알림 + 모바일 라이브 경기상세 API

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/match/MobileLiveGameController.java
+++ b/src/main/java/com/toy/nar/api/mobile/match/MobileLiveGameController.java
@@ -1,0 +1,34 @@
+package com.toy.nar.api.mobile.match;
+
+import com.toy.nar.app.mobile.match.MobileLiveGameService;
+import com.toy.nar.app.mobile.match.dto.LiveGameChampionsResponse;
+import com.toy.nar.app.mobile.match.dto.LiveGameEventsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mobile. 라이브 경기 상세", description = "모바일 경기 상세 화면용 라이브 챔피언 픽/밴 및 이벤트 타임라인 API")
+@RestController
+@RequestMapping("/api/mobile/live/games/{gameId}")
+@RequiredArgsConstructor
+public class MobileLiveGameController {
+
+	private final MobileLiveGameService liveGameService;
+
+	@Operation(summary = "라이브 챔피언 픽/밴 조회", description = "최신 라이브 상태 기준 블루/레드 팀의 챔피언 픽과 밴 목록을 조회합니다.")
+	@GetMapping("/champions")
+	public ResponseEntity<LiveGameChampionsResponse> getChampions(@PathVariable String gameId) {
+		return ResponseEntity.ok(liveGameService.getChampions(gameId));
+	}
+
+	@Operation(summary = "라이브 이벤트 타임라인 조회", description = "킬/오브젝트(드래곤·바론·타워·억제기) 이벤트를 최신순으로 조회합니다.")
+	@GetMapping("/events")
+	public ResponseEntity<LiveGameEventsResponse> getEvents(@PathVariable String gameId) {
+		return ResponseEntity.ok(liveGameService.getEvents(gameId));
+	}
+}

--- a/src/main/java/com/toy/nar/app/data/source/NotificationService.java
+++ b/src/main/java/com/toy/nar/app/data/source/NotificationService.java
@@ -176,6 +176,148 @@ public class NotificationService {
 	}
 
 	/**
+	 * LCK 등 라이브 경기 시작 감지 알림 (운영 웹훅으로 발송)
+	 */
+	public void sendLiveMatchNotification(
+			String leagueName,
+			String blueTeamName,
+			String redTeamName,
+			String gameId,
+			String matchId) {
+		if (!notificationEnabled) return;
+
+		String league = leagueName == null || leagueName.isBlank() ? "LoL Esports" : leagueName;
+		String blue = blueTeamName == null || blueTeamName.isBlank() ? "?" : blueTeamName;
+		String red = redTeamName == null || redTeamName.isBlank() ? "?" : redTeamName;
+		String message = String.format("상태: 라이브 경기 시작 감지\n감지 시각: `%s`\n\n" +
+				"```text\n" +
+				"리그    : %s\n" +
+				"대진    : %s vs %s\n" +
+				"게임 ID : %s\n" +
+				"매치 ID : %s\n" +
+				"```",
+			LocalDateTime.now().format(ALERT_TIME_FORMATTER),
+			league,
+			blue,
+			red,
+			gameId == null || gameId.isBlank() ? "-" : gameId,
+			matchId == null || matchId.isBlank() ? "-" : matchId
+		);
+
+		sendNotification(String.format("[%s 라이브 경기 시작]", league), message, "danger");
+	}
+
+	/**
+	 * 라이브 경기 중 오브젝트(타워/바론/드래곤/억제기) 이벤트 알림 (운영 웹훅으로 발송)
+	 */
+	public void sendLiveObjectEventNotification(
+			String leagueName,
+			String teamName,
+			String teamSide,
+			String eventType,
+			String eventSubType,
+			int eventOrder,
+			String gameId) {
+		if (!notificationEnabled) return;
+
+		String league = leagueName == null || leagueName.isBlank() ? "LoL Esports" : leagueName;
+		String team = teamDisplay(teamSide, teamName);
+		String label = liveEventLabel(eventType, eventSubType);
+		String color = eventType == null ? "info"
+				: switch (eventType.toUpperCase()) {
+					case "BARON" -> "warning";
+					default -> "good";
+				};
+
+		String message = String.format("리그: %s\n감지 시각: `%s`\n\n" +
+				"```text\n" +
+				"팀      : %s\n" +
+				"이벤트  : %s (%d번째)\n" +
+				"게임 ID : %s\n" +
+				"```",
+			league,
+			LocalDateTime.now().format(ALERT_TIME_FORMATTER),
+			team,
+			label,
+			eventOrder,
+			gameId == null || gameId.isBlank() ? "-" : gameId
+		);
+
+		sendNotification(String.format("[%s] %s — %s", league, label, team), message, color);
+	}
+
+	/**
+	 * 라이브 경기 중 킬 이벤트 알림 — 킬러/피해자(선수·챔피언) 포함 (운영 웹훅으로 발송)
+	 */
+	public void sendLiveKillNotification(
+			String leagueName,
+			String killerTeamName,
+			String killerTeamSide,
+			String killerName,
+			String killerChampion,
+			String victimName,
+			String victimChampion,
+			int killOrder,
+			String gameId) {
+		if (!notificationEnabled) return;
+
+		String league = leagueName == null || leagueName.isBlank() ? "LoL Esports" : leagueName;
+		String killer = playerWithChampion(killerName, killerChampion);
+		String victim = playerWithChampion(victimName, victimChampion);
+		String killerTeam = teamDisplay(killerTeamSide, killerTeamName);
+
+		String message = String.format("리그: %s\n감지 시각: `%s`\n\n" +
+				"```text\n" +
+				"킬러   : %s  [%s]\n" +
+				"피해자 : %s\n" +
+				"팀 킬   : %d번째\n" +
+				"게임 ID : %s\n" +
+				"```",
+			league,
+			LocalDateTime.now().format(ALERT_TIME_FORMATTER),
+			killer,
+			killerTeam,
+			victim,
+			killOrder,
+			gameId == null || gameId.isBlank() ? "-" : gameId
+		);
+
+		sendNotification(String.format("[%s] ⚔️ %s → %s", league, killer, victim), message, "danger");
+	}
+
+	private String teamDisplay(String teamSide, String teamName) {
+		String emoji = "Blue".equalsIgnoreCase(teamSide) ? "🔵"
+				: "Red".equalsIgnoreCase(teamSide) ? "🔴" : "";
+		String name = teamName == null || teamName.isBlank()
+				? ("Blue".equalsIgnoreCase(teamSide) ? "블루" : "Red".equalsIgnoreCase(teamSide) ? "레드" : "-")
+				: teamName;
+		return (emoji.isBlank() ? "" : emoji + " ") + name;
+	}
+
+	private String playerWithChampion(String playerName, String champion) {
+		String name = playerName == null || playerName.isBlank() ? "?" : playerName;
+		if (champion == null || champion.isBlank()) {
+			return name;
+		}
+		return name + " (" + champion + ")";
+	}
+
+	private String liveEventLabel(String eventType, String eventSubType) {
+		if (eventType == null) {
+			return "이벤트";
+		}
+		return switch (eventType.toUpperCase()) {
+			case "TOWER" -> "🗼 포탑 파괴";
+			case "BARON" -> "🟣 바론 처치";
+			case "INHIBITOR" -> "🛡️ 억제기 파괴";
+			case "DRAGON" -> "🐉 드래곤 처치"
+					+ (eventSubType == null || eventSubType.isBlank() ? "" : " (" + eventSubType + ")");
+			case "KILL" -> "⚔️ 킬";
+			default -> eventType;
+		};
+	}
+
+	/**
 	 * 실제 알림 전송
 	 */
 	private void sendNotification(String title, String message, String color) {

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -1,6 +1,7 @@
 package com.toy.nar.app.lolesports.live;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.data.source.NotificationService;
 import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +14,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -26,9 +29,18 @@ public class LiveObjectEventRecorder {
 	private static final String EVENT_BARON = "BARON";
 	private static final String EVENT_TOWER = "TOWER";
 	private static final String EVENT_INHIBITOR = "INHIBITOR";
+	private static final String EVENT_KILL = "KILL";
 
 	private final LiveGameObjectEventRepository objectEventRepository;
+	private final NotificationService notificationService;
 	private final Map<String, ObservedObjectState> lastObservedByGame = new ConcurrentHashMap<>();
+
+	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.events-enabled:false}")
+	private boolean eventNotificationEnabled;
+
+	// 디스코드 알림을 보낼 리그(쉼표 구분). 기본 LCK 만. 그 외 리그는 이벤트를 DB에 기록만 하고 알림은 안 보낸다.
+	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.leagues:LCK}")
+	private String notificationLeagues;
 
 	public void evict(String gameId) {
 		if (gameId == null || gameId.isBlank()) {
@@ -44,6 +56,8 @@ public class LiveObjectEventRecorder {
 			return;
 		}
 
+		Map<Integer, ParticipantMeta> metadata = parseMetadata(windowResponse.path("gameMetadata"));
+
 		List<FrameSnapshot> snapshots = toSnapshots(frames);
 		if (snapshots.isEmpty()) {
 			return;
@@ -55,11 +69,20 @@ public class LiveObjectEventRecorder {
 				continue;
 			}
 			if (previous != null) {
-				recordTeamDiff(activeGame, "Blue", previous.blue(), snapshot.blue(), snapshot.frameTimestampUtc());
-				recordTeamDiff(activeGame, "Red", previous.red(), snapshot.red(), snapshot.frameTimestampUtc());
+				recordObjectDiff(activeGame, "Blue", previous.blue(), snapshot.blue(), snapshot.frameTimestampUtc());
+				recordObjectDiff(activeGame, "Red", previous.red(), snapshot.red(), snapshot.frameTimestampUtc());
+				recordKills(activeGame, "Blue", previous.blue().kills(), snapshot.blue().kills(),
+						previous.blueParticipants(), snapshot.blueParticipants(),
+						previous.redParticipants(), snapshot.redParticipants(),
+						metadata, snapshot.frameTimestampUtc());
+				recordKills(activeGame, "Red", previous.red().kills(), snapshot.red().kills(),
+						previous.redParticipants(), snapshot.redParticipants(),
+						previous.blueParticipants(), snapshot.blueParticipants(),
+						metadata, snapshot.frameTimestampUtc());
 			}
 
-			previous = new ObservedObjectState(snapshot.frameTimestampUtc(), snapshot.blue(), snapshot.red());
+			previous = new ObservedObjectState(snapshot.frameTimestampUtc(), snapshot.blue(), snapshot.red(),
+					snapshot.blueParticipants(), snapshot.redParticipants());
 		}
 
 		lastObservedByGame.put(activeGame.gameId(), previous);
@@ -75,13 +98,15 @@ public class LiveObjectEventRecorder {
 			snapshots.add(new FrameSnapshot(
 					frameTimestampUtc,
 					TeamObjectState.from(frame.path("blueTeam")),
-					TeamObjectState.from(frame.path("redTeam"))));
+					TeamObjectState.from(frame.path("redTeam")),
+					parseParticipants(frame.path("blueTeam").path("participants")),
+					parseParticipants(frame.path("redTeam").path("participants"))));
 		}
 		snapshots.sort(Comparator.comparing(FrameSnapshot::frameTimestampUtc));
 		return snapshots;
 	}
 
-	private void recordTeamDiff(
+	private void recordObjectDiff(
 			ActiveLiveGame activeGame,
 			String teamSide,
 			TeamObjectState previous,
@@ -92,6 +117,39 @@ public class LiveObjectEventRecorder {
 		recordCounterEvents(activeGame, teamSide, EVENT_INHIBITOR, previous.inhibitors(), current.inhibitors(),
 				frameTimestampUtc);
 		recordDragonEvents(activeGame, teamSide, previous.dragons(), current.dragons(), frameTimestampUtc);
+	}
+
+	/**
+	 * 킬 이벤트 감지. 팀 totalKills 증가분을 순서(event_order)로 쓰고,
+	 * 같은 프레임 안에서 kills가 증가한 참가자(킬러)와 상대팀 deaths가 증가한 참가자(피해자)를 그리디 페어링한다.
+	 * 한타로 여러 명이 동시에 죽은 프레임은 1:1 매칭이 근사적이다.
+	 */
+	private void recordKills(
+			ActiveLiveGame activeGame,
+			String killerSide,
+			int previousTeamKills,
+			int currentTeamKills,
+			Map<Integer, Kd> killerPrevKd,
+			Map<Integer, Kd> killerCurKd,
+			Map<Integer, Kd> victimPrevKd,
+			Map<Integer, Kd> victimCurKd,
+			Map<Integer, ParticipantMeta> metadata,
+			LocalDateTime frameTimestampUtc) {
+		if (currentTeamKills <= previousTeamKills) {
+			return;
+		}
+
+		List<Integer> killers = expandByDelta(killerPrevKd, killerCurKd, true);
+		List<Integer> victims = expandByDelta(victimPrevKd, victimCurKd, false);
+
+		int newKills = currentTeamKills - previousTeamKills;
+		for (int i = 0; i < newKills; i++) {
+			int order = previousTeamKills + 1 + i;
+			Integer killerId = i < killers.size() ? killers.get(i) : null;
+			Integer victimId = i < victims.size() ? victims.get(i) : null;
+			saveKillEventIfAbsent(activeGame, killerSide, order, currentTeamKills, killerId, victimId, metadata,
+					frameTimestampUtc);
+		}
 	}
 
 	private void recordCounterEvents(
@@ -165,6 +223,151 @@ public class LiveObjectEventRecorder {
 				valueAfter,
 				frameTimestampUtc);
 		objectEventRepository.save(event);
+		log.info("[live-notify] event saved type={} team={} order={} gameId={} notify={}",
+				eventType, teamSide, eventOrder, activeGame.gameId(), eventNotificationEnabled);
+
+		if (eventNotificationEnabled && isNotifiableLeague(activeGame.leagueName())) {
+			notificationService.sendLiveObjectEventNotification(
+					activeGame.leagueName(),
+					teamNameOf(activeGame, teamSide),
+					teamSide,
+					eventType,
+					eventSubType,
+					eventOrder,
+					activeGame.gameId());
+		}
+	}
+
+	private void saveKillEventIfAbsent(
+			ActiveLiveGame activeGame,
+			String killerSide,
+			int eventOrder,
+			int teamKillsAfter,
+			Integer killerId,
+			Integer victimId,
+			Map<Integer, ParticipantMeta> metadata,
+			LocalDateTime frameTimestampUtc) {
+		boolean exists = objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
+				activeGame.gameId(), killerSide, EVENT_KILL, eventOrder);
+		if (exists) {
+			return;
+		}
+
+		ParticipantMeta killer = killerId == null ? null : metadata.get(killerId);
+		ParticipantMeta victim = victimId == null ? null : metadata.get(victimId);
+		String killerChampion = killer == null ? null : killer.champion();
+
+		// event_sub_type 은 하위호환을 위해 킬러 챔피언을 유지하고, 킬러/피해자 선수명과 피해자 챔피언을 신규 컬럼에 함께 저장한다.
+		LiveGameObjectEvent event = new LiveGameObjectEvent(
+				activeGame.gameId(),
+				activeGame.matchId(),
+				activeGame.leagueName(),
+				killerSide,
+				EVENT_KILL,
+				killerChampion,
+				eventOrder,
+				teamKillsAfter,
+				killer == null ? null : killer.summonerName(),
+				victim == null ? null : victim.champion(),
+				victim == null ? null : victim.summonerName(),
+				frameTimestampUtc);
+		objectEventRepository.save(event);
+		log.info("[live-notify] kill saved order={} team={} killer={} victim={} gameId={} notify={}",
+				eventOrder, killerSide,
+				killer == null ? "?" : killer.summonerName(),
+				victim == null ? "?" : victim.summonerName(),
+				activeGame.gameId(), eventNotificationEnabled);
+
+		if (eventNotificationEnabled && isNotifiableLeague(activeGame.leagueName())) {
+			notificationService.sendLiveKillNotification(
+					activeGame.leagueName(),
+					teamNameOf(activeGame, killerSide),
+					killerSide,
+					killer == null ? null : killer.summonerName(),
+					killerChampion,
+					victim == null ? null : victim.summonerName(),
+					victim == null ? null : victim.champion(),
+					eventOrder,
+					activeGame.gameId());
+		}
+	}
+
+	private String teamNameOf(ActiveLiveGame activeGame, String teamSide) {
+		if ("Blue".equalsIgnoreCase(teamSide)) {
+			return activeGame.blueTeamName();
+		}
+		if ("Red".equalsIgnoreCase(teamSide)) {
+			return activeGame.redTeamName();
+		}
+		return null;
+	}
+
+	/** prev 대비 cur에서 kills(또는 deaths)가 증가한 참가자를 증가분만큼 펼친 목록(참가자 ID 오름차순). */
+	private List<Integer> expandByDelta(Map<Integer, Kd> prev, Map<Integer, Kd> cur, boolean useKills) {
+		List<Integer> expanded = new ArrayList<>();
+		for (Map.Entry<Integer, Kd> entry : new TreeMap<>(cur).entrySet()) {
+			int pid = entry.getKey();
+			Kd before = prev.get(pid);
+			int prevValue = before == null ? 0 : (useKills ? before.kills() : before.deaths());
+			int curValue = useKills ? entry.getValue().kills() : entry.getValue().deaths();
+			for (int n = 0; n < curValue - prevValue; n++) {
+				expanded.add(pid);
+			}
+		}
+		return expanded;
+	}
+
+	private Map<Integer, Kd> parseParticipants(JsonNode participantsNode) {
+		Map<Integer, Kd> result = new HashMap<>();
+		if (participantsNode == null || !participantsNode.isArray()) {
+			return result;
+		}
+		for (JsonNode p : participantsNode) {
+			if (!p.path("participantId").isNumber()) {
+				continue;
+			}
+			int pid = p.path("participantId").asInt();
+			int kills = p.path("kills").isNumber() ? p.path("kills").asInt() : 0;
+			int deaths = p.path("deaths").isNumber() ? p.path("deaths").asInt() : 0;
+			result.put(pid, new Kd(kills, deaths));
+		}
+		return result;
+	}
+
+	private Map<Integer, ParticipantMeta> parseMetadata(JsonNode gameMetadata) {
+		Map<Integer, ParticipantMeta> result = new HashMap<>();
+		if (gameMetadata == null || gameMetadata.isMissingNode()) {
+			return result;
+		}
+		for (String teamKey : new String[] { "blueTeamMetadata", "redTeamMetadata" }) {
+			JsonNode arr = gameMetadata.path(teamKey).path("participantMetadata");
+			if (!arr.isArray()) {
+				continue;
+			}
+			for (JsonNode p : arr) {
+				if (!p.path("participantId").isNumber()) {
+					continue;
+				}
+				int pid = p.path("participantId").asInt();
+				String summoner = p.path("summonerName").asText(null);
+				String champion = p.path("championId").asText(null);
+				result.put(pid, new ParticipantMeta(summoner, champion));
+			}
+		}
+		return result;
+	}
+
+	/** 알림 대상 리그인지 (notificationLeagues 설정, 기본 LCK). 그 외 리그는 디스코드 알림 안 보냄. */
+	private boolean isNotifiableLeague(String league) {
+		if (league == null || league.isBlank()) {
+			return false;
+		}
+		for (String allowed : notificationLeagues.split(",")) {
+			if (allowed.trim().equalsIgnoreCase(league.trim())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private LocalDateTime parseFrameTimestamp(String raw) {
@@ -179,12 +382,19 @@ public class LiveObjectEventRecorder {
 		}
 	}
 
-	private record TeamObjectState(int towers, int barons, int inhibitors, List<String> dragons) {
+	private record Kd(int kills, int deaths) {
+	}
+
+	private record ParticipantMeta(String summonerName, String champion) {
+	}
+
+	private record TeamObjectState(int towers, int barons, int inhibitors, int kills, List<String> dragons) {
 
 		static TeamObjectState from(JsonNode teamNode) {
 			int towers = teamNode.path("towers").isNumber() ? teamNode.path("towers").asInt() : 0;
 			int barons = teamNode.path("barons").isNumber() ? teamNode.path("barons").asInt() : 0;
 			int inhibitors = teamNode.path("inhibitors").isNumber() ? teamNode.path("inhibitors").asInt() : 0;
+			int kills = teamNode.path("totalKills").isNumber() ? teamNode.path("totalKills").asInt() : 0;
 
 			List<String> dragons = new ArrayList<>();
 			JsonNode dragonNode = teamNode.path("dragons");
@@ -196,13 +406,23 @@ public class LiveObjectEventRecorder {
 					}
 				}
 			}
-			return new TeamObjectState(towers, barons, inhibitors, dragons);
+			return new TeamObjectState(towers, barons, inhibitors, kills, dragons);
 		}
 	}
 
-	private record FrameSnapshot(LocalDateTime frameTimestampUtc, TeamObjectState blue, TeamObjectState red) {
+	private record FrameSnapshot(
+			LocalDateTime frameTimestampUtc,
+			TeamObjectState blue,
+			TeamObjectState red,
+			Map<Integer, Kd> blueParticipants,
+			Map<Integer, Kd> redParticipants) {
 	}
 
-	private record ObservedObjectState(LocalDateTime frameTimestampUtc, TeamObjectState blue, TeamObjectState red) {
+	private record ObservedObjectState(
+			LocalDateTime frameTimestampUtc,
+			TeamObjectState blue,
+			TeamObjectState red,
+			Map<Integer, Kd> blueParticipants,
+			Map<Integer, Kd> redParticipants) {
 	}
 }

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -6,6 +6,7 @@ import com.toy.nar.app.lolesports.LeagueMatchService;
 import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
 import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.data.source.NotificationService;
 import com.toy.nar.app.schedule.CacheEvictionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,10 @@ public class LivePollingScheduler {
 
 	private static final DateTimeFormatter START_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
 	private static final long INITIAL_LOOKBACK_SECONDS = 90L;
+	/** 라이브 엣지 추적: 이보다 더 뒤처지면 엣지 근처로 점프해 catch-up 지연(분 단위)을 막는다. */
+	private static final long MAX_LAG_SECONDS = 50L;
+	/** 피드는 window end-time이 20초보다 최신이면 거부하므로, 이보다 최신은 요청하지 않는다. */
+	private static final long MIN_FEED_AGE_SECONDS = 35L;
 
 	private final WorldsService worldsService;
 	private final LiveStatsClient liveStatsClient;
@@ -41,12 +46,20 @@ public class LivePollingScheduler {
 	private final LiveGameMetadataService liveGameMetadataService;
 	private final LeagueMatchService leagueMatchService;
 	private final CacheEvictionService cacheEvictionService;
+	private final NotificationService notificationService;
 
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.stale-threshold-ms:180000}")
 	private long staleThresholdMs;
 
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.max-consecutive-failures:6}")
 	private int maxConsecutiveFailures;
+
+	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.enabled:false}")
+	private boolean liveNotificationEnabled;
+
+	// 디스코드 알림을 보낼 리그(쉼표 구분). 기본 LCK 만. 그 외 리그는 데이터 수집만 하고 알림은 보내지 않는다.
+	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.leagues:LCK}")
+	private String notificationLeagues;
 
 	@Scheduled(fixedDelayString = "${lolesports.live.discovery-interval-ms:60000}")
 	public void discoverLiveGames() {
@@ -89,6 +102,17 @@ public class LivePollingScheduler {
 								current != null ? current.consecutiveFailures() : 0);
 						activeGames.put(gameId, next);
 						liveGameMetadataService.remember(next);
+
+						if (liveNotificationEnabled && current == null && isNotifiableLeague(resolvedLeagueName)) {
+							log.info("[live-notify] match-start league={} {} vs {} gameId={}",
+									resolvedLeagueName, next.blueTeamName(), next.redTeamName(), gameId);
+							notificationService.sendLiveMatchNotification(
+									resolvedLeagueName,
+									next.blueTeamName(),
+									next.redTeamName(),
+									gameId,
+									match.getMatchId());
+						}
 					}
 				}
 			} catch (Exception e) {
@@ -154,17 +178,37 @@ public class LivePollingScheduler {
 	}
 
 	private String computeStartingTime(String gameId) {
+		Instant now = Instant.now();
 		Instant candidate = liveStateStore.getLatestState(gameId)
 				.map(state -> nextWindowStart(state.frameTimestampUtc().toInstant(ZoneOffset.UTC)))
-				.orElseGet(() -> Instant.now().minusSeconds(INITIAL_LOOKBACK_SECONDS));
+				.orElseGet(() -> now.minusSeconds(INITIAL_LOOKBACK_SECONDS));
 
-		Instant minAllowed = Instant.now().minus(Duration.ofMinutes(5));
-		if (candidate.isBefore(minAllowed)) {
-			candidate = minAllowed;
+		// 뒤처졌으면 라이브 엣지로 점프 (분 단위 catch-up 지연 방지)
+		Instant liveEdgeFloor = now.minusSeconds(MAX_LAG_SECONDS);
+		if (candidate.isBefore(liveEdgeFloor)) {
+			candidate = liveEdgeFloor;
+		}
+		// 피드 20초 룰: 너무 최신 window는 거부되므로 상한을 둔다
+		Instant newestAllowed = now.minusSeconds(MIN_FEED_AGE_SECONDS);
+		if (candidate.isAfter(newestAllowed)) {
+			candidate = newestAllowed;
 		}
 
 		long flooredSeconds = (candidate.getEpochSecond() / 10) * 10;
 		return LocalDateTime.ofInstant(Instant.ofEpochSecond(flooredSeconds), ZoneOffset.UTC).format(START_TIME_FORMATTER);
+	}
+
+	/** 알림 대상 리그인지 (notificationLeagues 설정, 기본 LCK). 그 외 리그는 디스코드 알림 안 보냄. */
+	private boolean isNotifiableLeague(String league) {
+		if (league == null || league.isBlank()) {
+			return false;
+		}
+		for (String allowed : notificationLeagues.split(",")) {
+			if (allowed.trim().equalsIgnoreCase(league.trim())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private Instant nextWindowStart(Instant latestFrameTimestamp) {

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStateAggregator.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStateAggregator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toy.nar.app.lolesports.live.dto.LiveGameState;
 import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -18,15 +19,22 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class LiveStateAggregator {
 
+	private static final String LOLESPORTS_SOURCE = "LOLESPORTS";
+
 	private final ObjectMapper objectMapper;
 	private final RuneMetadataResolver runeMetadataResolver;
 	private final ItemMetadataResolver itemMetadataResolver;
+	private final TeamExternalIdentityRepository teamExternalIdentityRepository;
+
+	// 세트마다 블루/레드 진영이 바뀌므로, 피드의 진영별 esportsTeamId 로 팀명을 조회한다(esportsTeamId→팀명 캐시).
+	private final Map<String, String> teamNameByExternalId = new ConcurrentHashMap<>();
 
 	public LiveGameState aggregate(
 			ActiveLiveGame activeGame,
@@ -105,12 +113,8 @@ public class LiveStateAggregator {
 				activeGame.gameId(),
 				activeGame.matchId(),
 				activeGame.leagueName(),
-				firstNonBlank(
-						activeGame.blueTeamName(),
-						textOrNull(blueTeamMetadata, "esportsTeamId")),
-				firstNonBlank(
-						activeGame.redTeamName(),
-						textOrNull(redTeamMetadata, "esportsTeamId")),
+				resolveTeamName(textOrNull(blueTeamMetadata, "esportsTeamId"), activeGame.blueTeamName()),
+				resolveTeamName(textOrNull(redTeamMetadata, "esportsTeamId"), activeGame.redTeamName()),
 				minuteBucketUtc,
 				frameTimestampUtc,
 				participants,
@@ -227,5 +231,28 @@ public class LiveStateAggregator {
 			return first;
 		}
 		return second;
+	}
+
+	/**
+	 * 피드의 진영별 esportsTeamId 로 실제 팀명을 조회한다(team_external_identity). 매핑이 없으면 fallback(매치 기준 이름).
+	 * 세트마다 블루/레드가 스왑되므로 매치 고정 이름이 아니라 이 값으로 진영-팀을 맞춰야 한다. esportsTeamId→팀명은 캐시한다.
+	 */
+	private String resolveTeamName(String esportsTeamId, String fallback) {
+		if (esportsTeamId == null || esportsTeamId.isBlank()) {
+			return fallback;
+		}
+		String cached = teamNameByExternalId.get(esportsTeamId);
+		if (cached != null) {
+			return cached;
+		}
+		String resolved = teamExternalIdentityRepository
+				.findBySourceAndExternalTeamId(LOLESPORTS_SOURCE, esportsTeamId)
+				.map(identity -> identity.getTeam().getName())
+				.orElse(null);
+		if (resolved != null && !resolved.isBlank()) {
+			teamNameByExternalId.put(esportsTeamId, resolved);
+			return resolved;
+		}
+		return fallback;
 	}
 }

--- a/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameObjectEvent.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/entity/LiveGameObjectEvent.java
@@ -50,6 +50,16 @@ public class LiveGameObjectEvent {
 	@Column(name = "value_after", nullable = false)
 	private Integer valueAfter;
 
+	// KILL 이벤트 전용. 그 외 이벤트는 NULL. (event_sub_type 은 하위호환을 위해 킬러 챔피언을 그대로 유지)
+	@Column(name = "killer_player_name", length = 64)
+	private String killerPlayerName;
+
+	@Column(name = "victim_champion", length = 40)
+	private String victimChampion;
+
+	@Column(name = "victim_player_name", length = 64)
+	private String victimPlayerName;
+
 	@Column(name = "source_frame_timestamp_utc", nullable = false)
 	private LocalDateTime sourceFrameTimestampUtc;
 
@@ -76,5 +86,26 @@ public class LiveGameObjectEvent {
 		this.eventOrder = eventOrder;
 		this.valueAfter = valueAfter;
 		this.sourceFrameTimestampUtc = sourceFrameTimestampUtc;
+	}
+
+	/** KILL 이벤트 전용 생성자. 킬러 챔피언은 하위호환을 위해 eventSubType 에 그대로 둔다. */
+	public LiveGameObjectEvent(
+			String gameId,
+			String matchId,
+			String leagueName,
+			String teamSide,
+			String eventType,
+			String eventSubType,
+			Integer eventOrder,
+			Integer valueAfter,
+			String killerPlayerName,
+			String victimChampion,
+			String victimPlayerName,
+			LocalDateTime sourceFrameTimestampUtc) {
+		this(gameId, matchId, leagueName, teamSide, eventType, eventSubType, eventOrder, valueAfter,
+				sourceFrameTimestampUtc);
+		this.killerPlayerName = killerPlayerName;
+		this.victimChampion = victimChampion;
+		this.victimPlayerName = victimPlayerName;
 	}
 }

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMinuteSnapshotRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameMinuteSnapshotRepository.java
@@ -28,4 +28,14 @@ public interface LiveGameMinuteSnapshotRepository extends JpaRepository<LiveGame
 			ORDER BY MAX(s.frameTimestampUtc) DESC
 			""")
 	List<String> findRecentGameIds(Pageable pageable);
+
+	/** 해당 매치에서 라이브 데이터를 수집한 게임 ID들(시작 시각 순). 게임 종료/재기동 후에도 영속된다. */
+	@Query("""
+			SELECT s.gameId
+			FROM LiveGameMinuteSnapshot s
+			WHERE s.matchId = :matchId
+			GROUP BY s.gameId
+			ORDER BY MIN(s.frameTimestampUtc)
+			""")
+	List<String> findGameIdsByMatchIdOrderByStart(String matchId);
 }

--- a/src/main/java/com/toy/nar/app/mobile/match/MobileLiveGameService.java
+++ b/src/main/java/com/toy/nar/app/mobile/match/MobileLiveGameService.java
@@ -1,0 +1,246 @@
+package com.toy.nar.app.mobile.match;
+
+import com.toy.nar.app.lolesports.live.LiveStateQueryService;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import com.toy.nar.app.mobile.match.dto.LiveGameChampionsResponse;
+import com.toy.nar.app.mobile.match.dto.LiveGameEventsResponse;
+import com.toy.nar.common.util.NameNormalizer;
+import com.toy.nar.domain.participant.entity.Champion;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.ChampionRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MobileLiveGameService {
+
+	private static final String BLUE = "Blue";
+	private static final String RED = "Red";
+	private static final String EVENT_KILL = "KILL";
+	private static final String EVENT_DRAGON = "DRAGON";
+
+	// 픽 정렬 기준: top → jungle → mid → bottom → support. 알 수 없는 역할은 맨 뒤.
+	private static final Map<String, Integer> ROLE_ORDER = Map.of(
+			"top", 0,
+			"jungle", 1,
+			"mid", 2,
+			"bottom", 3,
+			"support", 4);
+
+	private final LiveStateQueryService liveStateQueryService;
+	private final LiveGameObjectEventRepository objectEventRepository;
+	private final LiveGameMinuteSnapshotRepository minuteSnapshotRepository;
+	private final ChampionRepository championRepository;
+	private final TeamRepository teamRepository;
+
+	public LiveGameChampionsResponse getChampions(String gameId) {
+		LiveGameState state = requireState(gameId);
+
+		List<LiveParticipantState> blue = state.participants().stream()
+				.filter(p -> BLUE.equalsIgnoreCase(p.teamSide()))
+				.sorted(pickComparator())
+				.toList();
+		List<LiveParticipantState> red = state.participants().stream()
+				.filter(p -> RED.equalsIgnoreCase(p.teamSide()))
+				.sorted(pickComparator())
+				.toList();
+
+		return new LiveGameChampionsResponse(
+				gameId,
+				toTeamChampions(state.blueTeamName(), blue),
+				toTeamChampions(state.redTeamName(), red));
+	}
+
+	public LiveGameEventsResponse getEvents(String gameId) {
+		LiveGameState state = liveStateQueryService.getLatestState(gameId).orElse(null);
+		String blueTeamName = state == null ? null : state.blueTeamName();
+		String redTeamName = state == null ? null : state.redTeamName();
+		// 팀 로고는 요청당 한 번씩만 조회한다(이벤트마다 조회하지 않는다).
+		String blueTeamImageUrl = resolveTeamImageUrl(blueTeamName);
+		String redTeamImageUrl = resolveTeamImageUrl(redTeamName);
+
+		List<LiveGameObjectEvent> events = objectEventRepository
+				.findByGameIdOrderBySourceFrameTimestampUtcAscIdAsc(gameId);
+
+		// gameTime 기준점(t0)은 "이 경기에서 처음 관측된 분 스냅샷 프레임" = 게임 시작 무렵.
+		// (첫 킬/이벤트가 아니라 폴링 시작 시점이므로 인게임 시계와 거의 맞는다. 스냅샷은 재기동에도 DB에 보존됨)
+		// 분 스냅샷이 전혀 없으면 최초 이벤트로 폴백(근사).
+		LocalDateTime t0 = minuteSnapshotRepository.findTopByGameIdOrderByMinuteBucketUtcAsc(gameId)
+				.map(LiveGameMinuteSnapshot::getFrameTimestampUtc)
+				.orElseGet(() -> events.stream()
+						.map(LiveGameObjectEvent::getSourceFrameTimestampUtc)
+						.min(Comparator.naturalOrder())
+						.orElse(null));
+
+		List<LiveGameEventsResponse.Event> mapped = new ArrayList<>();
+		for (LiveGameObjectEvent event : events) {
+			mapped.add(toEvent(event, t0, blueTeamName, redTeamName));
+		}
+		// 최신순(newest first)으로 뒤집는다.
+		java.util.Collections.reverse(mapped);
+
+		return new LiveGameEventsResponse(
+				gameId,
+				blueTeamName, blueTeamImageUrl,
+				redTeamName, redTeamImageUrl,
+				mapped);
+	}
+
+	/** 팀명으로 로고 이미지 URL 을 조회한다. 매핑이 없거나 팀명이 비면 null. */
+	private String resolveTeamImageUrl(String teamName) {
+		if (teamName == null || teamName.isBlank()) {
+			return null;
+		}
+		String url = lookupTeamImage(teamName);
+		if (url == null) {
+			// 라이브 팀명은 "Gen.G Esports"처럼 접미사가 붙는 경우가 있어, 접미사를 떼고 재시도한다(예: DB "Gen.g").
+			String stripped = teamName
+					.replaceAll("(?i)\\s+(esports club|e-sports|esports|gaming)$", "")
+					.trim();
+			if (!stripped.isBlank() && !stripped.equalsIgnoreCase(teamName)) {
+				url = lookupTeamImage(stripped);
+			}
+		}
+		return url;
+	}
+
+	private String lookupTeamImage(String name) {
+		return teamRepository.findByNameIgnoreCase(name)
+				.map(Team::getImageUrl)
+				.orElse(null);
+	}
+
+	private LiveGameChampionsResponse.TeamChampions toTeamChampions(
+			String teamName, List<LiveParticipantState> participants) {
+		List<LiveGameChampionsResponse.Pick> picks = participants.stream()
+				.map(p -> new LiveGameChampionsResponse.Pick(
+						canonicalPosition(p.role()),
+						p.championName(),
+						resolveChampionImageUrl(p.championName()),
+						p.playerName()))
+				.toList();
+		// 라이브 상태에는 밴 정보가 없으므로 best-effort 로 빈 목록을 반환한다.
+		return new LiveGameChampionsResponse.TeamChampions(teamName, picks, List.of());
+	}
+
+	private LiveGameEventsResponse.Event toEvent(
+			LiveGameObjectEvent event, LocalDateTime t0, String blueTeamName, String redTeamName) {
+		int seconds = elapsedSeconds(t0, event.getSourceFrameTimestampUtc());
+		String gameTime = formatGameTime(seconds);
+		String type = event.getEventType();
+
+		if (EVENT_KILL.equals(type)) {
+			LiveGameEventsResponse.Participant killer = new LiveGameEventsResponse.Participant(
+					event.getKillerPlayerName(),
+					event.getEventSubType(),
+					resolveChampionImageUrl(event.getEventSubType()),
+					event.getTeamSide());
+			LiveGameEventsResponse.Participant victim = new LiveGameEventsResponse.Participant(
+					event.getVictimPlayerName(),
+					event.getVictimChampion(),
+					resolveChampionImageUrl(event.getVictimChampion()),
+					oppositeSide(event.getTeamSide()));
+			return new LiveGameEventsResponse.Event(
+					type, gameTime, seconds,
+					killer, victim, event.getValueAfter(),
+					null, null, null, null);
+		}
+
+		String teamName = teamNameBySide(event.getTeamSide(), blueTeamName, redTeamName);
+		String subType = EVENT_DRAGON.equals(type) ? event.getEventSubType() : null;
+		return new LiveGameEventsResponse.Event(
+				type, gameTime, seconds,
+				null, null, null,
+				subType, event.getTeamSide(), teamName, event.getValueAfter());
+	}
+
+	private Comparator<LiveParticipantState> pickComparator() {
+		return Comparator
+				.comparingInt((LiveParticipantState p) -> ROLE_ORDER.getOrDefault(canonicalPosition(p.role()), 99))
+				.thenComparing(p -> p.participantId() == null ? Integer.MAX_VALUE : p.participantId());
+	}
+
+	/** 라이브 역할 문자열을 계약상의 position 값(top/jungle/mid/bottom/support)으로 정규화한다. */
+	private String canonicalPosition(String role) {
+		if (role == null || role.isBlank()) {
+			return null;
+		}
+		return switch (role.trim().toLowerCase(Locale.ROOT)) {
+			case "top" -> "top";
+			case "jungle", "jungler", "jng" -> "jungle";
+			case "middle", "mid" -> "mid";
+			case "bottom", "bot", "adc" -> "bottom";
+			case "support", "sup", "utility" -> "support";
+			default -> role.trim().toLowerCase(Locale.ROOT);
+		};
+	}
+
+	/** 영문 챔피언명으로 이미지 URL 을 조회한다. 매핑이 없으면 null (Flutter 가 Data Dragon 으로 폴백). */
+	private String resolveChampionImageUrl(String championName) {
+		if (championName == null || championName.isBlank()) {
+			return null;
+		}
+		String normalized = NameNormalizer.normalizeChampionName(championName);
+		return championRepository.findByChampionNameEn(normalized)
+				.map(Champion::getImageUrl)
+				.orElse(null);
+	}
+
+	private int elapsedSeconds(LocalDateTime t0, LocalDateTime frame) {
+		if (t0 == null || frame == null) {
+			return 0;
+		}
+		long seconds = frame.toEpochSecond(ZoneOffset.UTC) - t0.toEpochSecond(ZoneOffset.UTC);
+		return (int) Math.max(0, seconds);
+	}
+
+	private String formatGameTime(int totalSeconds) {
+		int minutes = totalSeconds / 60;
+		int seconds = totalSeconds % 60;
+		return String.format("%02d:%02d", minutes, seconds);
+	}
+
+	private String oppositeSide(String teamSide) {
+		if (BLUE.equalsIgnoreCase(teamSide)) {
+			return RED;
+		}
+		if (RED.equalsIgnoreCase(teamSide)) {
+			return BLUE;
+		}
+		return null;
+	}
+
+	private String teamNameBySide(String teamSide, String blueTeamName, String redTeamName) {
+		if (BLUE.equalsIgnoreCase(teamSide)) {
+			return blueTeamName;
+		}
+		if (RED.equalsIgnoreCase(teamSide)) {
+			return redTeamName;
+		}
+		return null;
+	}
+
+	private LiveGameState requireState(String gameId) {
+		return liveStateQueryService.getLatestState(gameId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "라이브 경기 정보를 찾을 수 없습니다."));
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/match/dto/LiveGameChampionsResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/match/dto/LiveGameChampionsResponse.java
@@ -1,0 +1,28 @@
+package com.toy.nar.app.mobile.match.dto;
+
+import java.util.List;
+
+/** 라이브 경기 챔피언 픽/밴 화면용 응답. */
+public record LiveGameChampionsResponse(
+		String gameId,
+		TeamChampions blueTeam,
+		TeamChampions redTeam) {
+
+	public record TeamChampions(
+			String teamName,
+			List<Pick> picks,
+			List<Ban> bans) {
+	}
+
+	public record Pick(
+			String position,
+			String championName,
+			String championImageUrl,
+			String playerName) {
+	}
+
+	public record Ban(
+			String championName,
+			String championImageUrl) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/match/dto/LiveGameEventsResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/match/dto/LiveGameEventsResponse.java
@@ -1,0 +1,44 @@
+package com.toy.nar.app.mobile.match.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * 라이브 경기 이벤트 타임라인 응답(최신순).
+ * KILL/DRAGON/BARON/TOWER/INHIBITOR 이벤트가 한 배열에 섞여 내려가며,
+ * type 에 따라 채워지는 필드가 다르므로 NULL 필드는 응답에서 생략한다.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LiveGameEventsResponse(
+		String gameId,
+		String blueTeamName,
+		String blueTeamImageUrl,
+		String redTeamName,
+		String redTeamImageUrl,
+		List<Event> events) {
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Event(
+			String type,
+			String gameTime,
+			Integer gameTimeSeconds,
+			// KILL 전용
+			Participant killer,
+			Participant victim,
+			Integer teamKillCount,
+			// DRAGON/BARON/TOWER/INHIBITOR 전용
+			String subType,
+			String teamSide,
+			String teamName,
+			Integer count) {
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Participant(
+			String playerName,
+			String championName,
+			String championImageUrl,
+			String teamSide) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -1,6 +1,9 @@
 package com.toy.nar.app.mobile.schedule;
 
 import com.toy.nar.app.lolesports.LeagueConstants;
+import com.toy.nar.app.lolesports.live.ActiveLiveGame;
+import com.toy.nar.app.lolesports.live.LiveStateStore;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
@@ -57,6 +60,8 @@ public class MobileScheduleService {
 	private final LeagueMatchRepository leagueMatchRepository;
 	private final LeagueMatchGameRepository leagueMatchGameRepository;
 	private final TeamRepository teamRepository;
+	private final LiveStateStore liveStateStore;
+	private final LiveGameMinuteSnapshotRepository minuteSnapshotRepository;
 
 	public MobileScheduleFilterResponse getFilters(String league) {
 		String normalizedLeague = normalizeLeague(league);
@@ -178,10 +183,43 @@ public class MobileScheduleService {
 	public MobileMatchGamesResponse getMatchGames(String matchId) {
 		LeagueMatch match = leagueMatchRepository.findById(matchId)
 				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
-		List<MobileScheduleListResponse.MobileGameSummary> games = leagueMatchGameRepository
-				.findMappedGameRowsByMatchId(match.getId(), LOLESPORTS_SOURCE).stream()
-				.map(this::toGameSummary)
-				.toList();
+		// 상태 판정용 집합: 현재 라이브(스토어) / 라이브 데이터 수집됨(영속 스냅샷, 종료 후에도 유지).
+		java.util.Set<String> liveGameIds = liveStateStore.getActiveGames().values().stream()
+				.filter(live -> match.getId().equals(live.matchId()))
+				.map(ActiveLiveGame::gameId)
+				.filter(gameId -> gameId != null && !gameId.isBlank())
+				.collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+		List<String> recordedGameIds = minuteSnapshotRepository.findGameIdsByMatchIdOrderByStart(match.getId());
+		java.util.Set<String> recordedSet = new java.util.LinkedHashSet<>(recordedGameIds);
+
+		List<MobileScheduleListResponse.MobileGameSummary> games = new ArrayList<>();
+		java.util.Set<String> knownGameIds = new java.util.LinkedHashSet<>();
+		int maxOrder = 0;
+
+		// 1) DB 공식 매핑 게임 (gameOrder, recordGameId 보존) + 상태 계산
+		for (LeagueMatchGameRepository.MappedGameRow row :
+				leagueMatchGameRepository.findMappedGameRowsByMatchId(match.getId(), LOLESPORTS_SOURCE)) {
+			String gameId = row.getExternalGameId();
+			games.add(new MobileScheduleListResponse.MobileGameSummary(
+					row.getGameOrder(), gameId, row.getInternalGameId(),
+					gameStatus(gameId, liveGameIds, recordedSet)));
+			knownGameIds.add(gameId);
+			if (row.getGameOrder() != null) {
+				maxOrder = Math.max(maxOrder, row.getGameOrder());
+			}
+		}
+
+		// 2) DB 매핑에 없는 세트 보강: 라이브 데이터를 수집한 게임(영속, 시작 시각 순) + 현재 라이브 게임.
+		//    데이터도 없고 라이브도 아닌 gameId 는 자연히 제외된다. 게임 종료/서버 재기동 후에도 유지된다.
+		java.util.LinkedHashSet<String> extraGameIds = new java.util.LinkedHashSet<>(recordedGameIds);
+		extraGameIds.addAll(liveGameIds);
+		extraGameIds.removeAll(knownGameIds);
+		int nextOrder = maxOrder + 1;
+		for (String gameId : extraGameIds) {
+			games.add(new MobileScheduleListResponse.MobileGameSummary(
+					nextOrder++, gameId, null, gameStatus(gameId, liveGameIds, recordedSet)));
+		}
+
 		return new MobileMatchGamesResponse(match.getId(), games);
 	}
 
@@ -261,10 +299,23 @@ public class MobileScheduleService {
 	}
 
 	private MobileScheduleListResponse.MobileGameSummary toGameSummary(LeagueMatchGameRepository.MappedGameRow row) {
+		// 일정 목록에서는 세트 상태를 계산하지 않는다(상세 화면에서만 채움).
 		return new MobileScheduleListResponse.MobileGameSummary(
 				row.getGameOrder(),
 				row.getExternalGameId(),
-				row.getInternalGameId());
+				row.getInternalGameId(),
+				null);
+	}
+
+	/** 게임 상태 판정: 라이브 스토어에 있으면 LIVE, 영속 데이터가 있으면 ENDED, 아니면 SCHEDULED. */
+	private String gameStatus(String gameId, java.util.Set<String> liveGameIds, java.util.Set<String> recordedGameIds) {
+		if (liveGameIds.contains(gameId)) {
+			return "LIVE";
+		}
+		if (recordedGameIds.contains(gameId)) {
+			return "ENDED";
+		}
+		return "SCHEDULED";
 	}
 
 	private MatchCursor decodeCursor(String cursor) {

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
@@ -31,7 +31,9 @@ public record MobileScheduleListResponse(
 			@Schema(description = "라이브/선수 평점 API에서 사용하는 esports gameId", example = "113990000000000001")
 			String gameId,
 			@Schema(description = "기록(record) API에서 사용하는 내부 gameId. 기록 미적재 시 null", example = "1024", nullable = true)
-			Long recordGameId) {
+			Long recordGameId,
+			@Schema(description = "세트 상태: LIVE(진행 중)/ENDED(종료, 데이터 보유)/SCHEDULED(예정). 일정 목록에서는 null", example = "LIVE", nullable = true)
+			String status) {
 	}
 
 	public record MobileTeamResult(

--- a/src/main/resources/db/migration/V42__Add_kill_participant_columns_to_live_game_object_event.sql
+++ b/src/main/resources/db/migration/V42__Add_kill_participant_columns_to_live_game_object_event.sql
@@ -1,0 +1,6 @@
+-- KILL 이벤트에 킬러/피해자 선수명과 피해자 챔피언을 함께 저장하기 위한 NULL 허용 컬럼 추가.
+-- 기존 행(킬러 챔피언만 event_sub_type에 저장)은 NULL 로 남으며, 모바일 타임라인 API가 NULL 을 허용한다.
+ALTER TABLE live_game_object_event
+    ADD COLUMN killer_player_name VARCHAR(64) NULL,
+    ADD COLUMN victim_champion VARCHAR(40) NULL,
+    ADD COLUMN victim_player_name VARCHAR(64) NULL;

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.lolesports.live;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.data.source.NotificationService;
 import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ import static org.mockito.Mockito.when;
 class LiveObjectEventRecorderTest {
 
 	private final LiveGameObjectEventRepository objectEventRepository = mock(LiveGameObjectEventRepository.class);
-	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(objectEventRepository);
+	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(objectEventRepository, mock(NotificationService.class));
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Test

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -4,6 +4,7 @@ import com.toy.nar.app.lolesports.LeagueMatchService;
 import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
 import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.data.source.NotificationService;
 import com.toy.nar.app.schedule.CacheEvictionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -39,7 +40,8 @@ class LivePollingSchedulerTest {
 				liveFrameProcessor,
 				liveGameMetadataService,
 				leagueMatchService,
-				cacheEvictionService);
+				cacheEvictionService,
+				mock(NotificationService.class));
 		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 2);
 		liveStateStore.getActiveGames().put("game-1", new ActiveLiveGame(
 				"game-1",
@@ -75,7 +77,8 @@ class LivePollingSchedulerTest {
 				liveFrameProcessor,
 				liveGameMetadataService,
 				leagueMatchService,
-				cacheEvictionService);
+				cacheEvictionService,
+				mock(NotificationService.class));
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		ActiveLiveGame activeGame = new ActiveLiveGame(
 				"game-1",
@@ -112,7 +115,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class),
 				mock(LiveGameMetadataService.class),
 				mock(LeagueMatchService.class),
-				mock(CacheEvictionService.class));
+				mock(CacheEvictionService.class),
+				mock(NotificationService.class));
 
 		Instant nextWindow = ReflectionTestUtils.invokeMethod(
 				scheduler,


### PR DESCRIPTION
## 개요
LCK 라이브 경기의 **디스코드 실시간 알림**과, 모바일 앱 경기상세용 **라이브 챔피언픽/이벤트 API**를 추가합니다. 실기기(갤럭시)에서 진행 중 LCK 경기로 end-to-end 검증 완료.

## 변경
**디스코드 라이브 알림** (LCK 한정, `lolesports.live.notification.{enabled,events-enabled,leagues}`)
- 경기 시작 / 킬(킬러→피해자 선수·챔피언) / 오브젝트(드래곤·바론·타워·억제기) 발생 시 발송
- 이벤트당 즉시(실시간) 발송, 중복 방지

**모바일 라이브 경기상세 API** (public)
- `GET /api/mobile/live/games/{gameId}/champions` — 진영별 5픽(포지션·챔피언·이미지·선수) + 밴(best-effort)
- `GET /api/mobile/live/games/{gameId}/events` — newest-first 타임라인(킬 킬러/피해자, 드래곤/바론/타워/억제기), 진영별 팀명·로고 포함
- `GET /api/mobile/matches/{matchId}/games` — **영속 라이브 데이터 기반 세트 병합** + 세트 상태(`LIVE`/`ENDED`/`SCHEDULED`). 종료 세트 유지, 진행 세트 자동 인식.

**데이터/정합성**
- 킬 victim 컬럼 추가 (`V42`), `gameTime` 을 게임 시작(최초 스냅샷 프레임) 기준으로 보정
- 세트별 블루/레드 진영 스왑 대응: 피드 `esportsTeamId` → `team_external_identity` → 팀명 매핑 (`LiveStateAggregator`)

## 검증
- `./gradlew compileJava` / 라이브 패키지 테스트 통과
- 실기기에서 챔피언픽·킬/오브젝트 타임라인·세트 상태·드래곤 팀 귀속 정상 확인

## 비용/후속 (별도 이슈로 등록)
- 라이브 수집 리그 제한(현재 전체 리그 폴링), `/events` gzip·캐시, 스냅샷 보존정책 등

🤖 Generated with [Claude Code](https://claude.com/claude-code)