### PR TITLE
feat: 라이브 데이터 MSI 추가 + 폴링 활성화 + 3개월 백필 런북

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
               -e YOUTUBE_API_KEY="${{ secrets.YOUTUBE_API_KEY }}" \
               -e LOL_ESPORTS_KEY="${{ secrets.LOL_ESPORTS_KEY }}" \
               -e LOL_SYNC_CRON="0 0/30 * * * *" \
-              -e LOL_ACTIVE_LEAGUES="LCK,MSI" \
+              -e LOL_ACTIVE_LEAGUES="${{ secrets.LOL_ACTIVE_LEAGUES }}" \
               -e LOL_LIVE_ENABLED="true" \
               -e LOL_TEAM_METADATA_CRON="0 15 4 * * *" \
               -e DISCORD_PLAYER_WEBHOOK_URL="${{ secrets.DISCORD_PLAYER_WEBHOOK_URL }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,8 @@ jobs:
               -e YOUTUBE_API_KEY="${{ secrets.YOUTUBE_API_KEY }}" \
               -e LOL_ESPORTS_KEY="${{ secrets.LOL_ESPORTS_KEY }}" \
               -e LOL_SYNC_CRON="0 0/30 * * * *" \
-              -e LOL_ACTIVE_LEAGUES="${{ secrets.LOL_ACTIVE_LEAGUES }}" \
+              -e LOL_ACTIVE_LEAGUES="LCK,MSI" \
+              -e LOL_LIVE_ENABLED="true" \
               -e LOL_TEAM_METADATA_CRON="0 15 4 * * *" \
               -e DISCORD_PLAYER_WEBHOOK_URL="${{ secrets.DISCORD_PLAYER_WEBHOOK_URL }}" \
               -e RIOT_API_KEY="${{ secrets.RIOT_API_KEY }}" \

--- a/scripts/backfill_live_3m.sh
+++ b/scripts/backfill_live_3m.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# 최근 3개월 LCK+MSI 라이브(분단위) 데이터 백필. EC2 호스트에서 실행.
+# 외부 livestats 피드는 ~3개월만 보존하므로 그 이상은 받아올 수 없다.
+#
+# 사전:
+#   - 앱이 localhost:8080 에서 떠 있고 LOL_LIVE_ENABLED=true 로 배포됨
+#   - mysql 클라이언트로 Oracle MySQL 접근 가능 (DB_* 환경변수)
+#   - 먼저 MSI 매치 메타/gameId 동기화: 아래 0단계
+#
+# ponytail: 배치 백필 엔드포인트 신설 대신 기존 per-game 엔드포인트 + SQL 루프.
+#           게임 수가 수천으로 늘면 그때 배치 API 추가.
+set -euo pipefail
+
+APP="${APP_URL:-http://localhost:8080}"
+: "${DB_HOST:?}" "${DB_PORT:=3306}" "${DB_USER:?}" "${DB_PASSWORD:?}" "${DB_NAME:?}"
+SLEEP="${SLEEP_BETWEEN:-3}"   # 게임 간 대기(초). 외부 API 부하 방지.
+
+mysql_q() { mysql -h"$DB_HOST" -P"$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" -N -B -e "$1"; }
+
+# 0단계(수동, 1회): MSI 매치/gameId 동기화 — 안 돼 있으면 백필할 gameId가 없다.
+#   curl -fsS -X POST "$APP/api/admin/data/sync/matches/recent-backfill?league=MSI&includeTeamMetadata=true"
+#   curl -fsS -X POST "$APP/api/admin/data/sync/matches/recent-backfill?league=LCK&includeTeamMetadata=true"
+# 3개월이 1페이지에 안 들어오면(과거 더 필요) 전체 히스토리:
+#   curl -fsS -X POST "$APP/api/admin/data/sync/matches/history"
+
+# 최신순, 최근 3개월, 아직 스냅샷 없는 gameId만.
+SQL="SELECT g.game_id
+     FROM league_match_game g JOIN league_match m ON m.id = g.match_id
+     WHERE m.league_name IN ('LCK','MSI')
+       AND m.match_date >= DATE_SUB(NOW(), INTERVAL 3 MONTH)
+       AND g.game_id NOT IN (SELECT game_id FROM live_game_minute_snapshot)
+     ORDER BY m.match_date DESC"
+
+mapfile -t GAME_IDS < <(mysql_q "$SQL")
+echo "백필 대상 게임: ${#GAME_IDS[@]}개"
+
+ok=0; empty=0; fail=0
+for gid in "${GAME_IDS[@]}"; do
+  [ -z "$gid" ] && continue
+  resp=$(curl -fsS -X POST "$APP/api/live/games/$gid/backfill" || echo '{"snapshotsWritten":-1}')
+  written=$(echo "$resp" | grep -o '"snapshotsWritten":[0-9-]*' | cut -d: -f2)
+  case "${written:-}" in
+    -1|"") fail=$((fail+1)); echo "FAIL  $gid";;
+    0)     empty=$((empty+1)); echo "EMPTY $gid (피드 보존기간 초과 가능)";;
+    *)     ok=$((ok+1)); echo "OK    $gid  +${written} snapshots";;
+  esac
+  sleep "$SLEEP"
+done
+
+echo "완료: ok=$ok empty=$empty fail=$fail"

