### PR TITLE
feat: 라이브 경기 FCM 푸시 파이프라인 (플래그 게이트, #21)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/ActiveLiveGame.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/ActiveLiveGame.java
@@ -9,18 +9,38 @@ public record ActiveLiveGame(
 		String blueTeamName,
 		String redTeamName,
 		LocalDateTime lastSeenAtUtc,
-		int consecutiveFailures) {
+		int consecutiveFailures,
+		// 아래는 라이브 FCM 푸시(#21) 전용 메타데이터. 기존 경로에서는 nullable 이며 사용하지 않는다.
+		Integer setNumber,
+		String blueEsportsTeamId,
+		String redEsportsTeamId) {
+
+	/** 기존 호출부 호환용 생성자. FCM 메타데이터(setNumber/esportsTeamId) 없이 생성한다. */
+	public ActiveLiveGame(
+			String gameId,
+			String matchId,
+			String leagueName,
+			String blueTeamName,
+			String redTeamName,
+			LocalDateTime lastSeenAtUtc,
+			int consecutiveFailures) {
+		this(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc, consecutiveFailures,
+				null, null, null);
+	}
 
 	public ActiveLiveGame withLastSeenAt(LocalDateTime seenAtUtc) {
-		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, seenAtUtc, consecutiveFailures);
+		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, seenAtUtc, consecutiveFailures,
+				setNumber, blueEsportsTeamId, redEsportsTeamId);
 	}
 
 	public ActiveLiveGame increaseFailures() {
-		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc, consecutiveFailures + 1);
+		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc,
+				consecutiveFailures + 1, setNumber, blueEsportsTeamId, redEsportsTeamId);
 	}
 
 	public ActiveLiveGame clearFailures() {
-		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc, 0);
+		return new ActiveLiveGame(gameId, matchId, leagueName, blueTeamName, redTeamName, lastSeenAtUtc, 0,
+				setNumber, blueEsportsTeamId, redEsportsTeamId);
 	}
 
 	public ActiveLiveGame mergeMissingMetadata(ActiveLiveGame metadata) {
@@ -34,7 +54,10 @@ public record ActiveLiveGame(
 				firstDisplayName(blueTeamName, metadata.blueTeamName()),
 				firstDisplayName(redTeamName, metadata.redTeamName()),
 				lastSeenAtUtc,
-				consecutiveFailures);
+				consecutiveFailures,
+				setNumber != null ? setNumber : metadata.setNumber(),
+				firstUseful(blueEsportsTeamId, metadata.blueEsportsTeamId()),
+				firstUseful(redEsportsTeamId, metadata.redEsportsTeamId()));
 	}
 
 	private String firstUseful(String current, String fallback) {

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -33,7 +33,10 @@ public class LiveObjectEventRecorder {
 
 	private final LiveGameObjectEventRepository objectEventRepository;
 	private final NotificationService notificationService;
+	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
 	private final Map<String, ObservedObjectState> lastObservedByGame = new ConcurrentHashMap<>();
+	// [FCM #21] 세트마다 진영이 스왑되므로, 피드 window 의 진영별 esportsTeamId 를 게임별로 기억한다(Blue/Red → esportsTeamId).
+	private final Map<String, SideTeamIds> sideTeamIdsByGame = new ConcurrentHashMap<>();
 
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.events-enabled:false}")
 	private boolean eventNotificationEnabled;
@@ -47,6 +50,7 @@ public class LiveObjectEventRecorder {
 			return;
 		}
 		lastObservedByGame.remove(gameId);
+		sideTeamIdsByGame.remove(gameId);
 	}
 
 	@Transactional
@@ -56,7 +60,10 @@ public class LiveObjectEventRecorder {
 			return;
 		}
 
-		Map<Integer, ParticipantMeta> metadata = parseMetadata(windowResponse.path("gameMetadata"));
+		JsonNode gameMetadata = windowResponse.path("gameMetadata");
+		Map<Integer, ParticipantMeta> metadata = parseMetadata(gameMetadata);
+		// [FCM #21] 진영별 esportsTeamId 기억(세트마다 스왑되므로 window 기준이 신뢰 가능). 플래그 무관하게 가벼운 파싱.
+		rememberSideTeamIds(activeGame.gameId(), gameMetadata);
 
 		List<FrameSnapshot> snapshots = toSnapshots(frames);
 		if (snapshots.isEmpty()) {
@@ -222,7 +229,7 @@ public class LiveObjectEventRecorder {
 				eventOrder,
 				valueAfter,
 				frameTimestampUtc);
-		objectEventRepository.save(event);
+		event = objectEventRepository.save(event);
 		log.info("[live-notify] event saved type={} team={} order={} gameId={} notify={}",
 				eventType, teamSide, eventOrder, activeGame.gameId(), eventNotificationEnabled);
 
@@ -235,6 +242,12 @@ public class LiveObjectEventRecorder {
 					eventSubType,
 					eventOrder,
 					activeGame.gameId());
+		}
+
+		// [FCM #21] LIVE_EVENT 푸시. live.notification.fcm.enabled 플래그로 게이트.
+		// 멱등 키 event_order 는 킬/오브젝트 충돌을 막기 위해 저장된 이벤트의 전역 id 를 쓴다.
+		if (teamLiveEventPushService.isEnabled() && isNotifiableLeague(activeGame.leagueName())) {
+			fireLiveEventPush(activeGame, teamSide, objectEventLabel(eventType, eventSubType), event.getId());
 		}
 	}
 
