### PR TITLE
feat: 라이브 경기상세 champions 응답에 배치 밴 데이터 연동

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/match/MobileLiveGameService.java
+++ b/src/main/java/com/toy/nar/app/mobile/match/MobileLiveGameService.java
@@ -3,13 +3,16 @@ package com.toy.nar.app.mobile.match;
 import com.toy.nar.app.lolesports.live.LiveStateQueryService;
 import com.toy.nar.app.lolesports.live.dto.LiveGameState;
 import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMapping;
 import com.toy.nar.app.lolesports.live.entity.LiveGameMinuteSnapshot;
 import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMappingRepository;
 import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
 import com.toy.nar.app.mobile.match.dto.LiveGameChampionsResponse;
 import com.toy.nar.app.mobile.match.dto.LiveGameEventsResponse;
 import com.toy.nar.common.util.NameNormalizer;
+import com.toy.nar.domain.game.repository.BanRepository;
 import com.toy.nar.domain.participant.entity.Champion;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.ChampionRepository;
@@ -27,6 +30,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +39,9 @@ public class MobileLiveGameService {
 
 	private static final String BLUE = "Blue";
 	private static final String RED = "Red";
+	// game_participants.side 를 대문자화한 진영 키 (밴 그룹핑용).
+	private static final String BLUE_SIDE_KEY = "BLUE";
+	private static final String RED_SIDE_KEY = "RED";
 	private static final String EVENT_KILL = "KILL";
 	private static final String EVENT_DRAGON = "DRAGON";
 
@@ -51,6 +58,8 @@ public class MobileLiveGameService {
 	private final LiveGameMinuteSnapshotRepository minuteSnapshotRepository;
 	private final ChampionRepository championRepository;
 	private final TeamRepository teamRepository;
+	private final LiveGameMappingRepository liveGameMappingRepository;
+	private final BanRepository banRepository;
 
 	public LiveGameChampionsResponse getChampions(String gameId) {
 		LiveGameState state = requireState(gameId);
@@ -64,10 +73,38 @@ public class MobileLiveGameService {
 				.sorted(pickComparator())
 				.toList();
 
+		Map<String, List<LiveGameChampionsResponse.Ban>> bansBySide = resolveBans(gameId);
+
 		return new LiveGameChampionsResponse(
 				gameId,
-				toTeamChampions(state.blueTeamName(), blue),
-				toTeamChampions(state.redTeamName(), red));
+				toTeamChampions(state.blueTeamName(), blue,
+						bansBySide.getOrDefault(BLUE_SIDE_KEY, List.of())),
+				toTeamChampions(state.redTeamName(), red,
+						bansBySide.getOrDefault(RED_SIDE_KEY, List.of())));
+	}
+
+	/**
+	 * 라이브 gameId 를 reconcile 된 배치 game 으로 매핑해 진영(BLUE/RED)별 밴 목록을 만든다.
+	 *
+	 * <p>라이브 피드에는 밴이 없어 배치 {@code bans} 테이블에서 가져온다. 아직 reconcile 되지
+	 * 않았거나(매핑의 internalGameId 가 null) 배치 적재 전이면 빈 맵을 반환한다. 배치는 6시간
+	 * 주기 적재라, 갓 끝난 경기의 밴은 다음 적재 + reconcile 이후에 노출된다(그 전엔 빈 목록).
+	 */
+	private Map<String, List<LiveGameChampionsResponse.Ban>> resolveBans(String liveGameId) {
+		Long internalGameId = liveGameMappingRepository.findByLiveGameId(liveGameId)
+				.map(LiveGameMapping::getInternalGameId)
+				.orElse(null);
+		if (internalGameId == null) {
+			return Map.of();
+		}
+		return banRepository.findLiveBanRowsByGameId(internalGameId).stream()
+				.filter(row -> row.getSide() != null)
+				.collect(Collectors.groupingBy(
+						row -> row.getSide().toUpperCase(Locale.ROOT),
+						Collectors.mapping(
+								row -> new LiveGameChampionsResponse.Ban(
+										row.getChampionName(), row.getImageUrl()),
+								Collectors.toList())));
 	}
 
 	public LiveGameEventsResponse getEvents(String gameId) {
@@ -130,7 +167,8 @@ public class MobileLiveGameService {
 	}
 
 	private LiveGameChampionsResponse.TeamChampions toTeamChampions(
-			String teamName, List<LiveParticipantState> participants) {
+			String teamName, List<LiveParticipantState> participants,
+			List<LiveGameChampionsResponse.Ban> bans) {
 		List<LiveGameChampionsResponse.Pick> picks = participants.stream()
 				.map(p -> new LiveGameChampionsResponse.Pick(
 						canonicalPosition(p.role()),
@@ -138,8 +176,8 @@ public class MobileLiveGameService {
 						resolveChampionImageUrl(p.championName()),
 						p.playerName()))
 				.toList();
-		// 라이브 상태에는 밴 정보가 없으므로 best-effort 로 빈 목록을 반환한다.
-		return new LiveGameChampionsResponse.TeamChampions(teamName, picks, List.of());
+		// 밴은 reconcile 된 배치 데이터에서 채운다(라이브 피드엔 밴이 없음). 없으면 빈 목록.
+		return new LiveGameChampionsResponse.TeamChampions(teamName, picks, bans);
 	}
 
 	private LiveGameEventsResponse.Event toEvent(

--- a/src/main/java/com/toy/nar/app/mobile/match/dto/LiveBanRow.java
+++ b/src/main/java/com/toy/nar/app/mobile/match/dto/LiveBanRow.java
@@ -1,0 +1,19 @@
+package com.toy.nar.app.mobile.match.dto;
+
+/**
+ * 라이브 경기상세 챔피언 화면에서 밴을 진영별로 채우기 위한 배치 밴 조회 프로젝션.
+ *
+ * <p>라이브 피드에는 밴 정보가 없어, reconcile 된 배치 game 의 {@code bans} 테이블에서
+ * 가져온다. {@code side} 는 {@code game_participants.side} 를 대문자화한 'BLUE'/'RED'.
+ */
+public interface LiveBanRow {
+
+	/** 'BLUE' 또는 'RED' (game_participants.side 대문자). */
+	String getSide();
+
+	/** 영문 챔피언명 (라이브 픽과 표기 일관). */
+	String getChampionName();
+
+	/** 챔피언 이미지 URL. 없으면 null (Flutter 가 Data Dragon 으로 폴백). */
+	String getImageUrl();
+}

--- a/src/main/java/com/toy/nar/domain/game/repository/BanRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/BanRepository.java
@@ -1,5 +1,6 @@
 package com.toy.nar.domain.game.repository;
 
+import com.toy.nar.app.mobile.match.dto.LiveBanRow;
 import com.toy.nar.app.schedule.dto.GameBanRow;
 import java.util.List;
 import java.util.Set;
@@ -23,6 +24,28 @@ public interface BanRepository extends JpaRepository<Ban, Long> {
 			"FROM Ban b " +
 			"WHERE b.game.id IN :gameIds")
 	List<GameBanRow> findScheduleBanRowsByGameIds(@Param("gameIds") Set<Long> gameIds);
+
+	/**
+	 * 라이브 경기상세용: 배치 game_id 의 밴을 진영(game_participants.side)별로 조회한다.
+	 *
+	 * <p>{@code bans.game_id} 는 유니크 인덱스 (game_id, banned_champion_id) 의 선두 컬럼이라
+	 * 인덱스 레인지 스캔이며(풀스캔 아님), 진영은 해당 게임의 game_participants 로만 좁혀 조인한다.
+	 */
+	@Query(value = """
+			SELECT UPPER(gp.side) AS side,
+			       c.champion_name_en AS championName,
+			       c.image_url AS imageUrl
+			FROM bans b
+			JOIN champions c ON c.champion_id = b.banned_champion_id
+			JOIN (
+				SELECT DISTINCT game_id, team_id, side
+				FROM game_participants
+				WHERE game_id = :gameId
+			) gp ON gp.game_id = b.game_id AND gp.team_id = b.team_id
+			WHERE b.game_id = :gameId
+			ORDER BY UPPER(gp.side), c.champion_name_en
+			""", nativeQuery = true)
+	List<LiveBanRow> findLiveBanRowsByGameId(@Param("gameId") Long gameId);
 
 	/**
 	 * 필터 기반 챔피언별 밴 횟수 조회

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -49,7 +49,7 @@ class MobileMatchControllerTest {
 								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 2),
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 1),
 								null,
-								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L)))),
+								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, "ENDED")))),
 						"cursor-token",
 						true));
 
@@ -71,8 +71,8 @@ class MobileMatchControllerTest {
 				.thenReturn(new MobileMatchGamesResponse(
 						"match-1",
 						List.of(
-								new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L),
-								new MobileScheduleListResponse.MobileGameSummary(2, "game-2", null))));
+								new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, "ENDED"),
+								new MobileScheduleListResponse.MobileGameSummary(2, "game-2", null, null))));
 
 		mockMvc.perform(get("/api/mobile/matches/match-1/games"))
 				.andExpect(status().isOk())

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -105,7 +105,7 @@ class MobileScheduleControllerTest {
 								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 0),
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 0),
 								null,
-								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L))))));
+								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, null))))));
 
 		mockMvc.perform(get("/api/mobile/schedules")
 						.param("date", "2026-04-01")

--- a/src/test/java/com/toy/nar/app/mobile/match/MobileLiveGameServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/match/MobileLiveGameServiceTest.java
@@ -1,0 +1,106 @@
+package com.toy.nar.app.mobile.match;
+
+import com.toy.nar.app.lolesports.live.LiveStateQueryService;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import com.toy.nar.app.lolesports.live.entity.LiveGameMapping;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMappingRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import com.toy.nar.app.mobile.match.dto.LiveBanRow;
+import com.toy.nar.app.mobile.match.dto.LiveGameChampionsResponse;
+import com.toy.nar.domain.game.repository.BanRepository;
+import com.toy.nar.domain.participant.repository.ChampionRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MobileLiveGameServiceTest {
+
+	private final LiveStateQueryService liveStateQueryService = mock(LiveStateQueryService.class);
+	private final LiveGameObjectEventRepository objectEventRepository = mock(LiveGameObjectEventRepository.class);
+	private final LiveGameMinuteSnapshotRepository minuteSnapshotRepository = mock(LiveGameMinuteSnapshotRepository.class);
+	private final ChampionRepository championRepository = mock(ChampionRepository.class);
+	private final TeamRepository teamRepository = mock(TeamRepository.class);
+	private final LiveGameMappingRepository liveGameMappingRepository = mock(LiveGameMappingRepository.class);
+	private final BanRepository banRepository = mock(BanRepository.class);
+
+	private final MobileLiveGameService service = new MobileLiveGameService(
+			liveStateQueryService,
+			objectEventRepository,
+			minuteSnapshotRepository,
+			championRepository,
+			teamRepository,
+			liveGameMappingRepository,
+			banRepository);
+
+	private LiveGameState stateWith(String blueTeam, String redTeam) {
+		// 참가자(픽)는 이 테스트의 관심사가 아니므로 빈 목록 — 밴 채움만 검증한다.
+		return new LiveGameState("LIVE_G", "M1", "LCK", blueTeam, redTeam, null, null, List.of(), List.of());
+	}
+
+	private LiveBanRow banRow(String side, String championName, String imageUrl) {
+		// 익명 구현 — mock 안에서 when() 을 호출하면 외부 stubbing 과 중첩돼 깨지므로 직접 구현.
+		return new LiveBanRow() {
+			@Override
+			public String getSide() {
+				return side;
+			}
+
+			@Override
+			public String getChampionName() {
+				return championName;
+			}
+
+			@Override
+			public String getImageUrl() {
+				return imageUrl;
+			}
+		};
+	}
+
+	@Test
+	void getChampions_reconcile된_경기는_배치_밴을_진영별로_채운다() {
+		when(liveStateQueryService.getLatestState("LIVE_G"))
+				.thenReturn(Optional.of(stateWith("T1", "Gen.G")));
+
+		LiveGameMapping mapping = mock(LiveGameMapping.class);
+		when(mapping.getInternalGameId()).thenReturn(100L);
+		when(liveGameMappingRepository.findByLiveGameId("LIVE_G")).thenReturn(Optional.of(mapping));
+
+		when(banRepository.findLiveBanRowsByGameId(100L)).thenReturn(List.of(
+				banRow("BLUE", "Aatrox", "url/aatrox"),
+				banRow("BLUE", "Karma", "url/karma"),
+				banRow("RED", "Yasuo", "url/yasuo")));
+
+		LiveGameChampionsResponse response = service.getChampions("LIVE_G");
+
+		assertThat(response.blueTeam().teamName()).isEqualTo("T1");
+		assertThat(response.blueTeam().bans())
+				.extracting(LiveGameChampionsResponse.Ban::championName)
+				.containsExactly("Aatrox", "Karma");
+		assertThat(response.blueTeam().bans().get(0).championImageUrl()).isEqualTo("url/aatrox");
+
+		assertThat(response.redTeam().teamName()).isEqualTo("Gen.G");
+		assertThat(response.redTeam().bans())
+				.extracting(LiveGameChampionsResponse.Ban::championName)
+				.containsExactly("Yasuo");
+	}
+
+	@Test
+	void getChampions_reconcile_안된_경기는_밴이_빈_목록이다() {
+		when(liveStateQueryService.getLatestState("LIVE_G"))
+				.thenReturn(Optional.of(stateWith("T1", "Gen.G")));
+		when(liveGameMappingRepository.findByLiveGameId("LIVE_G")).thenReturn(Optional.empty());
+
+		LiveGameChampionsResponse response = service.getChampions("LIVE_G");
+
+		assertThat(response.blueTeam().bans()).isEmpty();
+		assertThat(response.redTeam().bans()).isEmpty();
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -1,5 +1,7 @@
 package com.toy.nar.app.mobile.schedule;
 
+import com.toy.nar.app.lolesports.live.LiveStateStore;
+import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
@@ -36,6 +38,8 @@ class MobileScheduleServiceTest {
 	private LeagueMatchRepository leagueMatchRepository;
 	private LeagueMatchGameRepository leagueMatchGameRepository;
 	private TeamRepository teamRepository;
+	private LiveStateStore liveStateStore;
+	private LiveGameMinuteSnapshotRepository minuteSnapshotRepository;
 	private MobileScheduleService service;
 
 	@BeforeEach
@@ -43,7 +47,10 @@ class MobileScheduleServiceTest {
 		leagueMatchRepository = mock(LeagueMatchRepository.class);
 		leagueMatchGameRepository = mock(LeagueMatchGameRepository.class);
 		teamRepository = mock(TeamRepository.class);
-		service = new MobileScheduleService(leagueMatchRepository, leagueMatchGameRepository, teamRepository);
+		liveStateStore = mock(LiveStateStore.class);
+		minuteSnapshotRepository = mock(LiveGameMinuteSnapshotRepository.class);
+		service = new MobileScheduleService(leagueMatchRepository, leagueMatchGameRepository,
+				teamRepository, liveStateStore, minuteSnapshotRepository);
 	}
 
 	@Test


### PR DESCRIPTION
## 배경
라이브 피드에는 밴 정보가 없어 `GET /api/mobile/live/games/{gameId}/champions` 응답의 팀별 `bans` 가 항상 빈 목록(`List.of()`)이었다. 모바일 앱은 이미 밴 렌더링 UI를 갖추고 있어, 백엔드가 채우면 그대로 노출된다.

## 변경
- reconcile 된 배치 game(`live_game_mapping.internal_game_id`)의 `bans` 테이블에서 진영(`game_participants.side`)별 밴을 조회해 champions 응답에 채운다.
- 매핑 전(reconcile 안 됨)이거나 배치 적재 전이면 빈 목록 유지(graceful). 배치는 6시간 주기라 갓 끝난 경기 밴은 다음 적재+reconcile 후 노출.
- `BanRepository.findLiveBanRowsByGameId` 추가(+ `LiveBanRow` 프로젝션).
- 깨져 있던 테스트 소스셋 컴파일 복구(별도 커밋, `MobileGameSummary`·`MobileScheduleService` 생성자 시그니처 반영).

## 비용/인덱스
`bans.game_id` 는 유니크 인덱스 `(game_id, banned_champion_id)` 의 선두 컬럼 → `WHERE game_id=?` 는 인덱스 레인지 스캔(풀스캔 아님). 실제 DB EXPLAIN 으로 `key=UKig4ap7...`, `type=ref` 확인.

## 검증
- 단위 테스트 `MobileLiveGameServiceTest` (진영별 밴 채움 / reconcile 안 된 경기 빈 목록) 통과
- 실제 DB 에서 쿼리 결과(BLUE 5밴 + RED 5밴, 영문명+이미지URL) 및 EXPLAIN 인덱스 사용 확인
- `./gradlew clean build -x test`(CI 동일) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)