### PR TITLE
feat: 마이구독 알림 리스트 전체 페이지 API

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/notification/MobileMemberNotificationController.java
+++ b/src/main/java/com/toy/nar/api/mobile/notification/MobileMemberNotificationController.java
@@ -1,0 +1,55 @@
+package com.toy.nar.api.mobile.notification;
+
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
+import com.toy.nar.app.mobile.notification.dto.MemberNotificationListResponse;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mobile. 마이구독 알림", description = "마이구독 알림 리스트 전체 페이지 API")
+@RestController
+@RequestMapping("/api/mobile/me/notifications")
+@RequiredArgsConstructor
+public class MobileMemberNotificationController {
+
+	private final MemberNotificationService notificationService;
+
+	@Operation(summary = "알림 리스트 조회",
+			description = "로그인한 회원이 받은 알림을 최신순으로 조회한다. type 으로 필터(미지정 시 전체).")
+	@SecurityRequirement(name = "bearerAuth")
+	@GetMapping
+	public ResponseEntity<MemberNotificationListResponse> getNotifications(
+			@AuthenticationPrincipal Long memberId,
+			@RequestParam(required = false) MemberNotificationType type,
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "20") int size) {
+		return ResponseEntity.ok(notificationService.getNotifications(memberId, type, page, size));
+	}
+
+	@Operation(summary = "알림 전체 읽음 처리", description = "미읽음 알림을 모두 읽음으로 표시하고 처리한 건수를 반환한다.")
+	@SecurityRequirement(name = "bearerAuth")
+	@PostMapping("/read")
+	public ResponseEntity<Integer> markAllRead(@AuthenticationPrincipal Long memberId) {
+		return ResponseEntity.ok(notificationService.markAllRead(memberId));
+	}
+
+	@Operation(summary = "알림 단건 읽음 처리")
+	@SecurityRequirement(name = "bearerAuth")
+	@PostMapping("/{notificationId}/read")
+	public ResponseEntity<Void> markRead(
+			@AuthenticationPrincipal Long memberId,
+			@PathVariable Long notificationId) {
+		notificationService.markRead(memberId, notificationId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
@@ -1,0 +1,91 @@
+package com.toy.nar.app.mobile.notification;
+
+import com.toy.nar.app.mobile.notification.dto.MemberNotificationListResponse;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberNotification;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import com.toy.nar.domain.member.repository.MemberNotificationRepository;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberNotificationService {
+
+	private final MemberNotificationRepository notificationRepository;
+	private final MemberRepository memberRepository;
+
+	/**
+	 * 푸시 발송 성공 시 알림 피드 1행을 기록한다. 피드 기록 실패가 푸시 흐름을 깨면 안 되므로
+	 * 호출부(푸시 서비스)에서 예외를 흡수한다.
+	 */
+	@Transactional
+	public void record(
+			Long memberId,
+			MemberNotificationType type,
+			String title,
+			String body,
+			Map<String, String> data) {
+		if (memberId == null || type == null || title == null) {
+			return;
+		}
+		Member member = memberRepository.getReferenceById(memberId);
+		notificationRepository.save(new MemberNotification(member, type, title, body, data));
+	}
+
+	public MemberNotificationListResponse getNotifications(
+			Long memberId,
+			MemberNotificationType type,
+			int page,
+			int size) {
+		requireLogin(memberId);
+		int safePage = Math.max(0, page);
+		int safeSize = Math.max(1, Math.min(size, 100));
+		PageRequest pageable = PageRequest.of(safePage, safeSize);
+		Page<MemberNotification> notifications = type == null
+				? notificationRepository.findByMember_IdOrderByCreatedAtDesc(memberId, pageable)
+				: notificationRepository.findByMember_IdAndTypeOrderByCreatedAtDesc(memberId, type, pageable);
+
+		return new MemberNotificationListResponse(
+				notifications.getContent().stream()
+						.map(MemberNotificationListResponse.Item::from)
+						.toList(),
+				notificationRepository.countByMember_IdAndReadAtIsNull(memberId),
+				notifications.getNumber(),
+				notifications.getSize(),
+				notifications.getTotalElements(),
+				notifications.getTotalPages());
+	}
+
+	@Transactional
+	public int markAllRead(Long memberId) {
+		requireLogin(memberId);
+		return notificationRepository.markAllReadByMember(memberId, LocalDateTime.now());
+	}
+
+	@Transactional
+	public void markRead(Long memberId, Long notificationId) {
+		requireLogin(memberId);
+		MemberNotification notification = notificationRepository.findByIdAndMember_Id(notificationId, memberId)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."));
+		notification.markRead();
+	}
+
+	private void requireLogin(Long memberId) {
+		if (memberId == null) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/notification/dto/MemberNotificationListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/dto/MemberNotificationListResponse.java
@@ -1,0 +1,44 @@
+package com.toy.nar.app.mobile.notification.dto;
+
+import com.toy.nar.domain.member.entity.MemberNotification;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "마이구독 알림 리스트 전체 페이지 응답")
+public record MemberNotificationListResponse(
+		List<Item> notifications,
+		@Schema(description = "미읽음 알림 수(필터와 무관한 전체 기준)", example = "3")
+		long unreadCount,
+		int page,
+		int size,
+		long totalElements,
+		int totalPages) {
+
+	public record Item(
+			Long id,
+			@Schema(description = "알림 종류", example = "SET_END")
+			MemberNotificationType type,
+			String title,
+			String body,
+			@Schema(description = "딥링크·참조 식별자(playerId/matchId/gameId/setNumber 등)")
+			Map<String, String> data,
+			@Schema(description = "읽음 여부", example = "false")
+			boolean read,
+			LocalDateTime createdAt) {
+
+		public static Item from(MemberNotification n) {
+			return new Item(
+					n.getId(),
+					n.getType(),
+					n.getTitle(),
+					n.getBody(),
+					n.getData(),
+					n.isRead(),
+					n.getCreatedAt());
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -1,6 +1,8 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
 import com.toy.nar.domain.member.entity.MemberDevice;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
 import com.toy.nar.domain.member.repository.MemberDeviceRepository;
 import com.toy.nar.domain.member.repository.PlayerSoloRankPushDeliveryRepository;
 import com.toy.nar.domain.participant.entity.Player;
@@ -26,6 +28,7 @@ public class PlayerSoloRankPushService {
 	private final MemberDeviceRepository deviceRepository;
 	private final PlayerSoloRankPushDeliveryRepository deliveryRepository;
 	private final MobilePushGateway pushGateway;
+	private final MemberNotificationService notificationService;
 
 	public void notifySubscribers(
 			Player player,
@@ -93,6 +96,7 @@ public class PlayerSoloRankPushService {
 			}
 			if (result.successCount() > 0) {
 				deliveryRepository.markSent(memberId, player.getId(), gameId);
+				recordFeed(memberId, message);
 			} else {
 				deliveryRepository.markFailed(
 						memberId,
@@ -141,6 +145,20 @@ public class PlayerSoloRankPushService {
 					playerId,
 					gameId,
 					persistenceException);
+		}
+	}
+
+	/** 마이구독 알림 피드에 기록한다. 피드 실패가 푸시 흐름을 깨면 안 되므로 예외를 흡수한다. */
+	private void recordFeed(Long memberId, MobilePushMessage message) {
+		try {
+			notificationService.record(
+					memberId,
+					MemberNotificationType.PLAYER_SOLO_RANK_STARTED,
+					message.title(),
+					message.body(),
+					message.data());
+		} catch (Exception e) {
+			log.warn("Failed to record solo rank notification feed memberId={}", memberId, e);
 		}
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -1,6 +1,8 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
 import com.toy.nar.domain.member.entity.MemberDevice;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
 import com.toy.nar.domain.member.repository.MemberDeviceRepository;
 import com.toy.nar.domain.member.repository.MemberTeamEventPushDeliveryRepository;
 import com.toy.nar.domain.participant.LckTeamCatalog;
@@ -46,6 +48,7 @@ public class TeamLiveEventPushService {
 	private final MemberTeamEventPushDeliveryRepository deliveryRepository;
 	private final TeamExternalIdentityRepository teamExternalIdentityRepository;
 	private final MobilePushGateway pushGateway;
+	private final MemberNotificationService notificationService;
 
 	@Value("${live.notification.fcm.enabled:false}")
 	private boolean fcmNotificationEnabled;
@@ -167,6 +170,7 @@ public class TeamLiveEventPushService {
 			}
 			if (result.successCount() > 0) {
 				deliveryRepository.markSent(memberId, matchId, setNumber, eventType, eventOrder);
+				recordFeed(memberId, eventType, message);
 			} else {
 				deliveryRepository.markFailed(memberId, matchId, setNumber, eventType, eventOrder,
 						"FCM 전송 성공 기기가 없습니다.");
@@ -210,6 +214,21 @@ public class TeamLiveEventPushService {
 				.findBySourceAndExternalTeamId(LOLESPORTS_SOURCE, esportsTeamId)
 				.map(identity -> identity.getTeam())
 				.filter(team -> LckTeamCatalog.contains(team.getCode()));
+	}
+
+	/** 마이구독 알림 피드에 기록한다. 피드 실패가 푸시 흐름을 깨면 안 되므로 예외를 흡수한다. */
+	private void recordFeed(Long memberId, String eventType, MobilePushMessage message) {
+		try {
+			notificationService.record(
+					memberId,
+					MemberNotificationType.valueOf(eventType),
+					message.title(),
+					message.body(),
+					message.data());
+		} catch (Exception e) {
+			log.warn("Failed to record team event notification feed memberId={} eventType={}",
+					memberId, eventType, e);
+		}
 	}
 
 	private MobilePushMessage buildMatchEventMessage(

--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                                 "/api/mobile/live/games/*/participants/*/my-rating"
                         ).authenticated()
                         .requestMatchers(
-                                "/api/mobile/me/notification-subscriptions/**"
+                                "/api/mobile/me/notification-subscriptions/**",
+                                "/api/mobile/me/notifications/**"
                         ).authenticated()
                         .requestMatchers(
                                 "/api/auth/me", "/api/auth/logout", "/api/auth/onboarding"

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberNotification.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberNotification.java
@@ -1,0 +1,85 @@
+package com.toy.nar.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * 마이구독 알림 피드 1건. 푸시 발송 성공 시점에 기록된다.
+ * 조회 전용에 가깝고, 읽음 처리({@link #markRead()})만 상태를 바꾼다.
+ */
+@Entity
+@Table(name = "member_notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberNotification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 40)
+	private MemberNotificationType type;
+
+	@Column(name = "title", nullable = false, length = 255)
+	private String title;
+
+	@Column(name = "body", length = 500)
+	private String body;
+
+	/** 딥링크·참조 식별자(playerId/matchId/gameId/setNumber 등). 푸시 data 를 그대로 보존한다. */
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(name = "data")
+	private Map<String, String> data;
+
+	@Column(name = "read_at")
+	private LocalDateTime readAt;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	public MemberNotification(
+			Member member,
+			MemberNotificationType type,
+			String title,
+			String body,
+			Map<String, String> data) {
+		this.member = member;
+		this.type = type;
+		this.title = title;
+		this.body = body;
+		this.data = data;
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public boolean isRead() {
+		return readAt != null;
+	}
+
+	public void markRead() {
+		if (readAt == null) {
+			this.readAt = LocalDateTime.now();
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberNotificationType.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberNotificationType.java
@@ -1,0 +1,11 @@
+package com.toy.nar.domain.member.entity;
+
+/**
+ * 마이구독 알림 피드 종류. 값은 FCM 푸시의 {@code data.type} 과 일치해야 한다.
+ */
+public enum MemberNotificationType {
+	SET_START,
+	SET_END,
+	LIVE_EVENT,
+	PLAYER_SOLO_RANK_STARTED
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepository.java
@@ -1,0 +1,29 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.MemberNotification;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
+
+	Page<MemberNotification> findByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+	Page<MemberNotification> findByMember_IdAndTypeOrderByCreatedAtDesc(
+			Long memberId, MemberNotificationType type, Pageable pageable);
+
+	long countByMember_IdAndReadAtIsNull(Long memberId);
+
+	Optional<MemberNotification> findByIdAndMember_Id(Long id, Long memberId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE MemberNotification n SET n.readAt = :now WHERE n.member.id = :memberId AND n.readAt IS NULL")
+	int markAllReadByMember(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
+}

--- a/src/main/resources/db/migration/V46__Create_member_notification.sql
+++ b/src/main/resources/db/migration/V46__Create_member_notification.sql
@@ -1,0 +1,21 @@
+-- 마이구독 알림 리스트(마이페이지) 피드 테이블.
+-- FCM 푸시는 발송 시점에만 콘텐츠(title/body)가 만들어지고 영속화되지 않아,
+-- 회원별 알림 히스토리를 조회할 수 없었다. 푸시 발송 성공 시 이 테이블에 1행을 남겨
+-- 알림 리스트 전체 페이지 API가 조회한다.
+--   - type: SET_START / SET_END / LIVE_EVENT / PLAYER_SOLO_RANK_STARTED (푸시 data.type 과 일치)
+--   - data: 딥링크·참조 식별자(playerId/matchId/gameId/setNumber 등) JSON
+--   - read_at: 읽음 처리 시각(미읽음이면 NULL)
+CREATE TABLE IF NOT EXISTS member_notification (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT       NOT NULL,
+    type       VARCHAR(40)  NOT NULL,
+    title      VARCHAR(255) NOT NULL,
+    body       VARCHAR(500),
+    data       JSON,
+    read_at    DATETIME,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_member_notification_member
+        FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    INDEX idx_member_notification_member_created (member_id, created_at),
+    INDEX idx_member_notification_member_type (member_id, type)
+);

--- a/src/test/java/com/toy/nar/app/mobile/notification/MemberNotificationServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/notification/MemberNotificationServiceTest.java
@@ -1,0 +1,129 @@
+package com.toy.nar.app.mobile.notification;
+
+import com.toy.nar.app.mobile.notification.dto.MemberNotificationListResponse;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberNotification;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import com.toy.nar.domain.member.repository.MemberNotificationRepository;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberNotificationServiceTest {
+
+	@Mock
+	private MemberNotificationRepository notificationRepository;
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	private MemberNotificationService service() {
+		return new MemberNotificationService(notificationRepository, memberRepository);
+	}
+
+	@Test
+	void recordSavesFeedRowWithMemberReference() {
+		Member member = member(7L);
+		when(memberRepository.getReferenceById(7L)).thenReturn(member);
+
+		service().record(7L, MemberNotificationType.SET_END, "T1 세트 종료",
+				"T1 vs GEN · 1세트 종료", Map.of("matchId", "m1"));
+
+		ArgumentCaptor<MemberNotification> captor = ArgumentCaptor.forClass(MemberNotification.class);
+		verify(notificationRepository).save(captor.capture());
+		MemberNotification saved = captor.getValue();
+		assertThat(saved.getType()).isEqualTo(MemberNotificationType.SET_END);
+		assertThat(saved.getTitle()).isEqualTo("T1 세트 종료");
+		assertThat(saved.getData()).containsEntry("matchId", "m1");
+		assertThat(saved.getMember()).isSameAs(member);
+	}
+
+	@Test
+	void recordIgnoresMissingMemberOrType() {
+		service().record(null, MemberNotificationType.SET_END, "t", "b", Map.of());
+		service().record(7L, null, "t", "b", Map.of());
+		verify(notificationRepository, never()).save(any());
+	}
+
+	@Test
+	void getNotificationsWithoutTypeReturnsAllWithUnreadCount() {
+		MemberNotification read = notification(1L, MemberNotificationType.SET_START, true);
+		MemberNotification unread = notification(2L, MemberNotificationType.LIVE_EVENT, false);
+		when(notificationRepository.findByMember_IdOrderByCreatedAtDesc(eq(7L), any()))
+				.thenReturn(new PageImpl<>(List.of(unread, read), PageRequest.of(0, 20), 2));
+		when(notificationRepository.countByMember_IdAndReadAtIsNull(7L)).thenReturn(1L);
+
+		MemberNotificationListResponse response = service().getNotifications(7L, null, 0, 20);
+
+		assertThat(response.notifications()).hasSize(2);
+		assertThat(response.unreadCount()).isEqualTo(1L);
+		assertThat(response.totalElements()).isEqualTo(2L);
+		assertThat(response.notifications().get(0).read()).isFalse();
+		verify(notificationRepository, never()).findByMember_IdAndTypeOrderByCreatedAtDesc(any(), any(), any());
+	}
+
+	@Test
+	void getNotificationsWithTypeFiltersByType() {
+		when(notificationRepository.findByMember_IdAndTypeOrderByCreatedAtDesc(
+				eq(7L), eq(MemberNotificationType.SET_END), any()))
+				.thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+		when(notificationRepository.countByMember_IdAndReadAtIsNull(7L)).thenReturn(0L);
+
+		service().getNotifications(7L, MemberNotificationType.SET_END, 0, 20);
+
+		verify(notificationRepository).findByMember_IdAndTypeOrderByCreatedAtDesc(
+				eq(7L), eq(MemberNotificationType.SET_END), any());
+		verify(notificationRepository, never()).findByMember_IdOrderByCreatedAtDesc(any(), any());
+	}
+
+	@Test
+	void markReadLoadsScopedToMemberAndMarks() {
+		MemberNotification notification = notification(9L, MemberNotificationType.SET_START, false);
+		when(notificationRepository.findByIdAndMember_Id(9L, 7L)).thenReturn(java.util.Optional.of(notification));
+
+		service().markRead(7L, 9L);
+
+		assertThat(notification.isRead()).isTrue();
+	}
+
+	@Test
+	void getNotificationsRequiresLogin() {
+		assertThatThrownBy(() -> service().getNotifications(null, null, 0, 20))
+				.isInstanceOf(ResponseStatusException.class);
+	}
+
+	private Member member(Long id) {
+		Member member = Member.builder().name("nick").tag("0000").email("a@b.c").build();
+		ReflectionTestUtils.setField(member, "id", id);
+		return member;
+	}
+
+	private MemberNotification notification(Long id, MemberNotificationType type, boolean read) {
+		MemberNotification n = new MemberNotification(member(7L), type, "title", "body", Map.of());
+		ReflectionTestUtils.setField(n, "id", id);
+		if (read) {
+			ReflectionTestUtils.setField(n, "readAt", LocalDateTime.now());
+		}
+		return n;
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
@@ -1,5 +1,6 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.entity.MemberDevice;
 import com.toy.nar.domain.member.entity.MobileDevicePlatform;
@@ -36,11 +37,15 @@ class PlayerSoloRankPushServiceTest {
 	@Mock
 	private MobilePushGateway pushGateway;
 
+	@Mock
+	private MemberNotificationService notificationService;
+
 	private PlayerSoloRankPushService service;
 
 	@BeforeEach
 	void setUp() {
-		service = new PlayerSoloRankPushService(deviceRepository, deliveryRepository, pushGateway);
+		service = new PlayerSoloRankPushService(
+				deviceRepository, deliveryRepository, pushGateway, notificationService);
 		when(pushGateway.isAvailable()).thenReturn(true);
 	}
 

--- a/src/test/java/com/toy/nar/domain/member/MobilePushSchemaMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/domain/member/MobilePushSchemaMySqlIntegrationTest.java
@@ -60,6 +60,7 @@ class MobilePushSchemaMySqlIntegrationTest {
 			new MetadataSources(registry)
 					.addAnnotatedClass(MemberDeviceSchemaProbe.class)
 					.addAnnotatedClass(PushDeliverySchemaProbe.class)
+					.addAnnotatedClass(MemberNotificationSchemaProbe.class)
 					.buildMetadata()
 					.buildSessionFactory()
 					.close();
@@ -88,6 +89,29 @@ class MobilePushSchemaMySqlIntegrationTest {
 		private LocalDateTime createdAt;
 		@Column(name = "updated_at", nullable = false)
 		private LocalDateTime updatedAt;
+	}
+
+	@Entity(name = "MemberNotificationSchemaProbe")
+	@Table(name = "member_notification")
+	static class MemberNotificationSchemaProbe {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+		@Column(name = "member_id", nullable = false)
+		private Long memberId;
+		@Column(name = "type", nullable = false, length = 40)
+		private String type;
+		@Column(name = "title", nullable = false, length = 255)
+		private String title;
+		@Column(name = "body", length = 500)
+		private String body;
+		@org.hibernate.annotations.JdbcTypeCode(org.hibernate.type.SqlTypes.JSON)
+		@Column(name = "data")
+		private java.util.Map<String, String> data;
+		@Column(name = "read_at")
+		private LocalDateTime readAt;
+		@Column(name = "created_at", nullable = false)
+		private LocalDateTime createdAt;
 	}
 
 	@Entity(name = "PushDeliverySchemaProbe")


### PR DESCRIPTION
## 배경
마이구독 페이지의 **알림 리스트 전체 페이지** API. FCM 푸시는 발송 시점에만 콘텐츠(title/body)가 만들어지고 영속화되지 않아, 회원이 받은 알림 히스토리를 조회할 방법이 없었다. 푸시 발송 성공 시 피드 행을 남기고, 이를 조회하는 API를 추가한다.

스크린샷의 알림 종류(선수 랭크 시작 감지 / 세트 시작·종료 / 라이브 이벤트)와 필터(전체·세트시작·세트종료·선수)를 커버한다.

## 변경
- **`member_notification` 테이블 (V46)** — `type` / `title` / `body` / `data`(JSON) / `read_at`
  - 실 MySQL 8.0.39에 마이그레이션 적용 + JSON 컬럼 roundtrip 검증 완료
- **피드 기록** — 푸시 발송 성공 지점에서 1행 insert
  - `PlayerSoloRankPushService` (PLAYER_SOLO_RANK_STARTED)
  - `TeamLiveEventPushService` (SET_START / SET_END / LIVE_EVENT)
  - 피드 기록 실패가 푸시 흐름을 깨지 않도록 예외 흡수
- **조회 API**
  - `GET /api/mobile/me/notifications?type=&page=&size=` — 최신순, type 필터(미지정 시 전체), 미읽음 수 포함
  - `POST /api/mobile/me/notifications/read` — 전체 읽음 처리
  - `POST /api/mobile/me/notifications/{id}/read` — 단건 읽음 처리

`data` 는 발송 페이로드(deepLink/playerId/matchId/setNumber 등)를 그대로 보존해 프론트가 딥링크·필터에 활용한다.

## 동작 메모
- 발송 후 적재되므로 **배포 이후 발생한 알림부터** 노출된다(소급 없음).
- 토픽(`all_solo_rank`) 발송분은 회원 단위 fan-out 이 아니라 제외. 구독 기반 회원 발송분만 피드에 남는다.

## 스킵 (필요 시 추가)
- 라이브 이벤트 펼침 타임라인(17:34 킬 로그 등) → 기존 라이브 경기 상세 API 로 대체 가능
- "선수전체" 드롭다운의 개별 선수 필터 → 현재는 type 필터까지

## 테스트
- `MemberNotificationServiceTest` — 기록/필터/읽음/미읽음수/인증 (통과)
- `PlayerSoloRankPushServiceTest` — 생성자 시그니처 변경 반영
- `MobilePushSchemaMySqlIntegrationTest` — `member_notification` 스키마 probe 추가(JSON 매핑 검증, CI Docker 환경에서 실행)

> 참고: 사전 존재 flaky 테스트 `TeamProfileServiceTest`(LocalDateTime.now() 의존)는 본 변경과 무관하게 실패하며 별도 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)