### PR TITLE
feat: 프로필 저장 연동 백엔드 — 닉네임 이름+태그 분리 (#20)

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/MemberResponse.java
@@ -10,8 +10,12 @@ import java.util.List;
 public record MemberResponse(
 		@Schema(description = "회원 ID", example = "12")
 		Long id,
-		@Schema(description = "랜덤 생성 또는 사용 중인 닉네임", example = "용맹한바론")
+		@Schema(description = "이름#태그 합성 닉네임 (표시용)", example = "짱아깨비#KR2")
 		String nickname,
+		@Schema(description = "이름", example = "짱아깨비")
+		String name,
+		@Schema(description = "태그", example = "KR2")
+		String tag,
 		@Schema(description = "소셜 로그인 이메일. 동의하지 않은 경우 null", example = "user@example.com", nullable = true)
 		String email,
 		@Schema(description = "선호 리그명", example = "LCK", nullable = true)
@@ -29,6 +33,8 @@ public record MemberResponse(
         return new MemberResponse(
                 member.getId(),
                 member.getNickname(),
+                member.getName(),
+                member.getTag(),
                 member.getEmail(),
                 member.getFavoriteLeagueName(),
                 member.getFavoriteTeam() != null ? member.getFavoriteTeam().getId() : null,

--- a/src/main/java/com/toy/nar/app/auth/NicknameGenerator.java
+++ b/src/main/java/com/toy/nar/app/auth/NicknameGenerator.java
@@ -19,23 +19,28 @@ public class NicknameGenerator {
 
     private final MemberRepository memberRepository;
 
-    public String generate() {
+    /** 랜덤 이름과 태그 조합. {@code (name, tag)}는 중복되지 않음을 보장한다. */
+    public record GeneratedNickname(String name, String tag) {
+    }
+
+    public GeneratedNickname generate() {
         int maxAttempts = 10;
         for (int i = 0; i < maxAttempts; i++) {
-            String candidate = buildNickname();
-            if (!memberRepository.existsByNickname(candidate)) {
+            GeneratedNickname candidate = build();
+            if (!memberRepository.existsByNameAndTag(candidate.name(), candidate.tag())) {
                 return candidate;
             }
         }
-        // 충돌 시 타임스탬프 suffix로 보장
-        return buildNickname() + System.currentTimeMillis() % 10000;
+        // 충돌 시 타임스탬프 suffix로 보장 (tag 컬럼 길이 10 이내)
+        GeneratedNickname candidate = build();
+        return new GeneratedNickname(candidate.name(), candidate.tag() + System.currentTimeMillis() % 1000);
     }
 
-    private String buildNickname() {
+    private GeneratedNickname build() {
         ThreadLocalRandom rng = ThreadLocalRandom.current();
         String adj = ADJECTIVES[rng.nextInt(ADJECTIVES.length)];
         String noun = NOUNS[rng.nextInt(NOUNS.length)];
         int num = rng.nextInt(1000, 9999);
-        return adj + noun + "#" + num;
+        return new GeneratedNickname(adj + noun, String.valueOf(num));
     }
 }

--- a/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
+++ b/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
@@ -59,9 +59,11 @@ public class SocialLoginService {
 	}
 
 	private Member createMember(SocialAccountInfo accountInfo) {
+		NicknameGenerator.GeneratedNickname nickname = nicknameGenerator.generate();
 		Member member = memberRepository.save(
 				Member.builder()
-						.nickname(nicknameGenerator.generate())
+						.name(nickname.name())
+						.tag(nickname.tag())
 						.email(accountInfo.email())
 						.build()
 		);

--- a/src/main/java/com/toy/nar/app/auth/profile/ProfileService.java
+++ b/src/main/java/com/toy/nar/app/auth/profile/ProfileService.java
@@ -29,16 +29,18 @@ public class ProfileService {
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"));
 
-		String nickname = request.nickname().trim();
-		// 본인의 현재 닉네임과 동일하면 중복검사 통과, 변경되는 경우에만 중복 확인
-		if (!nickname.equals(member.getNickname()) && memberRepository.existsByNickname(nickname)) {
+		String name = request.name().trim();
+		String tag = request.tag().trim();
+		// 본인의 현재 이름#태그 조합과 동일하면 중복검사 통과, 조합이 바뀌는 경우에만 중복 확인
+		boolean unchanged = name.equals(member.getName()) && tag.equals(member.getTag());
+		if (!unchanged && memberRepository.existsByNameAndTag(name, tag)) {
 			throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다");
 		}
 
 		Team team = teamRepository.findById(request.favoriteTeamId())
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다"));
 
-		member.updateProfile(nickname, team, request.profileImageUrl());
+		member.updateProfile(name, tag, team, request.profileImageUrl());
 		return MemberResponse.from(member);
 	}
 }

--- a/src/main/java/com/toy/nar/app/auth/profile/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/toy/nar/app/auth/profile/dto/ProfileUpdateRequest.java
@@ -3,14 +3,21 @@ package com.toy.nar.app.auth.profile.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "프로필 수정 요청")
 public record ProfileUpdateRequest(
-		@Schema(description = "닉네임. 본인의 현재 닉네임과 동일하면 통과, 그 외에는 중복 불가", example = "용맹한바론")
+		@Schema(description = "이름. '#'은 포함할 수 없다. 이름#태그 조합이 본인의 현재 값과 같으면 통과, 그 외에는 중복 불가",
+				example = "짱아깨비")
 		@NotBlank
 		@Size(max = 50)
-		String nickname,
+		@Pattern(regexp = "^[^#]+$", message = "이름에는 '#'을 포함할 수 없습니다")
+		String name,
+		@Schema(description = "태그. 영문/숫자 2~5자 (롤처럼 자유롭게 커스텀)", example = "KR2")
+		@NotBlank
+		@Pattern(regexp = "^[A-Za-z0-9]{2,5}$", message = "태그는 영문 또는 숫자 2~5자여야 합니다")
+		String tag,
 		@Schema(description = "선호 팀 ID", example = "3")
 		@NotNull Long favoriteTeamId,
 		@Schema(description = "프로필 이미지 URL. 선택값(nullable). 전달되면 그대로 저장한다.",

--- a/src/main/java/com/toy/nar/domain/member/entity/Member.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/Member.java
@@ -23,8 +23,11 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 50)
-    private String nickname;
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 10)
+    private String tag;
 
     @Column
     private String email;
@@ -49,10 +52,16 @@ public class Member {
     private LocalDateTime createdAt;
 
     @Builder
-    public Member(String nickname, String email) {
-        this.nickname = nickname;
+    public Member(String name, String tag, String email) {
+        this.name = name;
+        this.tag = tag;
         this.email = email;
         this.createdAt = LocalDateTime.now();
+    }
+
+    /** 표시용 닉네임. 이름과 태그를 {@code 이름#태그} 형태로 합성한다. */
+    public String getNickname() {
+        return name + "#" + tag;
     }
 
     public void completeOnboarding(String favoriteLeagueName, Team favoriteTeam, Collection<Player> favoritePlayers) {
@@ -76,8 +85,9 @@ public class Member {
                 .forEach(this.favoritePlayers::add);
     }
 
-    public void updateProfile(String nickname, Team favoriteTeam, String profileImageUrl) {
-        this.nickname = nickname;
+    public void updateProfile(String name, String tag, Team favoriteTeam, String profileImageUrl) {
+        this.name = name;
+        this.tag = tag;
         this.favoriteTeam = favoriteTeam;
         this.profileImageUrl = profileImageUrl;
     }

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    boolean existsByNickname(String nickname);
+    boolean existsByNameAndTag(String name, String tag);
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/resources/db/migration/V45__Split_member_nickname_into_name_and_tag.sql
+++ b/src/main/resources/db/migration/V45__Split_member_nickname_into_name_and_tag.sql
@@ -1,0 +1,19 @@
+-- #20 프로필 저장 연동: 닉네임을 이름(name) + 태그(tag)로 분리한다.
+-- 롤처럼 같은 이름이라도 태그가 다르면 공존할 수 있도록 (name, tag) 복합 UNIQUE 로 전환.
+
+ALTER TABLE member ADD COLUMN name VARCHAR(50);
+ALTER TABLE member ADD COLUMN tag  VARCHAR(10);
+
+-- 기존 nickname("이름#태그")을 마지막 '#' 기준으로 분리해 백필.
+-- '#'이 없던 레거시 닉네임은 전체를 이름으로 두고 태그는 id 기반으로 채워 유일성 보장.
+UPDATE member
+SET name = CASE WHEN nickname LIKE '%#%' THEN SUBSTRING_INDEX(nickname, '#', 1) ELSE nickname END,
+    tag  = CASE WHEN nickname LIKE '%#%' THEN SUBSTRING_INDEX(nickname, '#', -1) ELSE LPAD(id, 4, '0') END;
+
+ALTER TABLE member MODIFY COLUMN name VARCHAR(50) NOT NULL;
+ALTER TABLE member MODIFY COLUMN tag  VARCHAR(10) NOT NULL;
+
+-- 단일 nickname UNIQUE 컬럼 제거(컬럼 삭제 시 단일 컬럼 UNIQUE 인덱스도 함께 제거됨).
+ALTER TABLE member DROP COLUMN nickname;
+
+ALTER TABLE member ADD CONSTRAINT uq_member_name_tag UNIQUE (name, tag);

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -52,7 +52,7 @@ class AuthControllerOnboardingNotificationTest {
 				mobileDeviceService,
 				notificationService,
 				profileService);
-		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", 7L);
 		Team team = Team.builder().name("T1").code("T1").imageUrl("t1.png").build();
 		ReflectionTestUtils.setField(team, "id", 1L);
@@ -195,7 +195,7 @@ class AuthControllerOnboardingNotificationTest {
 	}
 
 	private Member member(Long id) {
-		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		return member;
 	}

--- a/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
@@ -91,7 +91,8 @@ class SocialLoginServiceTest {
 
 		when(memberSocialRepository.findByProviderAndProviderId(OAuthProvider.KAKAO, "67890"))
 				.thenReturn(Optional.empty());
-		when(nicknameGenerator.generate()).thenReturn("nar1234");
+		when(nicknameGenerator.generate())
+				.thenReturn(new NicknameGenerator.GeneratedNickname("nar", "1234"));
 		when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> {
 			Member saved = invocation.getArgument(0);
 			ReflectionTestUtils.setField(saved, "id", 11L);
@@ -117,7 +118,7 @@ class SocialLoginServiceTest {
 
 	private Member member(String email, Long id) {
 		Member member = Member.builder()
-				.nickname("nar-user")
+				.name("nar-user").tag("0000")
 				.email(email)
 				.build();
 		ReflectionTestUtils.setField(member, "id", id);

--- a/src/test/java/com/toy/nar/app/auth/profile/ProfileServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/profile/ProfileServiceTest.java
@@ -34,8 +34,8 @@ class ProfileServiceTest {
 		profileService = new ProfileService(memberRepository, teamRepository);
 	}
 
-	private Member member(Long id, String nickname) {
-		Member member = Member.builder().nickname(nickname).email("test@example.com").build();
+	private Member member(Long id, String name, String tag) {
+		Member member = Member.builder().name(name).tag(tag).email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		return member;
 	}
@@ -48,59 +48,79 @@ class ProfileServiceTest {
 
 	@Test
 	void updatesProfileSuccessfully() {
-		Member member = member(7L, "옛닉네임");
+		Member member = member(7L, "옛이름", "OLD1");
 		Team team = team(3L);
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
-		when(memberRepository.existsByNickname("새닉네임")).thenReturn(false);
+		when(memberRepository.existsByNameAndTag("짱아깨비", "KR2")).thenReturn(false);
 		when(teamRepository.findById(3L)).thenReturn(Optional.of(team));
 
 		MemberResponse response = profileService.updateProfile(
-				7L, new ProfileUpdateRequest("새닉네임", 3L, "https://img/p.png"));
+				7L, new ProfileUpdateRequest("짱아깨비", "KR2", 3L, "https://img/p.png"));
 
-		assertThat(response.nickname()).isEqualTo("새닉네임");
+		assertThat(response.name()).isEqualTo("짱아깨비");
+		assertThat(response.tag()).isEqualTo("KR2");
+		assertThat(response.nickname()).isEqualTo("짱아깨비#KR2");
 		assertThat(response.favoriteTeamId()).isEqualTo(3L);
 		assertThat(response.profileImageUrl()).isEqualTo("https://img/p.png");
-		assertThat(member.getNickname()).isEqualTo("새닉네임");
+		assertThat(member.getName()).isEqualTo("짱아깨비");
+		assertThat(member.getTag()).isEqualTo("KR2");
 		assertThat(member.getFavoriteTeam()).isSameAs(team);
-		assertThat(member.getProfileImageUrl()).isEqualTo("https://img/p.png");
 	}
 
 	@Test
-	void failsWhenNicknameTakenByAnotherMember() {
-		Member member = member(7L, "옛닉네임");
+	void changesTagOnlyKeepingName() {
+		// 롤처럼 이름은 그대로, 태그만 #OLD1 -> #KR2 로 변경
+		Member member = member(7L, "짱아깨비", "OLD1");
+		Team team = team(3L);
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
-		when(memberRepository.existsByNickname("중복닉네임")).thenReturn(true);
+		when(memberRepository.existsByNameAndTag("짱아깨비", "KR2")).thenReturn(false);
+		when(teamRepository.findById(3L)).thenReturn(Optional.of(team));
+
+		MemberResponse response = profileService.updateProfile(
+				7L, new ProfileUpdateRequest("짱아깨비", "KR2", 3L, null));
+
+		assertThat(response.nickname()).isEqualTo("짱아깨비#KR2");
+		assertThat(member.getTag()).isEqualTo("KR2");
+		// 조합이 바뀌었으므로 중복검사를 호출해야 한다
+		verify(memberRepository).existsByNameAndTag("짱아깨비", "KR2");
+	}
+
+	@Test
+	void failsWhenNameTagTakenByAnotherMember() {
+		Member member = member(7L, "옛이름", "OLD1");
+		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(memberRepository.existsByNameAndTag("짱아깨비", "KR1")).thenReturn(true);
 
 		assertThatThrownBy(() -> profileService.updateProfile(
-				7L, new ProfileUpdateRequest("중복닉네임", 3L, null)))
+				7L, new ProfileUpdateRequest("짱아깨비", "KR1", 3L, null)))
 				.isInstanceOf(ResponseStatusException.class)
-				.hasMessageContaining("이미 사용 중인 닉네임");
+				.hasMessageContaining("이미 사용 중인");
 	}
 
 	@Test
-	void passesWhenNicknameUnchanged() {
-		Member member = member(7L, "내닉네임");
+	void passesWhenNameAndTagUnchanged() {
+		Member member = member(7L, "짱아깨비", "KR1");
 		Team team = team(3L);
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
 		when(teamRepository.findById(3L)).thenReturn(Optional.of(team));
 
 		MemberResponse response = profileService.updateProfile(
-				7L, new ProfileUpdateRequest("내닉네임", 3L, null));
+				7L, new ProfileUpdateRequest("짱아깨비", "KR1", 3L, null));
 
-		assertThat(response.nickname()).isEqualTo("내닉네임");
-		// 본인 현재 닉네임과 동일하면 중복검사를 호출하지 않는다
-		verify(memberRepository, never()).existsByNickname(anyString());
+		assertThat(response.nickname()).isEqualTo("짱아깨비#KR1");
+		// 본인 현재 이름#태그와 동일하면 중복검사를 호출하지 않는다
+		verify(memberRepository, never()).existsByNameAndTag(anyString(), anyString());
 	}
 
 	@Test
 	void failsWhenFavoriteTeamNotFound() {
-		Member member = member(7L, "내닉네임");
+		Member member = member(7L, "내이름", "KR1");
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
-		when(memberRepository.existsByNickname("새닉네임")).thenReturn(false);
+		when(memberRepository.existsByNameAndTag("새이름", "KR9")).thenReturn(false);
 		when(teamRepository.findById(999L)).thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> profileService.updateProfile(
-				7L, new ProfileUpdateRequest("새닉네임", 999L, null)))
+				7L, new ProfileUpdateRequest("새이름", "KR9", 999L, null)))
 				.isInstanceOf(ResponseStatusException.class)
 				.hasMessageContaining("팀을 찾을 수 없습니다");
 	}

--- a/src/test/java/com/toy/nar/app/mobile/device/MobileDeviceServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/device/MobileDeviceServiceTest.java
@@ -92,7 +92,7 @@ class MobileDeviceServiceTest {
 	}
 
 	private Member member(Long id) {
-		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		return member;
 	}

--- a/src/test/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationServiceTest.java
@@ -189,7 +189,7 @@ class MobileTeamNotificationServiceTest {
 	}
 
 	private Member member(Long id, Team favoriteTeam) {
-		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		if (favoriteTeam != null) {
 			member.completeOnboarding("LCK", favoriteTeam, List.of());

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
@@ -117,7 +117,7 @@ class PlayerSoloRankPushServiceTest {
 	}
 
 	private Member member(Long id) {
-		Member member = Member.builder().nickname("member-" + id).email("test@example.com").build();
+		Member member = Member.builder().name("member-" + id).tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		return member;
 	}

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -76,7 +76,7 @@ class MobileLivePlayerRatingServiceTest {
 
 	@Test
 	void createsRatingAfterSetEnds() {
-		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		Player player = Player.builder().name("Faker").imageUrl("faker.png").build();
 		when(leagueMatchGameRepository.findWithMatchByGameId("game-1"))
 				.thenReturn(Optional.of(matchGame("inProgress", 1, 0, 1)));
@@ -160,7 +160,7 @@ class MobileLivePlayerRatingServiceTest {
 						org.assertj.core.groups.Tuple.tuple(1, 0L, 0.0));
 		assertThat(response.myRating().ratingId()).isEqualTo(11L);
 		assertThat(response.reviews()).first().satisfies(review -> {
-			assertThat(review.nickname()).isEqualTo("용맹한바론");
+			assertThat(review.nickname()).isEqualTo("용맹한바론#0000");
 			assertThat(review.mine()).isTrue();
 		});
 	}
@@ -248,7 +248,7 @@ class MobileLivePlayerRatingServiceTest {
 	}
 
 	private Member member(Long id, String nickname) {
-		Member member = Member.builder().nickname(nickname).email("test@example.com").build();
+		Member member = Member.builder().name(nickname).tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		return member;
 	}

--- a/src/test/java/com/toy/nar/app/mobile/subscription/MobilePlayerSubscriptionServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/subscription/MobilePlayerSubscriptionServiceTest.java
@@ -162,7 +162,7 @@ class MobilePlayerSubscriptionServiceTest {
 	}
 
 	private Member member(Long id) {
-		Member member = Member.builder().nickname("용맹한바론").email("test@example.com").build();
+		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);
 		return member;
 	}


### PR DESCRIPTION
## 개요
이슈 #20 (프로필 저장 연동) 백엔드. 프로필 수정 API와, 댓글 요구사항인 **이름#태그의 태그 별도 커스텀**(롤 방식)을 구현했습니다.

## 변경
- `PUT /api/auth/me` 프로필 수정 (닉네임·응원팀·프로필 이미지 URL)
- **닉네임 모델을 `name` + `tag` 2컬럼으로 분리** (`UNIQUE(name, tag)`)
  - 롤처럼 같은 이름이라도 태그가 다르면 공존 (`짱아깨비#KR1` ↔ `짱아깨비#KR2`)
  - `Member.getNickname()`은 `name#tag` 합성으로 유지 → 평점 등 기존 표시 로직 무수정
- 요청을 `name`(‘#’ 불가) + `tag`(영숫자 2~5자)로 분리, 검증 추가
- `MemberResponse`에 `name`/`tag` 노출 (+ 표시용 합성 `nickname`)
- 중복검사: `existsByNameAndTag` 조합 기준 (본인 현재 조합이면 통과)
- `NicknameGenerator` → `GeneratedNickname(name, tag)` 반환
- Flyway `V45`: 기존 닉네임 마지막 ‘#’ 기준 백필(‘#’ 없으면 `tag=id`), `nickname` 컬럼 제거

## API 계약 (모바일 연동용)
```
PUT /api/auth/me   (Bearer JWT)
요청: { name, tag, favoriteTeamId, profileImageUrl? }
응답: { id, nickname:"name#tag", name, tag, email, favoriteTeamId, ... }
에러: 400(검증) · 404(회원/팀 없음) · 409(name#tag 중복)
```

## 테스트
- TDD로 구현. `ProfileServiceTest` 재작성(태그만 변경 / 조합 중복 / 미변경 통과 / 팀 없음) + 닉네임 모델 변경에 영향받은 테스트 7종 갱신 — 모두 통과.
- 마이그레이션 V45를 **실제 MySQL 8 컨테이너**로 검증: 레거시 백필, `nickname` 제거, 복합 UNIQUE, 같은 이름+다른 태그 공존/동일 조합 거부 확인.
- 로컬 dev 서버(bootRun) 기동 후 라이브 확인: `GET /me`(name/tag 분리 응답), `PUT /me`(태그만 변경 200), 검증 위반(400).

## 참고
- ⚠️ `V45`는 `member.nickname` 컬럼을 제거합니다(데이터는 name/tag로 보존). 배포 시 기존 데이터 백필 동작 확인 요망.
- 모바일 파트(마이페이지 name/tag 분리 입력 UI 연동)는 별도 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)