### PR TITLE
fix: 정적 이미지(/images) permitAll — 선수 이미지 302 수정

### DIFF
--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -59,7 +59,10 @@ public class SecurityConfig {
                                 "/api/**",
                                 "/oauth2/**", "/login/oauth2/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
-                                "/actuator/**"
+                                "/actuator/**",
+                                // 정적 리소스(선수/팀 이미지 등)는 인증 없이 서빙. 없으면 302 로그인
+                                // 리다이렉트가 떠서 <img>/Image.network 로딩이 실패한다.
+                                "/images/**", "/static/**", "/favicon.ico"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
선수 이미지(/images/players/*.webp)가 SecurityConfig permitAll 목록에 없어 인증 대상 → 302 로그인 리다이렉트로 로딩 실패. /images/**·/static/**·/favicon.ico permitAll 추가. (참고: 선수 image_url 자체가 prod에서 대부분 null인 별도 데이터 이슈 있음 — 본 PR은 서빙 차단만 해소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)