### PR TITLE
feat: 프로필 수정 API (PUT /api/auth/me, 닉네임·응원팀)

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -12,6 +12,8 @@ import com.toy.nar.app.auth.JwtTokenProvider;
 import com.toy.nar.app.auth.KakaoUserClient;
 import com.toy.nar.app.auth.SocialAccountInfo;
 import com.toy.nar.app.auth.SocialLoginService;
+import com.toy.nar.app.auth.profile.ProfileService;
+import com.toy.nar.app.auth.profile.dto.ProfileUpdateRequest;
 import com.toy.nar.app.mobile.device.MobileDeviceService;
 import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
 import com.toy.nar.domain.member.entity.Member;
@@ -91,6 +93,7 @@ public class AuthController {
     private final PlayerRepository playerRepository;
     private final MobileDeviceService mobileDeviceService;
     private final MobileTeamNotificationService mobileTeamNotificationService;
+    private final ProfileService profileService;
 
     @Operation(
             summary = "모바일 카카오 로그인",
@@ -255,6 +258,23 @@ public class AuthController {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
         return ResponseEntity.ok(MemberResponse.from(member));
+    }
+
+    @Operation(
+            summary = "프로필 수정",
+            description = "현재 로그인한 사용자의 닉네임, 응원 팀, 프로필 이미지를 수정합니다. "
+                    + "닉네임은 본인의 현재 닉네임과 같으면 통과하고, 다른 회원이 사용 중이면 409로 실패합니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "회원 또는 팀을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임")
+    })
+    @PutMapping("/me")
+    public ResponseEntity<MemberResponse> updateProfile(@AuthenticationPrincipal Long memberId,
+                                                        @Valid @RequestBody ProfileUpdateRequest request) {
+        return ResponseEntity.ok(profileService.updateProfile(memberId, request));
     }
 
     private List<Team> findSelectableTeams(int year) {

--- a/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
@@ -20,6 +20,8 @@ public record MemberResponse(
 		Long favoriteTeamId,
 		@Schema(description = "선호 선수 ID 목록", example = "[10, 11]")
 		List<Long> favoritePlayerIds,
+		@Schema(description = "프로필 이미지 URL", example = "https://storage.example.com/profiles/12.png", nullable = true)
+		String profileImageUrl,
 		@Schema(description = "온보딩 완료 여부", example = "false")
 		boolean isOnboarded) {
 
@@ -34,6 +36,7 @@ public record MemberResponse(
                         .map(MemberFavoritePlayer::getPlayer)
                         .map(player -> player.getId())
                         .toList(),
+                member.getProfileImageUrl(),
                 member.isOnboarded()
         );
     }

--- a/src/main/java/com/toy/nar/app/auth/profile/ProfileService.java
+++ b/src/main/java/com/toy/nar/app/auth/profile/ProfileService.java
@@ -1,0 +1,44 @@
+package com.toy.nar.app.auth.profile;
+
+import com.toy.nar.api.auth.dto.MemberResponse;
+import com.toy.nar.app.auth.profile.dto.ProfileUpdateRequest;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+	private final MemberRepository memberRepository;
+	private final TeamRepository teamRepository;
+
+	@Transactional
+	public MemberResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
+		if (memberId == null) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+		}
+
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"));
+
+		String nickname = request.nickname().trim();
+		// 본인의 현재 닉네임과 동일하면 중복검사 통과, 변경되는 경우에만 중복 확인
+		if (!nickname.equals(member.getNickname()) && memberRepository.existsByNickname(nickname)) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다");
+		}
+
+		Team team = teamRepository.findById(request.favoriteTeamId())
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다"));
+
+		member.updateProfile(nickname, team, request.profileImageUrl());
+		return MemberResponse.from(member);
+	}
+}

--- a/src/main/java/com/toy/nar/app/auth/profile/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/toy/nar/app/auth/profile/dto/ProfileUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.toy.nar.app.auth.profile.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "프로필 수정 요청")
+public record ProfileUpdateRequest(
+		@Schema(description = "닉네임. 본인의 현재 닉네임과 동일하면 통과, 그 외에는 중복 불가", example = "용맹한바론")
+		@NotBlank
+		@Size(max = 50)
+		String nickname,
+		@Schema(description = "선호 팀 ID", example = "3")
+		@NotNull Long favoriteTeamId,
+		@Schema(description = "프로필 이미지 URL. 선택값(nullable). 전달되면 그대로 저장한다.",
+				example = "https://storage.example.com/profiles/12.png", nullable = true)
+		String profileImageUrl) {
+}