--- a/scripts/backfill_live_3m.sh
+++ b/scripts/backfill_live_3m.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# 최근 3개월 LCK+MSI 라이브(분단위) 데이터 백필. EC2 호스트에서 실행.
+# 최근 3개월 LCK 라이브(분단위) 데이터 백필. EC2 호스트에서 실행.
+# (MSI는 내일 시작이라 과거 백필 대상 없음 — 폴링으로 실시간 수집됨)
 # 외부 livestats 피드는 ~3개월만 보존하므로 그 이상은 받아올 수 없다.
 #
 # 사전:
@@ -17,8 +18,7 @@ SLEEP="${SLEEP_BETWEEN:-3}"   # 게임 간 대기(초). 외부 API 부하 방지
 
 mysql_q() { mysql -h"$DB_HOST" -P"$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" -N -B -e "$1"; }
 
-# 0단계(수동, 1회): MSI 매치/gameId 동기화 — 안 돼 있으면 백필할 gameId가 없다.
-#   curl -fsS -X POST "$APP/api/admin/data/sync/matches/recent-backfill?league=MSI&includeTeamMetadata=true"
+# 0단계(수동, 1회): LCK 매치/gameId 동기화 — 안 돼 있으면 백필할 gameId가 없다.
 #   curl -fsS -X POST "$APP/api/admin/data/sync/matches/recent-backfill?league=LCK&includeTeamMetadata=true"
 # 3개월이 1페이지에 안 들어오면(과거 더 필요) 전체 히스토리:
 #   curl -fsS -X POST "$APP/api/admin/data/sync/matches/history"
@@ -26,7 +26,7 @@ mysql_q() { mysql -h"$DB_HOST" -P"$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" "$DB_N
 # 최신순, 최근 3개월, 아직 스냅샷 없는 gameId만.
 SQL="SELECT g.game_id
      FROM league_match_game g JOIN league_match m ON m.id = g.match_id
-     WHERE m.league_name IN ('LCK','MSI')
+     WHERE m.league_name = 'LCK'
        AND m.match_date >= DATE_SUB(NOW(), INTERVAL 3 MONTH)
        AND g.game_id NOT IN (SELECT game_id FROM live_game_minute_snapshot)
      ORDER BY m.match_date DESC"


### PR DESCRIPTION
## 배경
배포환경에서 라이브 데이터가 사실상 LCK만 수집됨. MSI 추가 + 최근 3개월 백필 요청.

## 변경
**deploy.yml**
- `LOL_ACTIVE_LEAGUES="LCK,MSI"` — 기존 `${{ secrets.LOL_ACTIVE_LEAGUES }}`(값 LCK 추정) 대신 명시. 매치/스케줄 동기화 대상에 MSI 포함 → 백필할 gameId 확보.
- `LOL_LIVE_ENABLED="true"` — 기존 deploy.yml에 없어 `lolesports.live.enabled` 기본값 false로 **라이브 폴링 자체가 OFF**였음. 켜야 실시간 수집됨.
- 라이브 디스커버리(`LivePollingScheduler`)는 이미 `LeagueConstants.TARGET_LEAGUES`(MSI 포함)를 순회 → 코드 변경 불필요, 폴링만 켜면 MSI 자동 수집.

**scripts/backfill_live_3m.sh**
- 최근 3개월 LCK+MSI 분단위 라이브 백필 런북(EC2 호스트 실행).
- 기존 per-game 엔드포인트 + SQL 루프. 배치 API 신설 안 함(YAGNI).

## 주의
- 디스코드/FCM 라이브 알림은 별도 플래그(`notification.enabled`/`fcm.enabled`)로 여전히 OFF — 이번 변경은 **수집만**.
- 머지 시 운영 배포 트리거됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)