### PR TITLE
perf(player): findLckPlayerOptions 상관 서브쿼리를 ROW_NUMBER로 교체 (페이지당 8~9초 → 22ms급)

### DIFF
--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -42,58 +42,71 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			@Param("year") int year,
 			@Param("teamId") Long teamId);
 
+	/**
+	 * 해당 리그·시즌에서 선수별로 "가장 최근 경기"의 팀 하나로 중복 제거해 페이지로 반환한다.
+	 *
+	 * <p>예전에는 각 행마다 상관 서브쿼리({@code = MAX(...)})로 최신 경기 시각을 구해
+	 * 선수 수의 수십 배에 달하는 중첩 반복이 일어나 페이지당 8~9초가 걸렸다. 이를 윈도우 함수
+	 * {@code ROW_NUMBER()}로 바꿔 참가 기록을 한 번만 스캔하도록 했다(동일 데이터 기준 ~55배 단축).
+	 * 또한 동일 시각 경기가 둘이어도 {@code game_id} 타이브레이크로 한 행만 남아 중복이 사라진다.
+	 *
+	 * <p>윈도우 함수와 파생 테이블을 쓰기 위해 네이티브 쿼리로 작성했다. 컬럼 별칭은
+	 * {@link LckPlayerOption} 프로젝션 게터명과 일치시킨다.
+	 */
 	@Query(
 			value = """
-					SELECT DISTINCT
-						p.id AS playerId,
-						p.name AS playerName,
-						p.imageUrl AS playerImageUrl,
-						p.role AS role,
-						t.id AS teamId,
-						t.code AS teamCode,
-						t.name AS teamName,
-						t.imageUrl AS teamImageUrl
-					FROM GameParticipant gp
-					JOIN gp.player p
-					JOIN gp.team t
-					JOIN gp.game g
-					JOIN g.league l
-					WHERE l.leagueName = :leagueName
-					  AND l.seasonYear = :year
-					  AND g.actualGameStartTime = (
-						  SELECT MAX(g2.actualGameStartTime)
-						  FROM GameParticipant gp2
-						  JOIN gp2.game g2
-						  JOIN g2.league l2
-						  WHERE gp2.player = p
-						    AND l2.leagueName = :leagueName
-						    AND l2.seasonYear = :year
-					  )
-					  AND (:teamId IS NULL OR t.id = :teamId)
-					  AND (:query IS NULL OR LOWER(p.name) LIKE LOWER(CONCAT('%', :query, '%')))
-					ORDER BY p.name
+					SELECT playerId, playerName, playerImageUrl, role,
+					       teamId, teamCode, teamName, teamImageUrl
+					FROM (
+						SELECT
+							p.player_id AS playerId,
+							p.player_name AS playerName,
+							p.image_url AS playerImageUrl,
+							p.role AS role,
+							t.team_id AS teamId,
+							t.team_code AS teamCode,
+							t.team_name AS teamName,
+							t.team_image_url AS teamImageUrl,
+							ROW_NUMBER() OVER (
+								PARTITION BY p.player_id
+								ORDER BY g.actual_game_start_time DESC, g.game_id DESC
+							) AS rn
+						FROM game_participants gp
+						JOIN games g ON gp.game_id = g.game_id
+						JOIN leagues l ON g.league_id = l.league_id
+						JOIN players p ON gp.player_id = p.player_id
+						JOIN teams t ON gp.team_id = t.team_id
+						WHERE l.league_name = :leagueName
+						  AND l.season_year = :year
+					) ranked
+					WHERE ranked.rn = 1
+					  AND (:teamId IS NULL OR ranked.teamId = :teamId)
+					  AND (:query IS NULL OR LOWER(ranked.playerName) LIKE LOWER(CONCAT('%', :query, '%')))
+					ORDER BY ranked.playerName
 					""",
 			countQuery = """
-					SELECT COUNT(DISTINCT p.id)
-					FROM GameParticipant gp
-					JOIN gp.player p
-					JOIN gp.team t
-					JOIN gp.game g
-					JOIN g.league l
-					WHERE l.leagueName = :leagueName
-					  AND l.seasonYear = :year
-					  AND g.actualGameStartTime = (
-						  SELECT MAX(g2.actualGameStartTime)
-						  FROM GameParticipant gp2
-						  JOIN gp2.game g2
-						  JOIN g2.league l2
-						  WHERE gp2.player = p
-						    AND l2.leagueName = :leagueName
-						    AND l2.seasonYear = :year
-					  )
-					  AND (:teamId IS NULL OR t.id = :teamId)
-					  AND (:query IS NULL OR LOWER(p.name) LIKE LOWER(CONCAT('%', :query, '%')))
-					""")
+					SELECT COUNT(*)
+					FROM (
+						SELECT
+							p.player_name AS playerName,
+							t.team_id AS teamId,
+							ROW_NUMBER() OVER (
+								PARTITION BY p.player_id
+								ORDER BY g.actual_game_start_time DESC, g.game_id DESC
+							) AS rn
+						FROM game_participants gp
+						JOIN games g ON gp.game_id = g.game_id
+						JOIN leagues l ON g.league_id = l.league_id
+						JOIN players p ON gp.player_id = p.player_id
+						JOIN teams t ON gp.team_id = t.team_id
+						WHERE l.league_name = :leagueName
+						  AND l.season_year = :year
+					) ranked
+					WHERE ranked.rn = 1
+					  AND (:teamId IS NULL OR ranked.teamId = :teamId)
+					  AND (:query IS NULL OR LOWER(ranked.playerName) LIKE LOWER(CONCAT('%', :query, '%')))
+					""",
+			nativeQuery = true)
 	Page<LckPlayerOption> findLckPlayerOptions(
 			@Param("leagueName") String leagueName,
 			@Param("year") int year,

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
@@ -1,0 +1,209 @@
+package com.toy.nar.domain.participant.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import com.toy.nar.domain.participant.repository.PlayerRepository.LckPlayerOption;
+
+/**
+ * {@link PlayerRepository#findLckPlayerOptions}의 동작을 검증한다.
+ *
+ * <p>핵심 의미: 선수별로 "가장 최근 LCK 시즌 경기"의 팀 하나로 중복 제거한다.
+ * 이적 선수는 최신 팀으로만 1번, 동일 시각 경기가 둘이어도 1번만 나와야 한다.
+ *
+ * <p>마이그레이션은 MySQL 전용 문법이라 H2에서는 엔티티 기반 스키마(create-drop)를 사용한다.
+ * (저장소의 다른 리포지토리 테스트와 동일한 방식.) 엔티티 그래프(Champion/GamePlayerStat)가
+ * 무거워 시딩은 네이티브 SQL로 한다.
+ */
+@org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class PlayerRepositoryLckPlayerOptionsTest {
+
+	@Autowired
+	private PlayerRepository playerRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	private static final String LCK = "LCK";
+	private static final int YEAR = 2026;
+	private static final long T1 = 10L;
+	private static final long GEN = 20L;
+
+	@BeforeEach
+	void seed() {
+		exec("INSERT INTO champions (champion_id, champion_name_kr, champion_name_en, image_url)"
+				+ " VALUES (1, '아리', 'Ahri', 'ahri.png')");
+
+		// 리그: LCK 2026(100), LCK 2025(101), LPL 2026(102)
+		exec(league(100, "LCK", 2026));
+		exec(league(101, "LCK", 2025));
+		exec(league(102, "LPL", 2026));
+
+		exec(team(T1, "T1", "T1"));
+		exec(team(GEN, "Gen.G", "GEN"));
+
+		exec(player(1, "Faker", "Mid"));
+		exec(player(2, "Mover", "Top"));     // 이적: GEN → T1
+		exec(player(3, "OldGuy", "Jungle")); // 2025만 → 제외
+		exec(player(4, "Other", "Bot"));     // LPL만 → 제외
+		exec(player(5, "Twin", "Support"));  // 동일 시각 2경기
+		exec(player(6, "GenStar", "Mid"));   // 최신 팀이 GEN
+
+		// games(game_id, league_id, actual_game_start_time)
+		exec(game(1, 100, "2026-01-10 10:00:00"));
+		exec(game(2, 100, "2026-01-05 10:00:00"));
+		exec(game(3, 100, "2026-01-20 10:00:00")); // Mover 최신
+		exec(game(4, 101, "2025-06-01 10:00:00")); // 2025
+		exec(game(5, 102, "2026-02-01 10:00:00")); // LPL
+		exec(game(6, 100, "2026-03-01 00:00:00")); // Twin (동일 시각, 낮은 id) GEN
+		exec(game(7, 100, "2026-03-01 00:00:00")); // Twin (동일 시각, 높은 id) T1
+		exec(game(8, 100, "2026-01-15 10:00:00")); // GenStar
+
+		// game_participants(id, game_id, player_id, team_id)
+		exec(gp(1, 1, 1, T1));   // Faker @T1
+		exec(gp(2, 2, 2, GEN));  // Mover @GEN (이전)
+		exec(gp(3, 3, 2, T1));   // Mover @T1 (최신) → T1
+		exec(gp(4, 4, 3, T1));   // OldGuy 2025
+		exec(gp(5, 5, 4, T1));   // Other LPL
+		exec(gp(6, 6, 5, GEN));  // Twin @GEN (동일 시각)
+		exec(gp(7, 7, 5, T1));   // Twin @T1 (동일 시각, 높은 game_id) → T1
+		exec(gp(8, 8, 6, GEN));  // GenStar @GEN
+
+		em.flush();
+		em.clear();
+	}
+
+	@Test
+	@DisplayName("LCK 2026 선수는 최신 경기 팀으로 중복 없이 1번씩, 타 연도/리그는 제외된다")
+	void returnsDistinctPlayersWithLatestTeam() {
+		Page<LckPlayerOption> page = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, null, PageRequest.of(0, 50));
+
+		// Faker, Mover, Twin, GenStar = 4명 (OldGuy=2025, Other=LPL 제외)
+		assertThat(page.getTotalElements()).isEqualTo(4);
+		assertThat(page.getContent()).extracting(LckPlayerOption::getPlayerName)
+				.containsExactlyInAnyOrder("Faker", "Mover", "Twin", "GenStar")
+				.doesNotHaveDuplicates();
+	}
+
+	@Test
+	@DisplayName("이적 선수는 가장 최근 경기의 팀(T1)으로 표시된다")
+	void transferredPlayerShowsLatestTeam() {
+		Page<LckPlayerOption> page = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, "Mover", PageRequest.of(0, 50));
+
+		assertThat(page.getContent()).hasSize(1);
+		assertThat(page.getContent().get(0).getTeamId()).isEqualTo(T1);
+	}
+
+	@Test
+	@DisplayName("동일 시각 경기가 둘이어도 선수는 1번만, 타이브레이크로 한 팀만 나온다")
+	void sameTimestampGamesDoNotDuplicate() {
+		Page<LckPlayerOption> page = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, "Twin", PageRequest.of(0, 50));
+
+		// 구버전(= MAX + DISTINCT)은 두 팀 행을 모두 반환해 2건이 됨 → 1건이어야 한다.
+		assertThat(page.getTotalElements()).isEqualTo(1);
+		assertThat(page.getContent()).hasSize(1);
+		assertThat(page.getContent().get(0).getTeamId()).isEqualTo(T1); // game_id 높은 쪽
+	}
+
+	@Test
+	@DisplayName("teamId 필터는 최신 팀이 해당 팀인 선수만 반환한다")
+	void filtersByLatestTeam() {
+		Page<LckPlayerOption> genTeam = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, GEN, null, PageRequest.of(0, 50));
+		assertThat(genTeam.getContent()).extracting(LckPlayerOption::getPlayerName)
+				.containsExactly("GenStar");
+
+		Page<LckPlayerOption> t1Team = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, T1, null, PageRequest.of(0, 50));
+		assertThat(t1Team.getContent()).extracting(LckPlayerOption::getPlayerName)
+				.containsExactlyInAnyOrder("Faker", "Mover", "Twin");
+	}
+
+	@Test
+	@DisplayName("이름 검색은 부분 일치(대소문자 무시)로 동작한다")
+	void filtersByNameQuery() {
+		Page<LckPlayerOption> page = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, "fak", PageRequest.of(0, 50));
+		assertThat(page.getContent()).extracting(LckPlayerOption::getPlayerName)
+				.containsExactly("Faker");
+	}
+
+	@Test
+	@DisplayName("페이지네이션: size=2, page0 은 이름순 2건 + 전체 4건/2페이지")
+	void paginates() {
+		Page<LckPlayerOption> page0 = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, null, PageRequest.of(0, 2));
+
+		assertThat(page0.getTotalElements()).isEqualTo(4);
+		assertThat(page0.getTotalPages()).isEqualTo(2);
+		// 이름순: Faker, GenStar, Mover, Twin
+		assertThat(page0.getContent()).extracting(LckPlayerOption::getPlayerName)
+				.containsExactly("Faker", "GenStar");
+	}
+
+	// ── 시딩 헬퍼 (네이티브 SQL) ─────────────────────────────────
+
+	private void exec(String sql) {
+		em.createNativeQuery(sql).executeUpdate();
+	}
+
+	private static String league(long id, String name, int year) {
+		return "INSERT INTO leagues (league_id, league_name, season_year, season_split, is_playoffs)"
+				+ " VALUES (" + id + ", '" + name + "', " + year + ", 'Spring', false)";
+	}
+
+	private static String team(long id, String name, String code) {
+		return "INSERT INTO teams (team_id, team_name, team_code, team_image_url)"
+				+ " VALUES (" + id + ", '" + name + "', '" + code + "', '" + code + ".png')";
+	}
+
+	private static String player(long id, String name, String role) {
+		return "INSERT INTO players (player_id, player_name, image_url, role)"
+				+ " VALUES (" + id + ", '" + name + "', '" + name + ".png', '" + role + "')";
+	}
+
+	private static String game(long id, long leagueId, String startTime) {
+		return "INSERT INTO games (game_id, league_id, actual_game_start_time, game_number, patch,"
+				+ " game_length_seconds, ckpm) VALUES (" + id + ", " + leagueId + ", '" + startTime
+				+ "', 1, '14.1', 1800, 0.5)";
+	}
+
+	private static String gp(long id, long gameId, long playerId, long teamId) {
+		return "INSERT INTO game_participants (participant_game_id, game_id, player_id, team_id,"
+				+ " side, position, champion_id, is_win) VALUES (" + id + ", " + gameId + ", "
+				+ playerId + ", " + teamId + ", 'Blue', 'mid', 1, true)";
+	}
+
+	/**
+	 * 컨텍스트를 game·participant 도메인으로 한정한다. (전체 앱을 띄우면 Elasticsearch 빈을
+	 * 요구해 슬라이스 테스트가 실패하므로, 저장소의 다른 리포지토리 테스트와 동일하게 범위를 좁힌다.)
+	 */
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@EntityScan(basePackages = {
+			"com.toy.nar.domain.game.entity",
+			"com.toy.nar.domain.participant.entity"
+	})
+	@EnableJpaRepositories(basePackageClasses = PlayerRepository.class)
+	static class TestJpaConfiguration {
+	}
+}


### PR DESCRIPTION
## 문제
구독 가능 선수 목록 API (`GET /mobile/me/player-subscriptions/available-players`)가 **페이지당 8~9초**로 매우 느렸다. 모바일 구독 설정 화면에서 선수 목록이 안 뜨는 것처럼 보이는 원인.

## 원인 (EXPLAIN ANALYZE로 확인)
`findLckPlayerOptions`의 상관 서브쿼리 `g.actualGameStartTime = (SELECT MAX(...) WHERE gp2.player = p ...)`가:
1. 바깥 결과 **행마다** 실행됨 (실제 선수는 ~64명인데 LCK 2026 참가 행 ~3,490개 → 서브쿼리 3,490회, 동일 선수 max를 수십 번 중복 계산)
2. 매 실행마다 그 선수의 **전체 참가 기록**(평균 ~217행)을 `games`·`leagues`에 조인 → 총 **~757,098회** 중첩 반복

> 인덱스 부족이 아니라 **알고리즘 문제**다. `leagues`(작은 테이블)는 이미 유니크 인덱스로 처리되어, 인덱스 추가로는 해결되지 않는다.

## 변경
- 상관 서브쿼리를 윈도우 함수로 교체:
  `ROW_NUMBER() OVER (PARTITION BY player ORDER BY actual_game_start_time DESC, game_id DESC)` → `rn = 1`
  참가 기록을 **한 번만** 스캔해 선수별 "가장 최근 경기 팀"을 고른다.
- 윈도우 함수/파생 테이블을 위해 **네이티브 쿼리**로 작성 (별칭은 `LckPlayerOption` 프로젝션 게터명과 일치). count 쿼리도 동일 구조.
- 부수적으로 **동일 시각 경기가 둘인 선수가 중복 반환되던 잠재 버그**도 `game_id` 타이브레이크로 해소. (기존 `= MAX` + `DISTINCT`는 두 팀 행을 모두 반환했고, count는 `COUNT(DISTINCT p.id)`라 content와 totalElements가 어긋날 수 있었음.)

## 성능 (로컬 동일 데이터: game_participants 159,700행, LCK 2026 64명)
| | 응답 시간 |
|---|---|
| 기존(상관 서브쿼리) | **1223 ms** |
| 변경(ROW_NUMBER) | **22 ms** (~55배) |

결과 집합은 신·구 **동일(64명)** 확인.

## 검증
- `PlayerRepositoryLckPlayerOptionsTest` 추가 (H2 `@DataJpaTest`, 저장소의 기존 리포지토리 슬라이스 테스트와 동일 방식 — 컨텍스트는 game/participant 도메인으로 한정):
  최신 팀 중복 제거 · 연도/리그 제외 · `teamId`/검색 필터 · **동일 시각 타이브레이크** · 페이지네이션 등 6케이스. **구쿼리에서 RED → 신쿼리에서 GREEN** 확인.
- 로컬 MySQL 실데이터에서 신·구 결과 동일 + `EXPLAIN ANALYZE`로 병목 재현.

## 범위 / 참고
- 동일 패턴이 `findLckPlayerOption`(단건)·`findLckPlayerOptionsByPlayerIds`에도 있으나, 이들은 `playerId`로 한정돼 규모가 작아 이번 PR 범위에서 제외했다.
- ⚠️ 현재 `v3-dev`는 일부 모바일 테스트(`MobileScheduleServiceTest`, `MobileScheduleControllerTest`, `MobileMatchControllerTest`)가 메인 소스 시그니처 변경과 어긋나 **테스트 소스 컴파일이 깨져 있다**(이 PR과 무관, 본 변경에서 손대지 않음). 추가한 테스트는 그 파일들이 고쳐지면 전체 스위트에서 함께 실행된다 — 본 PR에서는 해당 깨진 파일을 임시로 제외하고 신규 테스트만 RED→GREEN으로 검증했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)