### PR TITLE
fix: 라이브 선수 평점 player 매칭 (팀 접두사 제거) — 선수 이미지 null 수정

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -253,9 +253,21 @@ public class MobileLivePlayerRatingService {
 				return byOriginId;
 			}
 		}
-		return participant.playerName() == null
-				? Optional.empty()
-				: playerRepository.findByName(participant.playerName());
+		String name = participant.playerName();
+		if (name == null || name.isBlank()) {
+			return Optional.empty();
+		}
+		Optional<Player> byName = playerRepository.findByName(name);
+		if (byName.isPresent()) {
+			return byName;
+		}
+		// 라이브 피드의 참가자명이 "팀코드 소환사명"(예: "HLE Zeus") 형태라
+		// Player.name("Zeus")과 안 맞는다. 마지막 토큰(소환사명)으로 한 번 더 매칭한다.
+		int lastSpace = name.lastIndexOf(' ');
+		if (lastSpace > 0 && lastSpace < name.length() - 1) {
+			return playerRepository.findByName(name.substring(lastSpace + 1).trim());
+		}
+		return Optional.empty();
 	}
 
 	private LivePlayerRatingListResponse.PlayerRatingSummary toSummary(


### PR DESCRIPTION
라이브 피드 참가자명이 '팀코드 소환사명'(예: `HLE Zeus`)인데 Player.name 은 `Zeus` 라 `resolvePlayer` 의 findByName 이 실패 → 평점 응답의 playerId·playerImageUrl 이 null. 마지막 토큰(소환사명)으로 재매칭하는 폴백 추가. (선수 카드는 Player 직접 조회라 영향 없었음.)

함께: /images permitAll(#202)로 정적 이미지 서빙도 복구됨. 이 둘로 선수 이미지가 평점 탭에 표시됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)