### PR TITLE
test: TeamProfileServiceTest 시각 의존성 제거

### DIFF
--- a/src/test/java/com/toy/nar/app/analysis/service/TeamProfileServiceTest.java
+++ b/src/test/java/com/toy/nar/app/analysis/service/TeamProfileServiceTest.java
@@ -6,7 +6,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +44,17 @@ class TeamProfileServiceTest {
 	@InjectMocks
 	private TeamProfileService teamProfileService;
 
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	// matchDate는 UTC로 저장되고 서비스가 KST로 변환해 "오늘"을 KST 날짜로 판정한다.
+	// KST 정오를 기준점으로 잡으면 양쪽 자정 경계에서 12시간 떨어져 있어 실행 시각과 무관하게 안정적이다.
+	private static LocalDateTime todayNoonUtc() {
+		return LocalDate.now(KST).atTime(12, 0)
+				.atZone(KST)
+				.withZoneSameInstant(ZoneOffset.UTC)
+				.toLocalDateTime();
+	}
+
 	@Test
 	@DisplayName("팀 헤더에서 이전/오늘/다음 순서로 경기 3개를 반환한다")
 	void getProfileHeader_returnsPreviousTodayNext() {
@@ -51,15 +65,15 @@ class TeamProfileServiceTest {
 		when(team.getImageUrl()).thenReturn("team-image");
 		when(teamRepository.findById(10L)).thenReturn(Optional.of(team));
 
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime base = todayNoonUtc();
 			List<LeagueMatch> matches = List.of(
-					LeagueMatch.builder().id("m1").leagueName("LCK").matchDate(now.minusDays(1)).state("completed")
+					LeagueMatch.builder().id("m1").leagueName("LCK").matchDate(base.minusDays(1)).state("completed")
 							.blueTeamCode("HLE").blueTeamName("HLE").redTeamCode("GEN").redTeamName("Gen.G").blueScore(0).redScore(2).build(),
-					LeagueMatch.builder().id("m2").leagueName("LCK").matchDate(now.minusHours(1)).state("inProgress")
+					LeagueMatch.builder().id("m2").leagueName("LCK").matchDate(base).state("inProgress")
 							.blueTeamCode("GEN").blueTeamName("Gen.G").redTeamCode("T1").redTeamName("T1").blueScore(1).redScore(0).build(),
-					LeagueMatch.builder().id("m3").leagueName("LCK").matchDate(now.plusHours(1)).state("unstarted")
+					LeagueMatch.builder().id("m3").leagueName("LCK").matchDate(base.plusHours(3)).state("unstarted")
 							.blueTeamCode("GEN").blueTeamName("Gen.G").redTeamCode("DK").redTeamName("DK").blueScore(0).redScore(0).build(),
-					LeagueMatch.builder().id("m4").leagueName("LCK").matchDate(now.plusDays(1)).state("unstarted")
+					LeagueMatch.builder().id("m4").leagueName("LCK").matchDate(base.plusDays(1)).state("unstarted")
 							.blueTeamCode("GEN").blueTeamName("Gen.G").redTeamCode("KT").redTeamName("KT").blueScore(0).redScore(0).build());
 
 		when(leagueMatchRepository.findTeamMatchesInDateRange(
@@ -92,11 +106,11 @@ class TeamProfileServiceTest {
 		when(team.getImageUrl()).thenReturn("team-image");
 		when(teamRepository.findById(10L)).thenReturn(Optional.of(team));
 
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime base = todayNoonUtc();
 			List<LeagueMatch> matches = List.of(
-					LeagueMatch.builder().id("m1").leagueName("LCK").matchDate(now.minusDays(2)).state("completed")
+					LeagueMatch.builder().id("m1").leagueName("LCK").matchDate(base.minusDays(2)).state("completed")
 							.blueTeamCode("HLE").blueTeamName("HLE").redTeamCode("GEN").redTeamName("Gen.G").blueScore(0).redScore(2).build(),
-					LeagueMatch.builder().id("m2").leagueName("LCK").matchDate(now.plusDays(1)).state("unstarted")
+					LeagueMatch.builder().id("m2").leagueName("LCK").matchDate(base.plusDays(1)).state("unstarted")
 							.blueTeamCode("GEN").blueTeamName("Gen.G").redTeamCode("DK").redTeamName("DK").blueScore(0).redScore(0).build());
 
 		when(leagueMatchRepository.findTeamMatchesInDateRange(


### PR DESCRIPTION
## 문제

`TeamProfileServiceTest.getProfileHeader_returnsPreviousTodayNext` 가 `LocalDateTime.now()` 기준 `±1h` fixture(`m2 = now.minusHours(1)`, `m3 = now.plusHours(1)`)로 "오늘 경기"를 만든다. 서비스(`TeamProfileService`)는 "오늘"을 **KST 캘린더 날짜**로 판정하므로, 실제 실행 시각이 KST 자정 경계 근처면 ±1h fixture가 어제/내일 날짜로 넘어가 "오늘" 경기가 윈도우 밖으로 떨어진다 → `Expected size: 3 but was: 2` 간헐 실패.

운영 코드는 정상이며 **테스트만 시각에 취약**했다.

## 수정

fixture 기준점을 `LocalDate.now(KST)` 의 **정오(=03:00 UTC)** 로 고정. 자정 경계에서 12시간 떨어져 있어 실행 시각/타임존과 무관하게 항상 같은 KST 날짜로 분류된다. 두 테스트 모두 동일 패턴으로 정리.

- 옵션 (b)(테스트 한정 고정) 채택 — 운영 코드 변경 0.
- 옵션 (a)(서비스에 `Clock` 주입)는 운영 코드에 버그가 없는 상황에서 테스트 전용 flake를 위해 prod 와이어링을 추가하는 과한 변경이라 보류.

## 검증

```
./gradlew test --tests "com.toy.nar.app.analysis.service.TeamProfileServiceTest"
BUILD SUCCESSFUL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)