### PR TITLE
fix(deploy): Google Drive 동기화 시크릿 이름 오타 → 6h 배치 404 복구

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
               -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
               -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
               -e ELASTICSEARCH_URI="${{ secrets.ELASTICSEARCH_URI }}" \
-              -e GOOGLE_DRIVE_CSV_ID="${{ secrets.GOOGLE_DRIVE_CSV_FILE_ID }}" \
+              -e GOOGLE_DRIVE_CSV_ID="${{ secrets.GOOGLE_DRIVE_CSV_ID }}" \
               -e YOUTUBE_API_KEY="${{ secrets.YOUTUBE_API_KEY }}" \
               -e LOL_ESPORTS_KEY="${{ secrets.LOL_ESPORTS_KEY }}" \
               -e LOL_SYNC_CRON="0 0/30 * * * *" \


### PR DESCRIPTION
## 증상
6시간 주기 Google Drive 데이터 동기화가 매번 `404 Not Found` (`GET .../files/?alt=media`, 파일ID 공백)로 실패. 이로 인해 배치(games/bans 등) 적재가 안 돼 prod DB에 최신 경기·밴 데이터가 비어 있음.

## 원인
`deploy.yml` 이 `GOOGLE_DRIVE_CSV_ID` 환경변수를 **존재하지 않는 시크릿** `secrets.GOOGLE_DRIVE_CSV_FILE_ID` 에서 주입 → 빈 문자열 → `application-prod.yml` 의 `google.drive.csv-file-id: ${GOOGLE_DRIVE_CSV_ID}` 가 공백 → `drive.files().get("")` → 404. 실제 등록된 시크릿 이름은 `GOOGLE_DRIVE_CSV_ID`.

## 수정
시크릿 참조를 `secrets.GOOGLE_DRIVE_CSV_ID` 로 교정(1줄).

## 주의 / 확인 필요
- 시크릿 `GOOGLE_DRIVE_CSV_ID` 의 **값**이 유효한 Drive 파일ID(코드 기본값 `1hnpbrUpBMS1TZI7IovfpKeZfWJH1Aptm`)이고 서비스 계정에 공유돼 있어야 한다. 값이 비어있거나 틀리면 이름 교정만으로는 여전히 404.
- 머지 시 prod 재배포 → 다음 배치 주기에 적재 성공 여부 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)