--- a/src/main/java/com/toy/nar/domain/member/entity/Member.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/Member.java
@@ -32,6 +32,9 @@ public class Member {
     @Column(name = "favorite_league_name", length = 50)
     private String favoriteLeagueName;
 
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "favorite_team_id")
     private Team favoriteTeam;
@@ -71,6 +74,12 @@ public class Member {
                         .player(player)
                         .build())
                 .forEach(this.favoritePlayers::add);
+    }
+
+    public void updateProfile(String nickname, Team favoriteTeam, String profileImageUrl) {
+        this.nickname = nickname;
+        this.favoriteTeam = favoriteTeam;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public boolean isOnboarded() {

--- a/src/main/resources/db/migration/V44__Add_profile_image_url_to_member.sql
+++ b/src/main/resources/db/migration/V44__Add_profile_image_url_to_member.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD COLUMN profile_image_url VARCHAR(500) NULL;

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -39,6 +39,8 @@ class AuthControllerOnboardingNotificationTest {
 		PlayerRepository playerRepository = mock(PlayerRepository.class);
 		MobileDeviceService mobileDeviceService = mock(MobileDeviceService.class);
 		MobileTeamNotificationService notificationService = mock(MobileTeamNotificationService.class);
+		com.toy.nar.app.auth.profile.ProfileService profileService =
+				mock(com.toy.nar.app.auth.profile.ProfileService.class);
 		AuthController controller = new AuthController(
 				jwtTokenProvider,
 				kakaoUserClient,
@@ -48,7 +50,8 @@ class AuthControllerOnboardingNotificationTest {
 				teamRepository,
 				playerRepository,
 				mobileDeviceService,
-				notificationService);
+				notificationService,
+				profileService);
 		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", 7L);
 		Team team = Team.builder().name("T1").code("T1").imageUrl("t1.png").build();
@@ -170,6 +173,8 @@ class AuthControllerOnboardingNotificationTest {
 		PlayerRepository playerRepository = mock(PlayerRepository.class);
 		MobileDeviceService mobileDeviceService = mock(MobileDeviceService.class);
 		MobileTeamNotificationService notificationService = mock(MobileTeamNotificationService.class);
+		com.toy.nar.app.auth.profile.ProfileService profileService =
+				mock(com.toy.nar.app.auth.profile.ProfileService.class);
 		AuthController controller = new AuthController(
 				jwtTokenProvider,
 				kakaoUserClient,
@@ -179,7 +184,8 @@ class AuthControllerOnboardingNotificationTest {
 				teamRepository,
 				playerRepository,
 				mobileDeviceService,
-				notificationService);
+				notificationService,
+				profileService);
 		return new TestContext(
 				controller,
 				memberRepository,

--- a/src/test/java/com/toy/nar/app/auth/profile/ProfileServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/profile/ProfileServiceTest.java
@@ -1,0 +1,107 @@
+package com.toy.nar.app.auth.profile;
+
+import com.toy.nar.api.auth.dto.MemberResponse;
+import com.toy.nar.app.auth.profile.dto.ProfileUpdateRequest;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProfileServiceTest {
+
+	private MemberRepository memberRepository;
+	private TeamRepository teamRepository;
+	private ProfileService profileService;
+
+	@BeforeEach
+	void setUp() {
+		memberRepository = mock(MemberRepository.class);
+		teamRepository = mock(TeamRepository.class);
+		profileService = new ProfileService(memberRepository, teamRepository);
+	}
+
+	private Member member(Long id, String nickname) {
+		Member member = Member.builder().nickname(nickname).email("test@example.com").build();
+		ReflectionTestUtils.setField(member, "id", id);
+		return member;
+	}
+
+	private Team team(Long id) {
+		Team team = Team.builder().name("T1").code("T1").imageUrl("t1.png").build();
+		ReflectionTestUtils.setField(team, "id", id);
+		return team;
+	}
+
+	@Test
+	void updatesProfileSuccessfully() {
+		Member member = member(7L, "옛닉네임");
+		Team team = team(3L);
+		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(memberRepository.existsByNickname("새닉네임")).thenReturn(false);
+		when(teamRepository.findById(3L)).thenReturn(Optional.of(team));
+
+		MemberResponse response = profileService.updateProfile(
+				7L, new ProfileUpdateRequest("새닉네임", 3L, "https://img/p.png"));
+
+		assertThat(response.nickname()).isEqualTo("새닉네임");
+		assertThat(response.favoriteTeamId()).isEqualTo(3L);
+		assertThat(response.profileImageUrl()).isEqualTo("https://img/p.png");
+		assertThat(member.getNickname()).isEqualTo("새닉네임");
+		assertThat(member.getFavoriteTeam()).isSameAs(team);
+		assertThat(member.getProfileImageUrl()).isEqualTo("https://img/p.png");
+	}
+
+	@Test
+	void failsWhenNicknameTakenByAnotherMember() {
+		Member member = member(7L, "옛닉네임");
+		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(memberRepository.existsByNickname("중복닉네임")).thenReturn(true);
+
+		assertThatThrownBy(() -> profileService.updateProfile(
+				7L, new ProfileUpdateRequest("중복닉네임", 3L, null)))
+				.isInstanceOf(ResponseStatusException.class)
+				.hasMessageContaining("이미 사용 중인 닉네임");
+	}
+
+	@Test
+	void passesWhenNicknameUnchanged() {
+		Member member = member(7L, "내닉네임");
+		Team team = team(3L);
+		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(teamRepository.findById(3L)).thenReturn(Optional.of(team));
+
+		MemberResponse response = profileService.updateProfile(
+				7L, new ProfileUpdateRequest("내닉네임", 3L, null));
+
+		assertThat(response.nickname()).isEqualTo("내닉네임");
+		// 본인 현재 닉네임과 동일하면 중복검사를 호출하지 않는다
+		verify(memberRepository, never()).existsByNickname(anyString());
+	}
+
+	@Test
+	void failsWhenFavoriteTeamNotFound() {
+		Member member = member(7L, "내닉네임");
+		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(memberRepository.existsByNickname("새닉네임")).thenReturn(false);
+		when(teamRepository.findById(999L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> profileService.updateProfile(
+				7L, new ProfileUpdateRequest("새닉네임", 999L, null)))
+				.isInstanceOf(ResponseStatusException.class)
+				.hasMessageContaining("팀을 찾을 수 없습니다");
+	}
+}


### PR DESCRIPTION
## 개요
warding 모바일 "프로필 수정" 기능용 백엔드 API. 닉네임·응원팀 수정과 프로필 이미지 URL 컬럼 선반영.

## API 계약
```
PUT /api/auth/me   (Bearer JWT)
요청: { "nickname": str, "favoriteTeamId": long, "profileImageUrl": str? }
응답: GET /api/auth/me 와 동일 형태 + profileImageUrl
에러: 400(닉네임 공백/50자초과) · 404(회원·팀 없음) · 409(닉네임 중복)
```

## 변경 사항
- `AuthController` — `PUT /api/auth/me` 핸들러 추가
- `app/auth/profile/ProfileService` + `ProfileUpdateRequest` (record + Jakarta Validation)
- `Member` — `profile_image_url` 컬럼 + `updateProfile()` 도메인 메서드
- `MemberResponse` — `profileImageUrl` 필드 추가
- `V44__Add_profile_image_url_to_member.sql` — Flyway 마이그레이션 (nullable VARCHAR(500))
- 테스트 4건: 정상수정 / 닉네임중복(409) / 본인닉네임유지 통과 / 없는팀(404)

## 참고
- 닉네임 중복검사는 본인 현재 닉네임 제외. 변경 시에만 `existsByNickname` 검사.
- `favoriteTeamId`는 "존재하는 팀"만 검증 (온보딩의 LCK 한정 검증은 미적용 — 필요 시 추가 가능).
- `favoriteLeagueName`·`favoritePlayers`는 이 API로 변경되지 않음.
- **이미지**: 실제 업로드는 추후 Firebase Storage 방식(폰 직접 업로드 → URL 저장)으로 예정. 이번엔 컬럼만 선반영하고 들어온 URL을 그대로 저장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)