### PR TITLE
feat: 선수 평점 리뷰 작성자 프로필·응원팀 이미지 필드 추가 (warding#42)

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -12,6 +12,7 @@ import com.toy.nar.app.mobile.rating.dto.MyRatingListResponse;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.rating.entity.LivePlayerRating;
 import com.toy.nar.domain.rating.repository.LivePlayerRatingRepository;
@@ -387,12 +388,17 @@ public class MobileLivePlayerRatingService {
 	}
 
 	private LivePlayerRatingDetailResponse.Review toReview(LivePlayerRating rating, Long memberId) {
+		Member member = rating.getMember();
+		Team favoriteTeam = member.getFavoriteTeam();
 		return new LivePlayerRatingDetailResponse.Review(
 				rating.getId(),
-				rating.getMember().getNickname(),
+				member.getNickname(),
+				member.getProfileImageUrl(),
+				favoriteTeam != null ? favoriteTeam.getId() : null,
+				favoriteTeam != null ? favoriteTeam.getImageUrl() : null,
 				rating.getRating(),
 				rating.getComment(),
-				memberId != null && memberId.equals(rating.getMember().getId()),
+				memberId != null && memberId.equals(member.getId()),
 				rating.getCreatedAt(),
 				rating.getUpdatedAt());
 	}

--- a/src/main/java/com/toy/nar/app/mobile/rating/dto/LivePlayerRatingDetailResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/dto/LivePlayerRatingDetailResponse.java
@@ -39,6 +39,9 @@ public record LivePlayerRatingDetailResponse(
 	public record Review(
 			Long ratingId,
 			String nickname,
+			String profileImageUrl,
+			Long favoriteTeamId,
+			String teamImageUrl,
 			int rating,
 			String comment,
 			boolean mine,

--- a/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
+++ b/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
@@ -23,7 +23,7 @@ public interface LivePlayerRatingRepository extends JpaRepository<LivePlayerRati
 	@EntityGraph(attributePaths = "player")
 	Page<LivePlayerRating> findByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
-	@EntityGraph(attributePaths = "member")
+	@EntityGraph(attributePaths = {"member", "member.favoriteTeam"})
 	Page<LivePlayerRating> findByLiveGameIdAndLiveParticipantIdOrderByCreatedAtDesc(
 			String liveGameId,
 			Integer liveParticipantId,

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -12,6 +12,7 @@ import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingRequest;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.rating.entity.LivePlayerRating;
 import com.toy.nar.domain.rating.repository.LivePlayerRatingRepository;
@@ -126,6 +127,10 @@ class MobileLivePlayerRatingServiceTest {
 	@Test
 	void returnsRatingDistributionReviewsAndMyRating() {
 		Member member = member(7L, "용맹한바론");
+		ReflectionTestUtils.setField(member, "profileImageUrl", "https://cdn/profile/7.png");
+		Team favoriteTeam = new Team("T1", "T1", "https://cdn/team/t1.png");
+		ReflectionTestUtils.setField(favoriteTeam, "id", 3L);
+		ReflectionTestUtils.setField(member, "favoriteTeam", favoriteTeam);
 		LivePlayerRating rating = rating(member, 5, "역시 페이커");
 		ReflectionTestUtils.setField(rating, "id", 11L);
 
@@ -162,6 +167,9 @@ class MobileLivePlayerRatingServiceTest {
 		assertThat(response.reviews()).first().satisfies(review -> {
 			assertThat(review.nickname()).isEqualTo("용맹한바론#0000");
 			assertThat(review.mine()).isTrue();
+			assertThat(review.profileImageUrl()).isEqualTo("https://cdn/profile/7.png");
+			assertThat(review.favoriteTeamId()).isEqualTo(3L);
+			assertThat(review.teamImageUrl()).isEqualTo("https://cdn/team/t1.png");
 		});
 	}
 


### PR DESCRIPTION
## 배경
NAR-GG/warding-mobile-repo#42 — 선수 평점 상세의 **다른 유저 리뷰**(`PlayerCommentSection`) 작성자 프로필/응원팀 이미지가 placeholder 상태. 백엔드 응답에 닉네임만 있고 프로필/팀 데이터가 없었다.

## 변경
- `LivePlayerRatingDetailResponse.Review`에 `profileImageUrl`, `favoriteTeamId`, `teamImageUrl` 추가
- `toReview`에서 `member` · `member.favoriteTeam`으로 채움 (응원팀 미설정 시 null)
- 상세 조회 `@EntityGraph`에 `member.favoriteTeam` 추가 → N+1 방지

## 응답 예시 (reviews[] 항목)
```
{ ratingId, nickname, profileImageUrl, favoriteTeamId, teamImageUrl, rating, comment, mine, createdAt, updatedAt }
```

## 프론트 후속 (warding-mobile-repo)
필드 추가됐으니 `PlayerCommentSection`의 프로필(37×37)·구독뱃지(21×21) placeholder를 실제 이미지로 연결.

## 테스트
`MobileLivePlayerRatingServiceTest.returnsRatingDistributionReviewsAndMyRating` 에 작성자 프로필/응원팀 필드 검증 추가, 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)