### PR TITLE
ci: 문서·번들 변경 머지는 운영 배포 스킵 (paths-ignore)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    # 문서·지식 번들만 바뀐 머지는 운영 배포를 건너뛴다.
+    # (변경 파일이 전부 아래 패턴에 매칭될 때만 스킵 — 코드와 섞이면 정상 배포)
+    paths-ignore:
+      - 'nar-okf/**'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
## 문제
`deploy.yml`이 `push: main`마다 EC2 운영 배포를 트리거한다. 그래서 `nar-okf` 번들·README 등 **문서만 바뀐 머지에도 운영 풀배포**가 나간다 (불필요, 배포 노이즈).

## 변경
`deploy.yml`에 `paths-ignore` 추가:
- `nar-okf/**`, `docs/**`, `**.md`
- 변경 파일이 **전부** 이 패턴에 매칭될 때만 배포 스킵. 코드(`src/`, `build.gradle` 등)와 섞이면 정상 배포.

## 주의
- CI(`ci.yml`, `build-and-test`)는 브랜치 보호 **필수 체크**라 필터를 걸지 않음 (걸면 문서 PR이 "체크 없음"으로 머지 막힘).
- 이 PR 자체는 워크플로(.yml)만 바뀌어 머지 시 평소대로 배포가 한 번 나감 (deploy.yml은 ignore 대상 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)