### PR TITLE
feat: 마이구독 알림 삭제 API (단건/전체)

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/notification/MobileMemberNotificationController.java
+++ b/src/main/java/com/toy/nar/api/mobile/notification/MobileMemberNotificationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +51,23 @@ public class MobileMemberNotificationController {
 			@AuthenticationPrincipal Long memberId,
 			@PathVariable Long notificationId) {
 		notificationService.markRead(memberId, notificationId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(summary = "알림 전체 삭제", description = "회원의 알림을 모두 삭제하고 삭제 건수를 반환한다.")
+	@SecurityRequirement(name = "bearerAuth")
+	@DeleteMapping
+	public ResponseEntity<Integer> deleteAll(@AuthenticationPrincipal Long memberId) {
+		return ResponseEntity.ok(notificationService.deleteAll(memberId));
+	}
+
+	@Operation(summary = "알림 단건 삭제")
+	@SecurityRequirement(name = "bearerAuth")
+	@DeleteMapping("/{notificationId}")
+	public ResponseEntity<Void> delete(
+			@AuthenticationPrincipal Long memberId,
+			@PathVariable Long notificationId) {
+		notificationService.delete(memberId, notificationId);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
@@ -83,6 +83,22 @@ public class MemberNotificationService {
 		notification.markRead();
 	}
 
+	/** 단건 삭제. 본인 알림이 아니거나 없으면 404. */
+	@Transactional
+	public void delete(Long memberId, Long notificationId) {
+		requireLogin(memberId);
+		if (notificationRepository.deleteByIdAndMember_Id(notificationId, memberId) == 0) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다.");
+		}
+	}
+
+	/** 회원의 알림을 모두 삭제하고 삭제 건수를 반환한다. */
+	@Transactional
+	public int deleteAll(Long memberId) {
+		requireLogin(memberId);
+		return notificationRepository.deleteAllByMember(memberId);
+	}
+
 	private void requireLogin(Long memberId) {
 		if (memberId == null) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepository.java
@@ -26,4 +26,10 @@ public interface MemberNotificationRepository extends JpaRepository<MemberNotifi
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE MemberNotification n SET n.readAt = :now WHERE n.member.id = :memberId AND n.readAt IS NULL")
 	int markAllReadByMember(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
+
+	int deleteByIdAndMember_Id(Long id, Long memberId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM MemberNotification n WHERE n.member.id = :memberId")
+	int deleteAllByMember(@Param("memberId") Long memberId);
 }

--- a/src/test/java/com/toy/nar/app/mobile/notification/MemberNotificationServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/notification/MemberNotificationServiceTest.java
@@ -112,6 +112,40 @@ class MemberNotificationServiceTest {
 				.isInstanceOf(ResponseStatusException.class);
 	}
 
+	@Test
+	void deleteRemovesWhenOwnedByMember() {
+		when(notificationRepository.deleteByIdAndMember_Id(9L, 7L)).thenReturn(1);
+
+		service().delete(7L, 9L);
+
+		verify(notificationRepository).deleteByIdAndMember_Id(9L, 7L);
+	}
+
+	@Test
+	void deleteThrowsNotFoundWhenNotOwnedOrMissing() {
+		when(notificationRepository.deleteByIdAndMember_Id(9L, 7L)).thenReturn(0);
+
+		assertThatThrownBy(() -> service().delete(7L, 9L))
+				.isInstanceOf(ResponseStatusException.class);
+	}
+
+	@Test
+	void deleteAllReturnsDeletedCount() {
+		when(notificationRepository.deleteAllByMember(7L)).thenReturn(3);
+
+		assertThat(service().deleteAll(7L)).isEqualTo(3);
+	}
+
+	@Test
+	void deleteRequiresLogin() {
+		assertThatThrownBy(() -> service().delete(null, 9L))
+				.isInstanceOf(ResponseStatusException.class);
+		assertThatThrownBy(() -> service().deleteAll(null))
+				.isInstanceOf(ResponseStatusException.class);
+		verify(notificationRepository, never()).deleteByIdAndMember_Id(any(), any());
+		verify(notificationRepository, never()).deleteAllByMember(any());
+	}
+
 	private Member member(Long id) {
 		Member member = Member.builder().name("nick").tag("0000").email("a@b.c").build();
 		ReflectionTestUtils.setField(member, "id", id);


### PR DESCRIPTION
## 배경
프론트 마이구독 피드에 **스와이프 삭제** + 헤더 **비우기(모두 삭제)** 를 붙이려는데, 기존 알림 API엔 읽음(read) 계열만 있고 삭제가 없어 추가.

## 변경
- `DELETE /api/mobile/me/notifications/{notificationId}` — 단건 삭제. 본인 소유 아니거나 없으면 404.
- `DELETE /api/mobile/me/notifications` — 전체 삭제. 삭제 건수 반환.
- Repository: `deleteByIdAndMember_Id`(파생) + `deleteAllByMember`(`@Modifying` 벌크 JPQL)
- 하드 삭제(피드는 휘발성 항목, 소프트삭제 컬럼 없음)

## 검증
- `SecurityConfig` 변경 불필요 — `/api/mobile/me/notifications/**` authenticated 규칙이 root 경로·DELETE 메서드까지 커버
- 단위 테스트 4건 추가(단건 삭제 / 소유 아님 404 / 전체 삭제 건수 / 로그인 필요) → `./gradlew test --tests MemberNotificationServiceTest` BUILD SUCCESSFUL

## 후속
프론트(warding) PR에서 repository·viewmodel·UI(비우기 아이콘 + 스와이프 + undo, 미읽음 점 제거) 연동 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)