### PR TITLE
feat: 프로필 이미지 Cloudinary 서명 업로드 엔드포인트 (#20)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,9 @@ jobs:
               -e NAVER_CLIENT_ID="${{ secrets.NAVER_CLIENT_ID }}" \
               -e NAVER_CLIENT_SECRET="${{ secrets.NAVER_CLIENT_SECRET }}" \
               -e FRONTEND_URL="${{ secrets.FRONTEND_URL }}" \
+              -e CLOUDINARY_CLOUD_NAME="${{ secrets.CLOUDINARY_CLOUD_NAME }}" \
+              -e CLOUDINARY_API_KEY="${{ secrets.CLOUDINARY_API_KEY }}" \
+              -e CLOUDINARY_API_SECRET="${{ secrets.CLOUDINARY_API_SECRET }}" \
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \

--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -12,7 +12,9 @@ import com.toy.nar.app.auth.JwtTokenProvider;
 import com.toy.nar.app.auth.KakaoUserClient;
 import com.toy.nar.app.auth.SocialAccountInfo;
 import com.toy.nar.app.auth.SocialLoginService;
+import com.toy.nar.app.auth.profile.CloudinarySignatureService;
 import com.toy.nar.app.auth.profile.ProfileService;
+import com.toy.nar.app.auth.profile.dto.ProfileImageUploadSignatureResponse;
 import com.toy.nar.app.auth.profile.dto.ProfileUpdateRequest;
 import com.toy.nar.app.mobile.device.MobileDeviceService;
 import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
@@ -39,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -94,6 +97,7 @@ public class AuthController {
     private final MobileDeviceService mobileDeviceService;
     private final MobileTeamNotificationService mobileTeamNotificationService;
     private final ProfileService profileService;
+    private final CloudinarySignatureService cloudinarySignatureService;
 
     @Operation(
             summary = "모바일 카카오 로그인",
@@ -275,6 +279,22 @@ public class AuthController {
     public ResponseEntity<MemberResponse> updateProfile(@AuthenticationPrincipal Long memberId,
                                                         @Valid @RequestBody ProfileUpdateRequest request) {
         return ResponseEntity.ok(profileService.updateProfile(memberId, request));
+    }
+
+    @Operation(
+            summary = "프로필 이미지 업로드 서명 발급",
+            description = "앱이 Cloudinary에 직접 서명 업로드할 때 사용할 파라미터(서명 포함)를 발급한다. "
+                    + "앱은 응답값으로 Cloudinary에 업로드한 뒤, 받은 secure_url을 PUT /api/auth/me 의 profileImageUrl로 저장한다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/me/profile-image/signature")
+    public ResponseEntity<ProfileImageUploadSignatureResponse> profileImageUploadSignature(
+            @AuthenticationPrincipal Long memberId) {
+        if (memberId == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        long timestamp = Instant.now().getEpochSecond();
+        return ResponseEntity.ok(cloudinarySignatureService.buildProfileUpload(memberId, timestamp));
     }
 
     private List<Team> findSelectableTeams(int year) {

--- a/src/main/java/com/toy/nar/app/auth/profile/CloudinarySignatureService.java
+++ b/src/main/java/com/toy/nar/app/auth/profile/CloudinarySignatureService.java
@@ -1,0 +1,71 @@
+package com.toy.nar.app.auth.profile;
+
+import com.toy.nar.app.auth.profile.dto.ProfileImageUploadSignatureResponse;
+import com.toy.nar.config.CloudinaryProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Cloudinary 서명 업로드용 서명 생성기.
+ * 앱(폰)이 직접 Cloudinary로 업로드하되, 서명은 서버(시크릿 보관)에서만 만들어
+ * 로그인한 사용자만 업로드할 수 있게 한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CloudinarySignatureService {
+
+	private final CloudinaryProperties properties;
+
+	/**
+	 * Cloudinary 규칙대로 서명한다: 파라미터를 키 알파벳순으로 정렬해
+	 * {@code k=v&k2=v2} 로 이은 뒤 api_secret을 덧붙여 SHA-1 hex.
+	 */
+	public String sign(Map<String, String> paramsToSign) {
+		String toSign = new TreeMap<>(paramsToSign).entrySet().stream()
+				.filter(e -> e.getValue() != null && !e.getValue().isEmpty())
+				.map(e -> e.getKey() + "=" + e.getValue())
+				.collect(Collectors.joining("&"));
+		return sha1Hex(toSign + properties.getApiSecret());
+	}
+
+	/** 회원별 프로필 이미지 업로드 서명 파라미터를 만든다. public_id는 회원당 고정(덮어쓰기). */
+	public ProfileImageUploadSignatureResponse buildProfileUpload(Long memberId, long timestamp) {
+		String publicId = "profiles/" + memberId;
+		Map<String, String> params = Map.of(
+				"overwrite", "true",
+				"public_id", publicId,
+				"timestamp", String.valueOf(timestamp));
+		String signature = sign(params);
+		String uploadUrl = "https://api.cloudinary.com/v1_1/" + properties.getCloudName() + "/image/upload";
+		return new ProfileImageUploadSignatureResponse(
+				properties.getCloudName(),
+				properties.getApiKey(),
+				timestamp,
+				publicId,
+				true,
+				signature,
+				uploadUrl);
+	}
+
+	private static String sha1Hex(String value) {
+		try {
+			byte[] digest = MessageDigest.getInstance("SHA-1")
+					.digest(value.getBytes(StandardCharsets.UTF_8));
+			StringBuilder sb = new StringBuilder(digest.length * 2);
+			for (byte b : digest) {
+				sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+				sb.append(Character.forDigit(b & 0xF, 16));
+			}
+			return sb.toString();
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-1 미지원", e);
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/auth/profile/dto/ProfileImageUploadSignatureResponse.java
+++ b/src/main/java/com/toy/nar/app/auth/profile/dto/ProfileImageUploadSignatureResponse.java
@@ -1,0 +1,22 @@
+package com.toy.nar.app.auth.profile.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Cloudinary 프로필 이미지 서명 업로드 파라미터. 앱은 이 값으로 Cloudinary에 직접 업로드한다.")
+public record ProfileImageUploadSignatureResponse(
+		@Schema(description = "Cloudinary cloud name", example = "dvvurdffw")
+		String cloudName,
+		@Schema(description = "Cloudinary API key", example = "422645889216881")
+		String apiKey,
+		@Schema(description = "서명에 사용된 Unix timestamp(초)", example = "1700000000")
+		long timestamp,
+		@Schema(description = "업로드 대상 public_id (회원별 고정)", example = "profiles/2")
+		String publicId,
+		@Schema(description = "기존 이미지 덮어쓰기 여부", example = "true")
+		boolean overwrite,
+		@Schema(description = "HMAC-SHA1 업로드 서명")
+		String signature,
+		@Schema(description = "Cloudinary 업로드 엔드포인트 URL",
+				example = "https://api.cloudinary.com/v1_1/dvvurdffw/image/upload")
+		String uploadUrl) {
+}

--- a/src/main/java/com/toy/nar/config/CloudinaryProperties.java
+++ b/src/main/java/com/toy/nar/config/CloudinaryProperties.java
@@ -1,0 +1,14 @@
+package com.toy.nar.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "cloudinary")
+public class CloudinaryProperties {
+	private String cloudName;
+	private String apiKey;
+	private String apiSecret;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,9 @@ live:
   notification:
     fcm:
       enabled: ${LIVE_NOTIFICATION_FCM_ENABLED:false}
+
+# 프로필 이미지 저장(Cloudinary 서명 업로드). 시크릿은 코드/깃에 박지 않고 env로 주입.
+cloudinary:
+  cloud-name: ${CLOUDINARY_CLOUD_NAME:}
+  api-key: ${CLOUDINARY_API_KEY:}
+  api-secret: ${CLOUDINARY_API_SECRET:}

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -4,6 +4,7 @@ import com.toy.nar.api.auth.dto.OnboardingRequest;
 import com.toy.nar.app.auth.JwtTokenProvider;
 import com.toy.nar.app.auth.KakaoUserClient;
 import com.toy.nar.app.auth.SocialLoginService;
+import com.toy.nar.app.auth.profile.CloudinarySignatureService;
 import com.toy.nar.app.mobile.device.MobileDeviceService;
 import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
 import com.toy.nar.domain.member.entity.Member;
@@ -51,7 +52,8 @@ class AuthControllerOnboardingNotificationTest {
 				playerRepository,
 				mobileDeviceService,
 				notificationService,
-				profileService);
+				profileService,
+				mock(CloudinarySignatureService.class));
 		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", 7L);
 		Team team = Team.builder().name("T1").code("T1").imageUrl("t1.png").build();
@@ -185,7 +187,8 @@ class AuthControllerOnboardingNotificationTest {
 				playerRepository,
 				mobileDeviceService,
 				notificationService,
-				profileService);
+				profileService,
+				mock(CloudinarySignatureService.class));
 		return new TestContext(
 				controller,
 				memberRepository,

--- a/src/test/java/com/toy/nar/app/auth/profile/CloudinarySignatureServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/profile/CloudinarySignatureServiceTest.java
@@ -1,0 +1,59 @@
+package com.toy.nar.app.auth.profile;
+
+import com.toy.nar.app.auth.profile.dto.ProfileImageUploadSignatureResponse;
+import com.toy.nar.config.CloudinaryProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudinarySignatureServiceTest {
+
+	private CloudinarySignatureService service;
+
+	@BeforeEach
+	void setUp() {
+		CloudinaryProperties props = new CloudinaryProperties();
+		props.setCloudName("dvvurdffw");
+		props.setApiKey("KEY123");
+		props.setApiSecret("testsecret123");
+		service = new CloudinarySignatureService(props);
+	}
+
+	@Test
+	void computesSignatureMatchingCloudinaryAlgorithm() {
+		// 공식 Cloudinary Python SDK(api_sign_request)가 동일 입력으로 만든 기준값
+		Map<String, String> params = new LinkedHashMap<>();
+		params.put("overwrite", "true");
+		params.put("public_id", "profiles/2");
+		params.put("timestamp", "1700000000");
+
+		assertThat(service.sign(params)).isEqualTo("056d67fda188951c5a19f6a9e962e3e121c290e0");
+	}
+
+	@Test
+	void sortsParamsAlphabeticallyRegardlessOfInsertionOrder() {
+		Map<String, String> shuffled = new LinkedHashMap<>();
+		shuffled.put("timestamp", "1700000000");
+		shuffled.put("public_id", "profiles/2");
+		shuffled.put("overwrite", "true");
+
+		assertThat(service.sign(shuffled)).isEqualTo("056d67fda188951c5a19f6a9e962e3e121c290e0");
+	}
+
+	@Test
+	void buildsProfileUploadSignatureForMember() {
+		ProfileImageUploadSignatureResponse res = service.buildProfileUpload(2L, 1700000000L);
+
+		assertThat(res.cloudName()).isEqualTo("dvvurdffw");
+		assertThat(res.apiKey()).isEqualTo("KEY123");
+		assertThat(res.publicId()).isEqualTo("profiles/2");
+		assertThat(res.overwrite()).isTrue();
+		assertThat(res.timestamp()).isEqualTo(1700000000L);
+		// 서명은 overwrite/public_id/timestamp 조합으로 계산된 위 기준값과 동일해야 한다
+		assertThat(res.signature()).isEqualTo("056d67fda188951c5a19f6a9e962e3e121c290e0");
+	}
+}


### PR DESCRIPTION
## 개요
#20 프로필 이미지 저장의 백엔드. 앱이 Cloudinary에 직접(서명) 업로드할 수 있도록 서명 발급 엔드포인트를 추가했습니다. (Firebase Storage는 카드/예치금 이슈로 제외, Cloudinary 채택)

## 변경
- `POST /api/auth/me/profile-image/signature` (JWT): 로그인 사용자에게 Cloudinary 서명 업로드 파라미터 발급
  - `public_id=profiles/{memberId}` 고정 + `overwrite=true` → 회원당 1장 덮어쓰기
- `CloudinarySignatureService`: 파라미터 정렬 → SHA-1 hex 서명 (공식 SDK 알고리즘과 일치하도록 테스트로 고정)
- `CloudinaryProperties`: `cloud-name`/`api-key`/`api-secret` 를 **env로만** 주입 (시크릿 미커밋)
- 저장은 기존 `PUT /api/auth/me` 의 `profileImageUrl` 로 처리(앱이 업로드 후 secure_url 전송)

## 흐름
```
앱 → POST /me/profile-image/signature (서명 발급)
앱 → Cloudinary 직접 업로드 (서명 사용) → secure_url
앱 → PUT /api/auth/me { name, tag, favoriteTeamId, profileImageUrl } → DB 저장
```

## ⚠️ 배포 전 필수: prod 환경변수 설정
이 엔드포인트는 다음 env가 있어야 동작합니다 (없으면 빈 서명 반환):
```
CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET
```
운영 서버에 위 3개를 설정한 뒤 머지/배포해야 합니다.

## 테스트
- 단위: `CloudinarySignatureServiceTest` (서명값을 공식 Python SDK 기준값에 고정), 영향받은 컨트롤러 테스트 갱신 — 통과.
- 로컬 실기기(Android) 연동: 서명 발급 → Cloudinary 업로드 → `PUT /me` 저장 → DB `profile_image_url` 반영까지 end-to-end 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)