@@ -271,7 +284,7 @@ public class LiveObjectEventRecorder {
 				victim == null ? null : victim.champion(),
 				victim == null ? null : victim.summonerName(),
 				frameTimestampUtc);
-		objectEventRepository.save(event);
+		event = objectEventRepository.save(event);
 		log.info("[live-notify] kill saved order={} team={} killer={} victim={} gameId={} notify={}",
 				eventOrder, killerSide,
 				killer == null ? "?" : killer.summonerName(),
@@ -289,6 +302,11 @@ public class LiveObjectEventRecorder {
 					victim == null ? null : victim.champion(),
 					eventOrder,
 					activeGame.gameId());
+		}
+
+		// [FCM #21] LIVE_EVENT(킬) 푸시. live.notification.fcm.enabled 플래그로 게이트.
+		if (teamLiveEventPushService.isEnabled() && isNotifiableLeague(activeGame.leagueName())) {
+			fireLiveEventPush(activeGame, killerSide, killEventLabel(killerSide, teamKillsAfter), event.getId());
 		}
 	}
 
@@ -357,6 +375,75 @@ public class LiveObjectEventRecorder {
 		return result;
 	}
 
+	/**
+	 * [FCM #21] 피드 window 의 진영별 esportsTeamId 를 기억한다. 세트마다 진영이 스왑되므로
+	 * 매치 고정 ID 가 아니라 이 값으로 진영-팀을 맞춰야 한다.
+	 */
+	private void rememberSideTeamIds(String gameId, JsonNode gameMetadata) {
+		if (gameId == null || gameMetadata == null || gameMetadata.isMissingNode()) {
+			return;
+		}
+		String blue = textOrNull(gameMetadata.path("blueTeamMetadata"), "esportsTeamId");
+		String red = textOrNull(gameMetadata.path("redTeamMetadata"), "esportsTeamId");
+		if (blue != null || red != null) {
+			sideTeamIdsByGame.put(gameId, new SideTeamIds(blue, red));
+		}
+	}
+
+	/** [FCM #21] LIVE_EVENT 푸시 호출. 진영별 esportsTeamId(window 기준)로 이벤트를 일으킨 팀 구독자에게 발송. */
+	private void fireLiveEventPush(ActiveLiveGame activeGame, String teamSide, String eventLabel, long eventOrder) {
+		try {
+			SideTeamIds sideIds = sideTeamIdsByGame.get(activeGame.gameId());
+			if (sideIds == null) {
+				return;
+			}
+			boolean blue = "Blue".equalsIgnoreCase(teamSide);
+			String actingEsportsTeamId = blue ? sideIds.blue() : sideIds.red();
+			if (actingEsportsTeamId == null || actingEsportsTeamId.isBlank()) {
+				return;
+			}
+			String actingTeamName = teamNameOf(activeGame, teamSide);
+			String opponentTeamName = teamNameOf(activeGame, blue ? "Red" : "Blue");
+			teamLiveEventPushService.notifyLiveEvent(
+					activeGame.matchId(),
+					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
+					eventOrder,
+					actingEsportsTeamId,
+					actingTeamName,
+					opponentTeamName,
+					eventLabel);
+		} catch (Exception e) {
+			log.warn("[live-notify] live-event FCM failed gameId={} side={}: {}",
+					activeGame.gameId(), teamSide, e.getMessage());
+		}
+	}
+
+	private String objectEventLabel(String eventType, String eventSubType) {
+		return switch (eventType) {
+			case EVENT_DRAGON -> "드래곤 처치";
+			case EVENT_BARON -> "바론 처치";
+			case EVENT_TOWER -> "포탑 파괴";
+			case EVENT_INHIBITOR -> "억제기 파괴";
+			default -> eventType;
+		};
+	}
+
+	private String killEventLabel(String killerSide, int teamKillsAfter) {
+		return teamKillsAfter + "킬 달성";
+	}
+
+	private String textOrNull(JsonNode node, String field) {
+		if (node == null || node.isMissingNode()) {
+			return null;
+		}
+		JsonNode target = node.path(field);
+		if (target.isMissingNode() || target.isNull()) {
+			return null;
+		}
+		String value = target.asText(null);
+		return value == null || value.isBlank() ? null : value;
+	}
+
 	/** 알림 대상 리그인지 (notificationLeagues 설정, 기본 LCK). 그 외 리그는 디스코드 알림 안 보냄. */
 	private boolean isNotifiableLeague(String league) {
 		if (league == null || league.isBlank()) {
@@ -383,6 +470,10 @@ public class LiveObjectEventRecorder {
 	}
 
 	private record Kd(int kills, int deaths) {
+	}
+
+	/** [FCM #21] 피드 window 기준 진영별 esportsTeamId. 세트마다 스왑되므로 게임별로 캐시한다. */
+	private record SideTeamIds(String blue, String red) {
 	}
 
 	private record ParticipantMeta(String summonerName, String champion) {

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -47,6 +47,7 @@ public class LivePollingScheduler {
 	private final LeagueMatchService leagueMatchService;
 	private final CacheEvictionService cacheEvictionService;
 	private final NotificationService notificationService;
+	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
 
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.stale-threshold-ms:180000}")
 	private long staleThresholdMs;
@@ -92,6 +93,11 @@ public class LivePollingScheduler {
 						String resolvedLeagueName = (match.getLeagueName() == null || match.getLeagueName().isBlank())
 								? league
 								: match.getLeagueName();
+						// 세트마다 진영(블루/레드)이 스왑되므로 매치 기준 팀명/팀ID 만으로는 진영을 단정할 수 없다.
+						// SET_START 는 'A vs B' 매치 단위 프레이밍이라 매치 기준 esportsTeamId 로 충분하다.
+						Integer setNumber = resolveSetNumber(match, gameId);
+						String blueExternalId = match.getBlueTeam() != null ? match.getBlueTeam().getExternalTeamId() : null;
+						String redExternalId = match.getRedTeam() != null ? match.getRedTeam().getExternalTeamId() : null;
 						ActiveLiveGame next = new ActiveLiveGame(
 								gameId,
 								match.getMatchId(),
@@ -99,7 +105,10 @@ public class LivePollingScheduler {
 								match.getBlueTeam() != null ? match.getBlueTeam().getName() : null,
 								match.getRedTeam() != null ? match.getRedTeam().getName() : null,
 								nowUtc,
-								current != null ? current.consecutiveFailures() : 0);
+								current != null ? current.consecutiveFailures() : 0,
+								setNumber,
+								blueExternalId,
+								redExternalId);
 						activeGames.put(gameId, next);
 						liveGameMetadataService.remember(next);
 
@@ -112,6 +121,20 @@ public class LivePollingScheduler {
 									next.redTeamName(),
 									gameId,
 									match.getMatchId());
+						}
+
+						// [FCM #21] SET_START 푸시. live.notification.fcm.enabled 플래그로 게이트.
+						// 디스코드 알림과 같은 'current == null'(새 세트 최초 발견) 조건에서만 1회 발송.
+						if (teamLiveEventPushService.isEnabled() && current == null
+								&& isNotifiableLeague(resolvedLeagueName)) {
+							teamLiveEventPushService.notifyMatchEvent(
+									com.toy.nar.app.mobile.push.TeamLiveEventPushService.TYPE_SET_START,
+									match.getMatchId(),
+									setNumber != null ? setNumber : 0,
+									blueExternalId,
+									redExternalId,
+									next.blueTeamName(),
+									next.redTeamName());
 						}
 					}
 				}
@@ -129,6 +152,15 @@ public class LivePollingScheduler {
 			boolean notDiscovered = !discoveredGameIds.contains(activeGame.gameId());
 			boolean stale = activeGame.lastSeenAtUtc() != null
 					&& java.time.Duration.between(activeGame.lastSeenAtUtc(), nowUtc).toMillis() > staleThresholdMs;
+
+			// [FCM #21] SET_END 감지(신규). 직전까지 활성이던 gameId 가 이번 사이클 피드의 라이브 세트에서
+			// 빠지면(=notDiscovered) 세트 종료로 본다. 플래그 게이트 + dedup 으로 1회만 발송된다.
+			// 플래그가 꺼져 있으면 어떤 부작용도 없다(기존 cleanup 동작과 바이트 동일).
+			if (notDiscovered && teamLiveEventPushService.isEnabled()
+					&& isNotifiableLeague(activeGame.leagueName())) {
+				fireSetEndNotification(activeGame);
+			}
+
 			if (notDiscovered && stale) {
 				toRemove.add(activeGame.gameId());
 			}
@@ -138,6 +170,32 @@ public class LivePollingScheduler {
 			liveStateStore.removeGame(gameId);
 			liveObjectEventRecorder.evict(gameId);
 		});
+	}
+
+	/** gameId 의 매치 내 1-based 세트 번호. match.gameIds 의 순서가 세트 순서다. 못 찾으면 null. */
+	private Integer resolveSetNumber(MatchResultDto match, String gameId) {
+		if (match.getGameIds() == null) {
+			return null;
+		}
+		int index = match.getGameIds().indexOf(gameId);
+		return index < 0 ? null : index + 1;
+	}
+
+	/** [FCM #21] SET_END 푸시. 매치 단위 프레이밍이라 매치 기준 esportsTeamId 로 양 팀 구독자에게 발송(dedup 1회). */
+	private void fireSetEndNotification(ActiveLiveGame activeGame) {
+		try {
+			teamLiveEventPushService.notifyMatchEvent(
+					com.toy.nar.app.mobile.push.TeamLiveEventPushService.TYPE_SET_END,
+					activeGame.matchId(),
+					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
+					activeGame.blueEsportsTeamId(),
+					activeGame.redEsportsTeamId(),
+					activeGame.blueTeamName(),
+					activeGame.redTeamName());
+		} catch (Exception e) {
+			log.warn("[live-notify] set-end FCM failed gameId={} matchId={}: {}",
+					activeGame.gameId(), activeGame.matchId(), e.getMessage());
+		}
 	}
 
 	private Set<String> activeMatchIds(Map<String, ActiveLiveGame> activeGames) {

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -1,0 +1,276 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.domain.member.entity.MemberDevice;
+import com.toy.nar.domain.member.repository.MemberDeviceRepository;
+import com.toy.nar.domain.member.repository.MemberTeamEventPushDeliveryRepository;
+import com.toy.nar.domain.participant.LckTeamCatalog;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 라이브 경기 팀 이벤트 FCM 푸시 서비스 (#21).
+ * {@code PlayerSoloRankPushService} 패턴을 복제했다.
+ *
+ * <p>모든 동작은 {@code live.notification.fcm.enabled} 플래그로 게이트된다(기본 false).
+ * 플래그가 꺼져 있으면 어떤 조회/발송도 하지 않는다.</p>
+ *
+ * <p>멱등 키가 팀이 아니라 matchId 라서, 한 회원이 한 경기의 양 팀을 모두 구독했더라도
+ * 이벤트당 1번만 발송된다(두 번째 팀 fan-out 시 reserve()=0 → skip).</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamLiveEventPushService {
+
+	private static final String LOLESPORTS_SOURCE = "LOLESPORTS";
+
+	/** 모바일과 일치해야 하는 data.type 값. */
+	public static final String TYPE_SET_START = "SET_START";
+	public static final String TYPE_SET_END = "SET_END";
+	public static final String TYPE_LIVE_EVENT = "LIVE_EVENT";
+
+	/** SET_START / SET_END 는 세트 내 순번이 없으므로 멱등 키 event_order 에 상수 0 을 쓴다. */
+	private static final long NO_EVENT_ORDER = 0L;
+
+	private final MemberDeviceRepository deviceRepository;
+	private final MemberTeamEventPushDeliveryRepository deliveryRepository;
+	private final TeamExternalIdentityRepository teamExternalIdentityRepository;
+	private final MobilePushGateway pushGateway;
+
+	@Value("${live.notification.fcm.enabled:false}")
+	private boolean fcmNotificationEnabled;
+
+	public boolean isEnabled() {
+		return fcmNotificationEnabled;
+	}
+
+	/**
+	 * 세트 시작/종료 등 경기 단위 이벤트. 경기의 양 진영 팀 구독자에게 모두 발송한다(dedup 으로 1인 1회 보장).
+	 */
+	public void notifyMatchEvent(
+			String eventType,
+			String matchId,
+			int setNumber,
+			String blueEsportsTeamId,
+			String redEsportsTeamId,
+			String blueTeamName,
+			String redTeamName) {
+		if (!isReady() || matchId == null || matchId.isBlank()) {
+			return;
+		}
+		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
+				blueEsportsTeamId, blueTeamName, redTeamName, true);
+		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
+				redEsportsTeamId, redTeamName, blueTeamName, false);
+	}
+
+	/**
+	 * 라이브 이벤트(킬/오브젝트 등). 이벤트를 일으킨 팀(actingEsportsTeamId) 구독자에게 발송한다.
+	 * event_order 는 같은 세트 안의 이벤트 순번이라 멱등 키에 포함된다.
+	 */
+	public void notifyLiveEvent(
+			String matchId,
+			int setNumber,
+			long eventOrder,
+			String actingEsportsTeamId,
+			String actingTeamName,
+			String opponentTeamName,
+			String eventLabel) {
+		if (!isReady() || matchId == null || matchId.isBlank()) {
+			return;
+		}
+		Optional<Team> team = resolveLckTeam(actingEsportsTeamId);
+		if (team.isEmpty()) {
+			return;
+		}
+		Team resolved = team.get();
+		String teamName = preferDisplayName(actingTeamName, resolved.getName());
+		MobilePushMessage message = buildLiveEventMessage(
+				matchId, setNumber, teamName, eventLabel);
+		fanOut(TYPE_LIVE_EVENT, matchId, setNumber, eventOrder, resolved.getId(), message);
+	}
+
+	private void notifyTeamSide(
+			String eventType,
+			String matchId,
+			int setNumber,
+			long eventOrder,
+			String esportsTeamId,
+			String teamName,
+			String opponentTeamName,
+			boolean blueSide) {
+		Optional<Team> team = resolveLckTeam(esportsTeamId);
+		if (team.isEmpty()) {
+			return;
+		}
+		Team resolved = team.get();
+		String displayName = preferDisplayName(teamName, resolved.getName());
+		String opponent = opponentTeamName;
+		String blue = blueSide ? displayName : opponent;
+		String red = blueSide ? opponent : displayName;
+		MobilePushMessage message = buildMatchEventMessage(
+				eventType, matchId, setNumber, displayName, blue, red);
+		fanOut(eventType, matchId, setNumber, eventOrder, resolved.getId(), message);
+	}
+
+	private void fanOut(
+			String eventType,
+			String matchId,
+			int setNumber,
+			long eventOrder,
+			Long teamId,
+			MobilePushMessage message) {
+		try {
+			List<MemberDevice> devices =
+					deviceRepository.findActiveDevicesBySubscribedTeamId(teamId, eventType);
+			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
+					.collect(Collectors.groupingBy(
+							device -> device.getMember().getId(),
+							LinkedHashMap::new,
+							Collectors.toList()));
+			for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
+				sendToMember(entry.getKey(), entry.getValue(), eventType, matchId, setNumber, eventOrder, message);
+			}
+		} catch (Exception e) {
+			log.warn("Failed to prepare team live event pushes eventType={} matchId={} setNumber={} teamId={}",
+					eventType, matchId, setNumber, teamId, e);
+		}
+	}
+
+	private void sendToMember(
+			Long memberId,
+			List<MemberDevice> devices,
+			String eventType,
+			String matchId,
+			int setNumber,
+			long eventOrder,
+			MobilePushMessage message) {
+		try {
+			// dedup: 양 팀 구독자라도 (member, matchId, setNumber, eventType, eventOrder) 1회만 통과한다.
+			if (deliveryRepository.reserve(memberId, matchId, setNumber, eventType, eventOrder) == 0) {
+				return;
+			}
+			List<String> tokens = devices.stream().map(MemberDevice::getFcmToken).toList();
+			MobilePushResult result = pushGateway.send(tokens, message);
+			if (!result.invalidTokens().isEmpty()) {
+				deactivateInvalidTokens(result.invalidTokens(), matchId, eventType);
+			}
+			if (result.successCount() > 0) {
+				deliveryRepository.markSent(memberId, matchId, setNumber, eventType, eventOrder);
+			} else {
+				deliveryRepository.markFailed(memberId, matchId, setNumber, eventType, eventOrder,
+						"FCM 전송 성공 기기가 없습니다.");
+			}
+		} catch (Exception e) {
+			markFailed(memberId, matchId, setNumber, eventType, eventOrder, truncate(e.getMessage()));
+			log.warn("Team live event push failed memberId={} eventType={} matchId={} setNumber={} eventOrder={}",
+					memberId, eventType, matchId, setNumber, eventOrder, e);
+		}
+	}
+
+	private void deactivateInvalidTokens(List<String> invalidTokens, String matchId, String eventType) {
+		try {
+			deviceRepository.deactivateByFcmTokenIn(invalidTokens);
+		} catch (Exception e) {
+			log.warn("Failed to deactivate invalid FCM tokens matchId={} eventType={}", matchId, eventType, e);
+		}
+	}
+
+	private void markFailed(
+			Long memberId,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder,
+			String errorMessage) {
+		try {
+			deliveryRepository.markFailed(memberId, matchId, setNumber, eventType, eventOrder, errorMessage);
+		} catch (Exception persistenceException) {
+			log.warn("Failed to persist team push failure memberId={} matchId={} eventType={}",
+					memberId, matchId, eventType, persistenceException);
+		}
+	}
+
+	/** esportsTeamId → Team 매핑 후 LCK 팀만 통과시킨다. 세트마다 진영이 스왑되므로 매 호출마다 진영별로 해석한다. */
+	private Optional<Team> resolveLckTeam(String esportsTeamId) {
+		if (esportsTeamId == null || esportsTeamId.isBlank()) {
+			return Optional.empty();
+		}
+		return teamExternalIdentityRepository
+				.findBySourceAndExternalTeamId(LOLESPORTS_SOURCE, esportsTeamId)
+				.map(identity -> identity.getTeam())
+				.filter(team -> LckTeamCatalog.contains(team.getCode()));
+	}
+
+	private MobilePushMessage buildMatchEventMessage(
+			String eventType,
+			String matchId,
+			int setNumber,
+			String teamName,
+			String blueTeamName,
+			String redTeamName) {
+		String matchup = matchup(blueTeamName, redTeamName);
+		String title;
+		String body;
+		if (TYPE_SET_END.equals(eventType)) {
+			title = teamName + " 세트 종료";
+			body = matchup + " · " + setNumber + "세트 종료";
+		} else {
+			title = teamName + " 세트 시작";
+			body = matchup + " · " + setNumber + "세트 시작";
+		}
+		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber));
+	}
+
+	private MobilePushMessage buildLiveEventMessage(
+			String matchId,
+			int setNumber,
+			String teamName,
+			String eventLabel) {
+		String label = eventLabel == null || eventLabel.isBlank() ? "라이브 이벤트" : eventLabel;
+		String title = teamName + " " + label;
+		String body = teamName + " " + label + " · " + setNumber + "세트";
+		return new MobilePushMessage(title, body, baseData(TYPE_LIVE_EVENT, matchId, setNumber));
+	}
+
+	/** 모바일 계약: data.type / data.matchId / data.setNumber 는 모두 String. */
+	private Map<String, String> baseData(String eventType, String matchId, int setNumber) {
+		Map<String, String> data = new LinkedHashMap<>();
+		data.put("type", eventType);
+		data.put("matchId", matchId);
+		data.put("setNumber", String.valueOf(setNumber));
+		return Map.copyOf(data);
+	}
+
+	private String matchup(String blueTeamName, String redTeamName) {
+		String blue = blueTeamName == null || blueTeamName.isBlank() ? "Blue" : blueTeamName;
+		String red = redTeamName == null || redTeamName.isBlank() ? "Red" : redTeamName;
+		return blue + " vs " + red;
+	}
+
+	private String preferDisplayName(String feedName, String resolvedName) {
+		if (feedName != null && !feedName.isBlank()) {
+			return feedName;
+		}
+		return resolvedName;
+	}
+
+	private boolean isReady() {
+		return fcmNotificationEnabled && pushGateway.isAvailable();
+	}
+
+	private String truncate(String message) {
+		String normalized = message == null || message.isBlank() ? "알 수 없는 FCM 오류" : message;
+		return normalized.length() <= 500 ? normalized : normalized.substring(0, 500);
+	}
+}

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberTeamEventPushDelivery.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberTeamEventPushDelivery.java
@@ -1,0 +1,72 @@
+package com.toy.nar.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 라이브 경기 팀 이벤트 FCM 푸시(#21) 멱등 처리 테이블.
+ * 유니크 키 (member_id, match_id, set_number, event_type, event_order) 로 한 회원당 이벤트 1회 발송을 보장한다.
+ * 키가 팀이 아니라 match_id 라서, 한 회원이 한 경기의 양 팀을 모두 구독해도 이벤트당 1번만 발송된다(두 번째 팀 reserve()=0).
+ * PlayerSoloRankPushDelivery 패턴을 그대로 복제했다.
+ */
+@Entity
+@Table(name = "member_team_event_push_delivery", uniqueConstraints = {
+		@UniqueConstraint(
+				name = "uk_member_team_event_push_delivery",
+				columnNames = { "member_id", "match_id", "set_number", "event_type", "event_order" })
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTeamEventPushDelivery {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "match_id", nullable = false, length = 64)
+	private String matchId;
+
+	@Column(name = "set_number", nullable = false)
+	private int setNumber;
+
+	@Column(name = "event_type", nullable = false, length = 20)
+	private String eventType;
+
+	@Column(name = "event_order", nullable = false)
+	private long eventOrder;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20)
+	private PushDeliveryStatus status;
+
+	@Column(name = "error_message", length = 500)
+	private String errorMessage;
+
+	@Column(name = "sent_at")
+	private LocalDateTime sentAt;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
@@ -32,6 +32,32 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
 			""")
 	List<MemberDevice> findActiveDevicesBySubscribedPlayerId(@Param("playerId") Long playerId);
 
+	/**
+	 * 특정 팀을 구독하고 해당 이벤트 토글(SET_START/SET_END/LIVE_EVENT)이 켜진 회원들의 활성 기기 목록.
+	 * 라이브 FCM 푸시(#21) 전용. 토글은 eventType 에 따라 다른 컬럼을 본다(EXISTS + CASE).
+	 * 기존 player 구독 쿼리(findActiveDevicesBySubscribedPlayerId)와 동일한 패턴이다.
+	 */
+	@EntityGraph(attributePaths = "member")
+	@Query("""
+			SELECT DISTINCT device
+			FROM MemberDevice device
+			WHERE device.active = true
+			  AND EXISTS (
+				  SELECT subscription.id
+				  FROM MemberTeamNotificationSubscription subscription
+				  WHERE subscription.member = device.member
+				    AND subscription.team.id = :teamId
+				    AND (
+				        (:eventType = 'SET_START' AND subscription.setStartEnabled = true)
+				        OR (:eventType = 'SET_END' AND subscription.setEndEnabled = true)
+				        OR (:eventType = 'LIVE_EVENT' AND subscription.liveEventEnabled = true)
+				    )
+			  )
+			""")
+	List<MemberDevice> findActiveDevicesBySubscribedTeamId(
+			@Param("teamId") Long teamId,
+			@Param("eventType") String eventType);
+
 	@Modifying(clearAutomatically = true)
 	@Transactional
 	@Query("""

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
@@ -1,0 +1,108 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.MemberTeamEventPushDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 라이브 경기 팀 이벤트 FCM 푸시(#21) 멱등 리포지토리.
+ * PlayerSoloRankPushDeliveryRepository 의 reserve / markSent / markFailed 패턴을 복제했다.
+ * 멱등 키는 (member_id, match_id, set_number, event_type, event_order).
+ */
+public interface MemberTeamEventPushDeliveryRepository
+		extends JpaRepository<MemberTeamEventPushDelivery, Long> {
+
+	@Modifying
+	@Transactional
+	@Query(value = """
+			INSERT IGNORE INTO member_team_event_push_delivery (
+				member_id,
+				match_id,
+				set_number,
+				event_type,
+				event_order,
+				status,
+				created_at,
+				updated_at
+			) VALUES (
+				:memberId,
+				:matchId,
+				:setNumber,
+				:eventType,
+				:eventOrder,
+				'PENDING',
+				NOW(),
+				NOW()
+			)
+			ON DUPLICATE KEY UPDATE
+				error_message = IF(
+					status = 'FAILED'
+						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
+					NULL,
+					error_message
+				),
+				updated_at = IF(
+					status = 'FAILED'
+						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
+					NOW(),
+					updated_at
+				),
+				status = IF(
+					status = 'FAILED'
+						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
+					'PENDING',
+					status
+				)
+			""", nativeQuery = true)
+	int reserve(
+			@Param("memberId") Long memberId,
+			@Param("matchId") String matchId,
+			@Param("setNumber") int setNumber,
+			@Param("eventType") String eventType,
+			@Param("eventOrder") long eventOrder);
+
+	@Modifying
+	@Transactional
+	@Query("""
+			UPDATE MemberTeamEventPushDelivery delivery
+			SET delivery.status = com.toy.nar.domain.member.entity.PushDeliveryStatus.SENT,
+			    delivery.errorMessage = null,
+			    delivery.sentAt = CURRENT_TIMESTAMP,
+			    delivery.updatedAt = CURRENT_TIMESTAMP
+			WHERE delivery.member.id = :memberId
+			  AND delivery.matchId = :matchId
+			  AND delivery.setNumber = :setNumber
+			  AND delivery.eventType = :eventType
+			  AND delivery.eventOrder = :eventOrder
+			""")
+	int markSent(
+			@Param("memberId") Long memberId,
+			@Param("matchId") String matchId,
+			@Param("setNumber") int setNumber,
+			@Param("eventType") String eventType,
+			@Param("eventOrder") long eventOrder);
+
+	@Modifying
+	@Transactional
+	@Query("""
+			UPDATE MemberTeamEventPushDelivery delivery
+			SET delivery.status = com.toy.nar.domain.member.entity.PushDeliveryStatus.FAILED,
+			    delivery.errorMessage = :errorMessage,
+			    delivery.updatedAt = CURRENT_TIMESTAMP
+			WHERE delivery.member.id = :memberId
+			  AND delivery.matchId = :matchId
+			  AND delivery.setNumber = :setNumber
+			  AND delivery.eventType = :eventType
+			  AND delivery.eventOrder = :eventOrder
+			""")
+	int markFailed(
+			@Param("memberId") Long memberId,
+			@Param("matchId") String matchId,
+			@Param("setNumber") int setNumber,
+			@Param("eventType") String eventType,
+			@Param("eventOrder") long eventOrder,
+			@Param("errorMessage") String errorMessage);
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -140,3 +140,10 @@ nar:
           enabled: ${NAR_DATA_INGESTION_JDBC_PARALLEL_ENABLED:false}
           threads: ${NAR_DATA_INGESTION_JDBC_PARALLEL_THREADS:4}
           max-in-flight: ${NAR_DATA_INGESTION_JDBC_PARALLEL_MAX_IN_FLIGHT:8}
+
+# 라이브 경기 FCM 푸시 파이프라인(#21). 기본 OFF (env LIVE_NOTIFICATION_FCM_ENABLED 로 오버라이드).
+# OFF 면 라이브 폴링 동작은 기존과 바이트 동일하다. 활성화 전 라이브 경기 검증 필수.
+live:
+  notification:
+    fcm:
+      enabled: ${LIVE_NOTIFICATION_FCM_ENABLED:false}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,11 @@ nar:
 firebase:
   messaging:
     enabled: ${FIREBASE_MESSAGING_ENABLED:false}
+
+# 라이브 경기 FCM 푸시 파이프라인(#21). 기본 OFF.
+# OFF 면 라이브 폴링 동작은 기존과 바이트 동일하다(새 발송/감지 부작용 없음).
+# 활성화 전 라이브 경기 검증 필수. firebase.messaging.enabled 도 함께 켜져 있어야 실제 발송된다.
+live:
+  notification:
+    fcm:
+      enabled: ${LIVE_NOTIFICATION_FCM_ENABLED:false}

--- a/src/main/resources/db/migration/V43__Create_member_team_event_push_delivery.sql
+++ b/src/main/resources/db/migration/V43__Create_member_team_event_push_delivery.sql
@@ -1,0 +1,26 @@
+-- 라이브 경기 팀 이벤트 FCM 푸시(#21) 멱등 처리 테이블.
+-- player_solo_rank_push_delivery 패턴을 복제했다.
+-- 멱등 키는 (member_id, match_id, set_number, event_type, event_order):
+--   - event_type: SET_START / SET_END / LIVE_EVENT
+--   - event_order: LIVE_EVENT 는 충돌 없는 전역 순번으로 live_game_object_event.id 를 사용한다(킬/오브젝트 혼선 방지).
+--     SET_START/SET_END 는 세트 내 순번이 없으므로 0 상수를 사용한다.
+--     (MySQL UNIQUE 는 NULL 을 서로 다른 값으로 취급해 멱등이 깨지므로 NULL 대신 0 을 쓴다.)
+-- 키가 팀이 아니라 match_id 라서, 한 회원이 한 경기의 양 팀을 모두 구독해도 이벤트당 1번만 발송된다.
+CREATE TABLE member_team_event_push_delivery (
+    id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id     BIGINT       NOT NULL,
+    match_id      VARCHAR(64)  NOT NULL,
+    set_number    INT          NOT NULL,
+    event_type    VARCHAR(20)  NOT NULL,
+    event_order   BIGINT       NOT NULL DEFAULT 0,
+    status        VARCHAR(20)  NOT NULL,
+    error_message VARCHAR(500),
+    sent_at       DATETIME,
+    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_member_team_event_push_delivery
+        UNIQUE (member_id, match_id, set_number, event_type, event_order),
+    CONSTRAINT fk_member_team_event_push_delivery_member
+        FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    INDEX idx_member_team_event_push_delivery_status (status, created_at)
+);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toy.nar.app.data.source.NotificationService;
 import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import com.toy.nar.app.mobile.push.TeamLiveEventPushService;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
@@ -19,7 +20,8 @@ import static org.mockito.Mockito.when;
 class LiveObjectEventRecorderTest {
 
 	private final LiveGameObjectEventRepository objectEventRepository = mock(LiveGameObjectEventRepository.class);
-	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(objectEventRepository, mock(NotificationService.class));
+	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(
+			objectEventRepository, mock(NotificationService.class), mock(TeamLiveEventPushService.class));
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Test

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -5,6 +5,7 @@ import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
 import com.toy.nar.app.lolesports.WorldsService;
 import com.toy.nar.app.data.source.NotificationService;
+import com.toy.nar.app.mobile.push.TeamLiveEventPushService;
 import com.toy.nar.app.schedule.CacheEvictionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -41,7 +42,8 @@ class LivePollingSchedulerTest {
 				liveGameMetadataService,
 				leagueMatchService,
 				cacheEvictionService,
-				mock(NotificationService.class));
+				mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
 		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 2);
 		liveStateStore.getActiveGames().put("game-1", new ActiveLiveGame(
 				"game-1",
@@ -78,7 +80,8 @@ class LivePollingSchedulerTest {
 				liveGameMetadataService,
 				leagueMatchService,
 				cacheEvictionService,
-				mock(NotificationService.class));
+				mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		ActiveLiveGame activeGame = new ActiveLiveGame(
 				"game-1",
@@ -116,7 +119,8 @@ class LivePollingSchedulerTest {
 				mock(LiveGameMetadataService.class),
 				mock(LeagueMatchService.class),
 				mock(CacheEvictionService.class),
-				mock(NotificationService.class));
+				mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
 
 		Instant nextWindow = ReflectionTestUtils.invokeMethod(
 				scheduler,


### PR DESCRIPTION
## 개요

라이브 경기에서 **세트 시작 / 세트 종료 / 라이브 이벤트(킬·오브젝트)** 가 발생하면, 해당 팀을 구독한 모바일 사용자에게 FCM 푸시를 발송하는 백엔드 파이프라인입니다. (warding #21)

> ⚠️ **플래그 OFF 상태로 머지됩니다. 배포해도 동작은 inert(무영향) 입니다.** 활성화 전 휴먼 리뷰 + 라이브 경기 검증이 필요합니다. **머지/배포 금지 (리뷰 전용)**.

## 빌드
`./gradlew clean build -x test` → **BUILD SUCCESSFUL**
라이브 파이프라인 단위 테스트(`com.toy.nar.app.lolesports.live.*`) 통과 — 플래그 OFF 시 기존 동작 유지 확인.

## 무엇을 만들었나

1. **디바이스 조회** — `MemberDeviceRepository.findActiveDevicesBySubscribedTeamId(teamId, eventType)`. 해당 팀을 구독하고 이벤트 토글(SET_START/SET_END/LIVE_EVENT)이 켜진 회원의 활성 기기. 기존 player 구독 쿼리와 동일한 EXISTS 패턴.
2. **esportsTeamId → Team.id 해석** — 세트마다 블루/레드가 스왑되므로 진영별로 매번 해석.
   - SET_START/SET_END: 매치 단위 프레이밍이라 매치 기준 esportsTeamId 사용. `ActiveLiveGame` 에 nullable 필드(`setNumber`, `blueEsportsTeamId`, `redEsportsTeamId`) 추가, discover 경로에서 set.
   - LIVE_EVENT: 피드 window 의 진영별 `esportsTeamId`(blueTeamMetadata/redTeamMetadata)로 해석 — 스왑에 안전.
   - `TeamExternalIdentityRepository.findBySourceAndExternalTeamId("LOLESPORTS", ...)` 로 `Team` 매핑, LCK 팀만 통과(`LckTeamCatalog`).
3. **멱등 테이블 + 서비스** — `member_team_event_push_delivery` (V43), 유니크 키 `(member_id, match_id, set_number, event_type, event_order)`. `TeamLiveEventPushService` 는 `PlayerSoloRankPushService` 패턴(reserve/markSent/markFailed, INSERT IGNORE / ON DUPLICATE KEY)을 복제.
4. **SET_END 감지(신규)** — `LivePollingScheduler` cleanup 직전, 직전까지 활성이던 gameId 가 이번 사이클 피드의 라이브 세트에서 빠지면 세트 종료로 보고 1회 발송. 플래그 OFF 면 부작용 없음.
5. **훅(모두 플래그 + 토글 체크)** — SET_START(디스코드 경기시작 옆), LIVE_EVENT(`LiveObjectEventRecorder` 의 킬/오브젝트 디스코드 옆), SET_END.

## FCM payload 계약 (모바일과 일치 필수)
- `data.type` ∈ {`SET_START`, `SET_END`, `LIVE_EVENT`} (String)
- `data.matchId` (String), `data.setNumber` (String)
- `notification.title` / `notification.body` (한국어)
  - SET_START: `"{teamName} 세트 시작"` / `"{blue} vs {red} · {n}세트 시작"`
  - SET_END: `"{teamName} 세트 종료"` / `"{blue} vs {red} · {n}세트 종료"`
  - LIVE_EVENT: `"{teamName} {event}"` (예: `"T1 드래곤 처치"`, `"T1 5킬 달성"`)

> collapse_key/tag: 현재 `MobilePushGateway` API 가 노출하지 않아 강제하지 않음. 추후 게이트웨이 확장 시 (matchId, eventType, setNumber) 기준 태그 추가 권장.

## 듀얼팀 dedup 설계
멱등 키를 팀이 아니라 **matchId** 기준으로 잡았습니다. 한 사용자가 한 경기의 양 팀을 모두 구독해도, 첫 팀 fan-out 에서 `reserve()` 가 통과하면 두 번째 팀 fan-out 의 `reserve()` 는 0 을 반환 → skip. 결과적으로 **이벤트당 1푸시**.
- SET_START/SET_END: `event_order` 에 상수 0 (MySQL UNIQUE 가 NULL 을 서로 다른 값으로 취급하므로 NULL 대신 0).
- LIVE_EVENT: 킬/오브젝트 간 순번 충돌을 막기 위해 `event_order` 에 `live_game_object_event.id`(전역 autoincrement) 사용.

## 활성화 체크리스트 (배포 후 단계적)
- [ ] `live.notification.fcm.enabled=true` (env `LIVE_NOTIFICATION_FCM_ENABLED`) + `firebase.messaging.enabled=true` 동시 ON
- [ ] 실제 라이브 경기 1건으로 검증 시작
- [ ] **SET_START / SET_END 먼저** 검증 (오발송·중복 여부, 팀명/세트번호 정확도)
- [ ] 안정 확인 후 **LIVE_EVENT 마지막** 활성 (빈도 높음 — 푸시 폭주/배터리 주의)
- [ ] `member_team_event_push_delivery` 의 FAILED 비율 모니터링

## 통합 리스크 / 비게이트 경로 영향
- `ActiveLiveGame` 에 nullable 필드 3개를 추가했으나 기존 7-arg 생성자를 compact 생성자로 유지 → discover/merge/poll 경로 호환. 기존 테스트 통과.
- 플래그 OFF 시: SET_START/SET_END/LIVE_EVENT 훅은 `teamLiveEventPushService.isEnabled()==false` 로 즉시 단락, cleanup 로직(toRemove)도 기존과 동일.
- `LiveObjectEventRecorder.record` 에서 진영별 esportsTeamId 파싱(`rememberSideTeamIds`)은 플래그와 무관하게 항상 수행되는 가벼운 텍스트 추출이며 부작용 없음(맵 put 뿐). 발송은 플래그로 게이트.
- 객체/킬 저장 시 `save(event)` 반환을 캡처하도록 변경(`event = ...save(event)`) — id 사용 목적. 기존 동작과 동일(반환 캡처만 추가).

🤖 Generated with [Claude Code](https://claude.com/claude-code)