### PR TITLE
feat: 선수 솔랭 게임 이력 적재 (선수 카드 기반)

### DIFF
--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
@@ -44,6 +44,7 @@ public class PlayerSoloRankMonitorService {
 	private final NotificationService notificationService;
 	private final PlayerSoloRankPushService playerSoloRankPushService;
 	private final SchedulerAlertService schedulerAlertService;
+	private final SoloRankGameHistoryRecorder soloRankGameHistoryRecorder;
 
 	@Transactional
 	public PlayerSoloRankMonitorResult pollTrackedAccounts() {
@@ -81,9 +82,15 @@ public class PlayerSoloRankMonitorService {
 					continue;
 				}
 
+				// 새 게임 1회만 챔피언 해석(추가 Riot 콜 없음 — spectator 응답에서 조회).
+				Champion champion = resolveTrackedChampion(currentGame, account.getPuuid());
+
 				if (isRankedSolo(currentGame)) {
 					account.markRecentRankedSolo(currentGameId, checkedAt);
 					rankedSoloCount++;
+					// 구독 여부와 무관하게 솔랭 게임 이력 적재(선수 카드 최근 솔랭·챔프 폭).
+					soloRankGameHistoryRecorder.record(
+							account.getPlayer(), currentGameId, champion, checkedAt);
 				} else {
 					account.markRecentOtherQueue(currentGameId, checkedAt);
 					otherQueueCount++;
@@ -97,7 +104,6 @@ public class PlayerSoloRankMonitorService {
 				}
 
 				if (account.shouldSendAlertFor(currentGameId)) {
-					Champion champion = resolveTrackedChampion(currentGame, account.getPuuid());
 					String queueDisplayName = resolveQueueDisplayName(currentGame.gameQueueConfigId());
 					notificationService.sendPlayerGameNotification(
 							account.getPlayer().getName(),

--- a/src/main/java/com/toy/nar/app/riot/SoloRankGameHistoryRecorder.java
+++ b/src/main/java/com/toy/nar/app/riot/SoloRankGameHistoryRecorder.java
@@ -1,0 +1,46 @@
+package com.toy.nar.app.riot;
+
+import com.toy.nar.domain.participant.entity.Champion;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.PlayerSoloRankGame;
+import com.toy.nar.domain.participant.repository.PlayerSoloRankGameRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * 추적 선수의 새 솔랭 게임을 이력 테이블에 적재한다.
+ *
+ * <p>모니터 폴링 트랜잭션과 분리({@code REQUIRES_NEW})하고 예외를 흡수해, 적재 실패가
+ * 폴링 흐름이나 알림 발송을 깨지 않도록 한다(피드 기록과 동일한 안전 원칙).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SoloRankGameHistoryRecorder {
+
+	private final PlayerSoloRankGameRepository repository;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void record(Player player, String gameId, Champion champion, LocalDateTime detectedAt) {
+		if (player == null || player.getId() == null || gameId == null || gameId.isBlank()) {
+			return;
+		}
+		try {
+			if (repository.existsByPlayer_IdAndGameId(player.getId(), gameId)) {
+				return;
+			}
+			repository.save(new PlayerSoloRankGame(player, gameId, champion, detectedAt));
+		} catch (DataIntegrityViolationException e) {
+			// 동시 폴링으로 인한 (player, gameId) 중복 — 무시.
+		} catch (Exception e) {
+			log.warn("Failed to record solo rank game history playerId={} gameId={}",
+					player.getId(), gameId, e);
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/domain/participant/entity/PlayerSoloRankGame.java
+++ b/src/main/java/com/toy/nar/domain/participant/entity/PlayerSoloRankGame.java
@@ -1,0 +1,64 @@
+package com.toy.nar.domain.participant.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 추적 선수가 시작한 솔로 랭크 게임 한 건의 이력.
+ *
+ * <p>라이브 모니터({@code PlayerSoloRankMonitorService})가 spectator(현재 게임) API로 새 솔랭
+ * 게임을 감지한 시점에 적재한다. 구독 여부와 무관하게 모든 추적 선수에 대해 쌓이며,
+ * 선수 카드의 "최근 솔랭 / 챔프 폭" 표시에 쓴다.
+ *
+ * <p>승패·KDA 등 결과는 spectator API에 없어 담지 않는다(추후 match-v5 연동 시 별도 확장).
+ */
+@Entity
+@Table(name = "player_solo_rank_game", uniqueConstraints = {
+		@UniqueConstraint(
+				name = "uk_player_solo_rank_game",
+				columnNames = {"player_id", "game_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlayerSoloRankGame {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "player_id", nullable = false)
+	private Player player;
+
+	@Column(name = "game_id", nullable = false, length = 64)
+	private String gameId;
+
+	/** 시작 시 픽한 챔피언. 해석 실패 시 null. */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "champion_id")
+	private Champion champion;
+
+	/** 모니터가 게임을 감지한 시각(실제 게임 시작 시각과 다소 차이 있을 수 있음). */
+	@Column(name = "detected_at", nullable = false)
+	private LocalDateTime detectedAt;
+
+	public PlayerSoloRankGame(Player player, String gameId, Champion champion, LocalDateTime detectedAt) {
+		this.player = player;
+		this.gameId = gameId;
+		this.champion = champion;
+		this.detectedAt = detectedAt;
+	}
+}

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerSoloRankGameRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerSoloRankGameRepository.java
@@ -1,0 +1,31 @@
+package com.toy.nar.domain.participant.repository;
+
+import com.toy.nar.domain.participant.entity.PlayerSoloRankGame;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PlayerSoloRankGameRepository extends JpaRepository<PlayerSoloRankGame, Long> {
+
+	boolean existsByPlayer_IdAndGameId(Long playerId, String gameId);
+
+	/** 선수의 최근 솔랭 게임(감지 최신순). 선수 카드 "최근 솔랭"용. */
+	List<PlayerSoloRankGame> findTop20ByPlayer_IdOrderByDetectedAtDesc(Long playerId);
+
+	/** 선수의 챔피언별 솔랭 플레이 횟수(많은 순). 선수 카드 "챔프 폭"용. */
+	@Query("SELECT g.champion.id AS championId, COUNT(g) AS playCount "
+			+ "FROM PlayerSoloRankGame g "
+			+ "WHERE g.player.id = :playerId AND g.champion IS NOT NULL "
+			+ "GROUP BY g.champion.id "
+			+ "ORDER BY COUNT(g) DESC")
+	List<ChampionPlayCount> findChampionPlayCounts(@Param("playerId") Long playerId);
+
+	/** 챔프 폭 집계 projection. */
+	interface ChampionPlayCount {
+		Long getChampionId();
+
+		long getPlayCount();
+	}
+}

--- a/src/main/resources/db/migration/V47__Create_player_solo_rank_game.sql
+++ b/src/main/resources/db/migration/V47__Create_player_solo_rank_game.sql
@@ -1,0 +1,16 @@
+-- 추적 선수의 솔로 랭크 게임 이력. 라이브 모니터가 새 솔랭 감지 시 1행 적재(구독 무관).
+-- 선수 카드 "최근 솔랭 / 챔프 폭"용. 승패·KDA 등 결과는 담지 않음(spectator API 한계).
+CREATE TABLE IF NOT EXISTS player_solo_rank_game (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    player_id   BIGINT       NOT NULL,
+    game_id     VARCHAR(64)  NOT NULL,
+    champion_id BIGINT       NULL,
+    detected_at DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_player_solo_rank_game UNIQUE (player_id, game_id),
+    INDEX idx_player_solo_rank_game_player_detected (player_id, detected_at),
+    CONSTRAINT fk_player_solo_rank_game_player
+        FOREIGN KEY (player_id) REFERENCES player (id) ON DELETE CASCADE,
+    CONSTRAINT fk_player_solo_rank_game_champion
+        FOREIGN KEY (champion_id) REFERENCES champion (id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/main/resources/db/migration/V47__Create_player_solo_rank_game.sql
+++ b/src/main/resources/db/migration/V47__Create_player_solo_rank_game.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS player_solo_rank_game (
     CONSTRAINT uk_player_solo_rank_game UNIQUE (player_id, game_id),
     INDEX idx_player_solo_rank_game_player_detected (player_id, detected_at),
     CONSTRAINT fk_player_solo_rank_game_player
-        FOREIGN KEY (player_id) REFERENCES player (id) ON DELETE CASCADE,
+        FOREIGN KEY (player_id) REFERENCES players (player_id) ON DELETE CASCADE,
     CONSTRAINT fk_player_solo_rank_game_champion
-        FOREIGN KEY (champion_id) REFERENCES champion (id)
+        FOREIGN KEY (champion_id) REFERENCES champions (champion_id)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;

--- a/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMonitorServiceTest.java
+++ b/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMonitorServiceTest.java
@@ -22,7 +22,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +50,9 @@ class PlayerSoloRankMonitorServiceTest {
 	@Mock
 	private SchedulerAlertService schedulerAlertService;
 
+	@Mock
+	private SoloRankGameHistoryRecorder soloRankGameHistoryRecorder;
+
 	private RiotMonitorProperties riotMonitorProperties;
 	private PlayerSoloRankMonitorService playerSoloRankMonitorService;
 
@@ -63,7 +68,8 @@ class PlayerSoloRankMonitorServiceTest {
 				riotMonitorProperties,
 				notificationService,
 				playerSoloRankPushService,
-				schedulerAlertService);
+				schedulerAlertService,
+				soloRankGameHistoryRecorder);
 	}
 
 	@Test
@@ -120,6 +126,7 @@ class PlayerSoloRankMonitorServiceTest {
 				"https://ddragon.leagueoflegends.com/cdn/15.13.1/img/champion/Yasuo.png",
 				"솔로 랭크",
 				"https://www.op.gg/summoners/kr/Hide+on+bush-KR1");
+		verify(soloRankGameHistoryRecorder).record(eq(player), eq("222"), any(), any());
 	}
 
 	@Test
@@ -322,5 +329,6 @@ class PlayerSoloRankMonitorServiceTest {
 				org.mockito.ArgumentMatchers.any(),
 				org.mockito.ArgumentMatchers.any(),
 				org.mockito.ArgumentMatchers.any());
+		verify(soloRankGameHistoryRecorder, never()).record(any(), anyString(), any(), any());
 	}
 }

--- a/src/test/java/com/toy/nar/app/riot/SoloRankGameHistoryRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/riot/SoloRankGameHistoryRecorderTest.java
@@ -1,0 +1,60 @@
+package com.toy.nar.app.riot;
+
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.PlayerSoloRankGame;
+import com.toy.nar.domain.participant.repository.PlayerSoloRankGameRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SoloRankGameHistoryRecorderTest {
+
+	@Mock
+	private PlayerSoloRankGameRepository repository;
+
+	@InjectMocks
+	private SoloRankGameHistoryRecorder recorder;
+
+	private Player player(Long id) {
+		Player player = Player.builder().name("Faker").build();
+		ReflectionTestUtils.setField(player, "id", id);
+		return player;
+	}
+
+	@Test
+	void savesNewGame() {
+		when(repository.existsByPlayer_IdAndGameId(7L, "222")).thenReturn(false);
+
+		recorder.record(player(7L), "222", null, LocalDateTime.now());
+
+		verify(repository).save(any(PlayerSoloRankGame.class));
+	}
+
+	@Test
+	void skipsDuplicate() {
+		when(repository.existsByPlayer_IdAndGameId(7L, "222")).thenReturn(true);
+
+		recorder.record(player(7L), "222", null, LocalDateTime.now());
+
+		verify(repository, never()).save(any());
+	}
+
+	@Test
+	void ignoresBlankInput() {
+		recorder.record(null, "222", null, LocalDateTime.now());
+		recorder.record(player(7L), "", null, LocalDateTime.now());
+
+		verify(repository, never()).save(any());
+	}
+}


### PR DESCRIPTION
선수 카드 "최근 솔랭 / 챔프 폭"을 위한 **데이터 적재 토대**. (A안 — 시작 기록만, 추가 API 0)

## 변경
- **엔티티** `PlayerSoloRankGame` + 마이그레이션 **V47**
  - `(player_id, game_id, champion_id, detected_at)`, `unique(player_id, game_id)`, `(player_id, detected_at)` 인덱스
- **`SoloRankGameHistoryRecorder`**: `REQUIRES_NEW` + 중복/예외 흡수 → 폴링·알림 흐름 안 깸
- **모니터 훅**: 새 게임 챔피언 해석을 분기 앞으로 hoist(추가 Riot 콜 없음), 솔랭 감지 시 적재. **구독 게이트 앞**에 둬 구독자 없어도 쌓임
- **Repository 읽기 쿼리**: 최근 N판 / 챔프별 플레이 횟수

## 비용·범위
- 폴링은 이미 **전체 추적계정** 대상 → **추가 Riot API 콜 0** (spectator 응답만 사용)
- 승패·KDA 등 결과는 미수집 (spectator API 한계 — 필요 시 match-v5 후속 PR)
- retention 잡 없음: 추적선수 × 게임수라 증가 완만, 읽기는 최근 N 제한. 볼륨 커지면 추가 (ponytail)
- **선수 카드 노출(DTO/엔드포인트/프론트)은 후속 PR** — 이 PR은 데이터부터 쌓기 시작

## 트렁크 안전성
신규 테이블 + 패시브 적재만. 신규 엔드포인트/사용자 동작 변화 없음. 모니터는 기존 `RIOT_MONITOR_ENABLED` 플래그 하에 동작.

## 검증
- `./gradlew test --tests PlayerSoloRankMonitorServiceTest --tests SoloRankGameHistoryRecorderTest` → BUILD SUCCESSFUL
- 모니터 적재 호출/미적재(다른 큐) + recorder 저장·중복·빈입력

🤖 Generated with [Claude Code](https://claude.com/claude-code)