### PR TITLE
feat: 챔피언 세로 이미지를 CommunityDragon 고화질 splash로 통일

### DIFF
--- a/src/main/java/com/toy/nar/api/v1/ChampionController.java
+++ b/src/main/java/com/toy/nar/api/v1/ChampionController.java
@@ -98,12 +98,4 @@ public class ChampionController {
 		return ResponseEntity.ok("Champion loading image updated successfully.");
 	}
 
-	@Operation(summary = "전체 챔피언 로딩 이미지 URL 일괄 업데이트", description = "모든 챔피언의 loading 이미지 URL을 자동 생성해 저장합니다.")
-	@PostMapping("/loading-image/all")
-	public ResponseEntity<String> updateAllChampionLoadingImages(
-			@RequestParam(defaultValue = "false") boolean overwrite) {
-		int updatedCount = championService.updateAllChampionLoadingImages(overwrite);
-		return ResponseEntity.ok("Champion loading images updated: " + updatedCount);
-	}
-
 }

--- a/src/main/java/com/toy/nar/app/analysis/service/PlayerCardService.java
+++ b/src/main/java/com/toy/nar/app/analysis/service/PlayerCardService.java
@@ -27,7 +27,6 @@ public class PlayerCardService {
 
 	private static final int MOST_CHAMPION_LIMIT = 3;
 	private static final int MAX_PAGE_SIZE = 100;
-	private static final String DDRAGON_LOADING_URL_FORMAT = "https://ddragon.leagueoflegends.com/cdn/img/champion/loading/%s_0.jpg";
 
 	private final GameParticipantRepository gameParticipantRepository;
 	private final ObjectMapper objectMapper;
@@ -106,7 +105,7 @@ public class PlayerCardService {
 					.championNameKr(toString(row[2]))
 					.championNameEn(toString(row[3]))
 					.championImageUrl(championImageUrl)
-					.championLoadingImageUrl(buildChampionLoadingImageUrl(championImageUrl, toString(row[3])))
+					.championLoadingImageUrl(toString(row[7]))
 					.playCount(playCount)
 					.winRatePct(round(winRatePct, 1))
 					.build());
@@ -227,34 +226,6 @@ public class PlayerCardService {
 	private double round(double value, int scale) {
 		double factor = Math.pow(10, scale);
 		return Math.round(value * factor) / factor;
-	}
-
-	private String buildChampionLoadingImageUrl(String championImageUrl, String championNameEn) {
-		String championKey = extractChampionKeyFromImageUrl(championImageUrl);
-		if (championKey == null || championKey.isBlank()) {
-			championKey = normalizeChampionKey(championNameEn);
-		}
-		if (championKey == null || championKey.isBlank()) {
-			return null;
-		}
-		return String.format(DDRAGON_LOADING_URL_FORMAT, championKey);
-	}
-
-	private String extractChampionKeyFromImageUrl(String championImageUrl) {
-		if (championImageUrl == null || championImageUrl.isBlank()) {
-			return null;
-		}
-		int slashIdx = championImageUrl.lastIndexOf('/');
-		String fileName = slashIdx >= 0 ? championImageUrl.substring(slashIdx + 1) : championImageUrl;
-		int dotIdx = fileName.lastIndexOf('.');
-		return dotIdx > 0 ? fileName.substring(0, dotIdx) : fileName;
-	}
-
-	private String normalizeChampionKey(String championNameEn) {
-		if (championNameEn == null || championNameEn.isBlank()) {
-			return null;
-		}
-		return championNameEn.replaceAll("[^A-Za-z0-9]", "");
 	}
 
 	private record GameAccount(String summonerName, String soloRankTier) {

--- a/src/main/java/com/toy/nar/app/data/source/ChampionDataService.java
+++ b/src/main/java/com/toy/nar/app/data/source/ChampionDataService.java
@@ -30,6 +30,15 @@ public class ChampionDataService {
 
 	private static final String VERSION_URL = "https://ddragon.leagueoflegends.com/api/versions.json";
 	private static final String BASE_URL = "https://ddragon.leagueoflegends.com/cdn/";
+	private static final String SPLASH_URL_FORMAT = "https://cdn.communitydragon.org/latest/champion/%s/splash-art/centered";
+
+	/** numeric Riot key("266") → CommunityDragon centered splash(고화질 세로 크롭용). key 없으면 null. */
+	private static String buildSplashImageUrl(String riotKey) {
+		if (riotKey == null || riotKey.isBlank()) {
+			return null;
+		}
+		return String.format(SPLASH_URL_FORMAT, riotKey.trim());
+	}
 
 	private volatile Map<Integer, String> championNameByRiotKey = Collections.emptyMap();
 
@@ -108,17 +117,29 @@ public class ChampionDataService {
 			String normalizedName = NameNormalizer.normalizeChampionName(enChampionData.id());
 			String championKrName = krResponse.data().get(enChampionData.id()).name();
 			String imageUrl = versionedBaseUrl + "/img/champion/" + enChampionData.image().full();
+			// 세로 로딩 이미지는 CommunityDragon centered splash(고화질, numeric Riot key 사용)로 통일.
+			String loadingImageUrl = buildSplashImageUrl(enChampionData.key());
 
 			if (existingChampionNames.contains(normalizedName)) {
 				// 기존 챔피언이 있는 경우 이미지 URL 업데이트 확인
 				Champion existingChampion = championRepository.findByChampionNameEn(normalizedName)
 					.orElse(null);
+				if (existingChampion == null) {
+					continue;
+				}
 
-				if (existingChampion != null && !imageUrl.equals(existingChampion.getImageUrl())) {
+				boolean dirty = false;
+				if (!imageUrl.equals(existingChampion.getImageUrl())) {
 					log.info("🔄 Updating image URL for champion: {} (old: {}, new: {})",
 						normalizedName, existingChampion.getImageUrl(), imageUrl);
-
 					existingChampion.updateImageUrl(imageUrl);
+					dirty = true;
+				}
+				if (loadingImageUrl != null && !loadingImageUrl.equals(existingChampion.getLoadingImageUrl())) {
+					existingChampion.updateLoadingImageUrl(loadingImageUrl);
+					dirty = true;
+				}
+				if (dirty) {
 					championsToUpdate.add(existingChampion);
 				}
 			} else {
@@ -129,6 +150,7 @@ public class ChampionDataService {
 					.championNameEn(normalizedName)
 					.championNameKr(championKrName)
 					.imageUrl(imageUrl)
+					.loadingImageUrl(loadingImageUrl)
 					.build());
 			}
 		}

--- a/src/main/java/com/toy/nar/app/participant/service/ChampionService.java
+++ b/src/main/java/com/toy/nar/app/participant/service/ChampionService.java
@@ -18,8 +18,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class ChampionService {
 
-	private static final String DDRAGON_LOADING_URL_FORMAT = "https://ddragon.leagueoflegends.com/cdn/img/champion/loading/%s_0.jpg";
-
 	private final ChampionRepository championRepository;
 
 	public List<ChampionDto> getAllChampions() {
@@ -53,31 +51,6 @@ public class ChampionService {
 		champion.updateLoadingImageUrl(imageUrl);
 	}
 
-	@Transactional
-	public int updateAllChampionLoadingImages(boolean overwrite) {
-		List<Champion> champions = championRepository.findAll();
-		int updatedCount = 0;
-
-		for (Champion champion : champions) {
-			if (!overwrite && hasText(champion.getLoadingImageUrl())) {
-				continue;
-			}
-
-			String loadingImageUrl = buildLoadingImageUrl(champion);
-			if (!hasText(loadingImageUrl)) {
-				continue;
-			}
-			if (loadingImageUrl.equals(champion.getLoadingImageUrl())) {
-				continue;
-			}
-
-			champion.updateLoadingImageUrl(loadingImageUrl);
-			updatedCount++;
-		}
-
-		return updatedCount;
-	}
-
 	private ChampionDto convertToDto(Champion champion) {
 		return new ChampionDto(
 			champion.getId(),
@@ -86,40 +59,6 @@ public class ChampionService {
 			champion.getImageUrl(),
 			champion.getLoadingImageUrl()
 		);
-	}
-
-	private String buildLoadingImageUrl(Champion champion) {
-		String championKey = extractChampionKeyFromImageUrl(champion.getImageUrl());
-		if (!hasText(championKey)) {
-			championKey = normalizeChampionKey(champion.getChampionNameEn());
-		}
-		if (!hasText(championKey)) {
-			return null;
-		}
-		return String.format(DDRAGON_LOADING_URL_FORMAT, championKey);
-	}
-
-	private String extractChampionKeyFromImageUrl(String championImageUrl) {
-		if (!hasText(championImageUrl)) {
-			return null;
-		}
-		int slashIdx = championImageUrl.lastIndexOf('/');
-		String fileName = slashIdx >= 0 ? championImageUrl.substring(slashIdx + 1) : championImageUrl;
-		int dotIdx = fileName.lastIndexOf('.');
-		return dotIdx > 0 ? fileName.substring(0, dotIdx) : fileName;
-	}
-
-	private String normalizeChampionKey(String championNameEn) {
-		if (!hasText(championNameEn)) {
-			return null;
-		}
-		return championNameEn
-				.trim()
-				.replaceAll("[^A-Za-z0-9]", "");
-	}
-
-	private boolean hasText(String value) {
-		return value != null && !value.isBlank();
 	}
 
 	private String safe(String value) {

--- a/src/main/java/com/toy/nar/domain/game/repository/GameParticipantRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/GameParticipantRepository.java
@@ -482,7 +482,8 @@ public interface GameParticipantRepository
 				c.champion_name_en,
 				c.image_url,
 				COUNT(*) AS games_played,
-				SUM(CASE WHEN gp.is_win = 1 THEN 1 ELSE 0 END) AS wins
+				SUM(CASE WHEN gp.is_win = 1 THEN 1 ELSE 0 END) AS wins,
+				c.loading_image_url
 			FROM game_participants gp
 			JOIN champions c ON c.champion_id = gp.champion_id
 			JOIN games g ON g.game_id = gp.game_id
@@ -493,7 +494,7 @@ public interface GameParticipantRepository
 			  AND (:split IS NULL OR l.season_split = :split)
 			  AND (:patch IS NULL OR g.patch = :patch)
 			  AND (:side IS NULL OR UPPER(gp.side) = :side)
-			GROUP BY gp.player_id, c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url
+			GROUP BY gp.player_id, c.champion_id, c.champion_name_kr, c.champion_name_en, c.image_url, c.loading_image_url
 			ORDER BY gp.player_id, games_played DESC, wins DESC, c.champion_name_en
 			""", nativeQuery = true)
 	List<Object[]> findPlayerMostChampionsByFilter(

--- a/src/test/java/com/toy/nar/app/analysis/service/PlayerCardServiceTest.java
+++ b/src/test/java/com/toy/nar/app/analysis/service/PlayerCardServiceTest.java
@@ -48,11 +48,16 @@ class PlayerCardServiceTest {
 		when(gameParticipantRepository.findPlayerMostChampionsByFilter(
 				List.of(1L, 2L), "LCK", 2026, "Round 3-5", "14.1", null))
 				.thenReturn(List.of(
-						new Object[] { 1L, 101L, "아리", "Ahri", "ahri.png", 10L, 7L },
-						new Object[] { 1L, 102L, "아지르", "Azir", "azir.png", 9L, 6L },
-						new Object[] { 1L, 103L, "요네", "Yone", "yone.png", 8L, 5L },
-						new Object[] { 1L, 104L, "탈리야", "Taliyah", "taliyah.png", 4L, 3L },
-						new Object[] { 2L, 201L, "레나타", "Renata", "renata.png", 12L, 8L }));
+						new Object[] { 1L, 101L, "아리", "Ahri", "ahri.png", 10L, 7L,
+								"https://cdn.communitydragon.org/latest/champion/103/splash-art/centered" },
+						new Object[] { 1L, 102L, "아지르", "Azir", "azir.png", 9L, 6L,
+								"https://cdn.communitydragon.org/latest/champion/268/splash-art/centered" },
+						new Object[] { 1L, 103L, "요네", "Yone", "yone.png", 8L, 5L,
+								"https://cdn.communitydragon.org/latest/champion/777/splash-art/centered" },
+						new Object[] { 1L, 104L, "탈리야", "Taliyah", "taliyah.png", 4L, 3L,
+								"https://cdn.communitydragon.org/latest/champion/163/splash-art/centered" },
+						new Object[] { 2L, 201L, "레나타", "Renata", "renata.png", 12L, 8L,
+								"https://cdn.communitydragon.org/latest/champion/888/splash-art/centered" }));
 
 		PlayerCardListResponse response = playerCardService.getPlayerCards(
 				"LCK", 2026, "Round 3-5", "14.1", "ALL", 1, 20);
@@ -70,9 +75,9 @@ class PlayerCardServiceTest {
 		assertThat(response.getPlayers().get(0).getMostChampions()).hasSize(3);
 		assertThat(response.getPlayers().get(0).getMostChampions().get(0).getWinRatePct()).isEqualTo(70.0);
 		assertThat(response.getPlayers().get(0).getMostChampions().get(0).getChampionLoadingImageUrl())
-				.isEqualTo("https://ddragon.leagueoflegends.com/cdn/img/champion/loading/ahri_0.jpg");
+				.isEqualTo("https://cdn.communitydragon.org/latest/champion/103/splash-art/centered");
 		assertThat(response.getPlayers().get(0).getTopChampionLoadingImageUrl())
-				.isEqualTo("https://ddragon.leagueoflegends.com/cdn/img/champion/loading/ahri_0.jpg");
+				.isEqualTo("https://cdn.communitydragon.org/latest/champion/103/splash-art/centered");
 		assertThat(response.getPlayers().get(0).getProfile().getKda()).isEqualTo(8.25);
 		assertThat(response.getPlayers().get(0).getProfile().getGpm()).isEqualTo(441.7);
 		assertThat(response.getPlayers().get(0).getProfile().getDpm()).isEqualTo(958.2);


### PR DESCRIPTION
## 배경
경기 상세의 세로 챔피언 이미지가 ddragon loading(원본 308×560)을 확대해 표시하면서 화질이 저하됐다. 또한 같은 로딩 URL이 **두 곳에서 따로 생성**되고 있었다.
- DB `champions.loading_image_url` 컬럼 → `GET /api/champions`(경기 상세 소스)
- `PlayerCardService`가 square image_url에서 즉석 조립 → 선수 카드

## 변경
- **단일 진실 원천 통합**: 로딩 URL을 DB 컬럼으로 일원화. PlayerCard는 더 이상 조립하지 않고 컬럼을 읽는다.
- **고화질 소스**: ddragon loading → CommunityDragon centered splash.
  `https://cdn.communitydragon.org/latest/champion/{riotKey}/splash-art/centered` (1280×720, 인물 중앙 정렬)
- numeric Riot key는 `ChampionDataService`가 ddragon champion.json에서 이미 파싱 중 → 동기화 시점에 세팅(유일 write 경로).

| 파일 | 변경 |
|---|---|
| `ChampionDataService` | 동기화 시 CommunityDragon URL을 신규·기존 챔피언에 세팅 |
| `GameParticipantRepository` | 모스트 챔피언 쿼리에 `c.loading_image_url` 추가 |
| `PlayerCardService` | 즉석 조립 제거, 컬럼 직접 사용 |
| `ChampionService` | 죽은 ddragon 빌더/일괄 메서드 제거 |
| `ChampionController` | obsolete `/loading-image/all` 제거 |

순변경 -70줄.

## 프론트 영향: 없음
경기 상세(`game-header.tsx`)·선수 카드(`player-card.tsx`) 모두 세로 컨테이너에 `fill` + `object-cover`로 이미 렌더 중. object-cover는 가로 splash를 찌그러뜨리지 않고 중앙 크롭하므로 centered splash가 그대로 들어맞는다. 제거한 `/loading-image/all`은 프론트에서 호출하지 않는다(generated 타입만 존재, 재생성 대상).

## 배포 후
`loading_image_url` 컬럼은 V16에 이미 존재 → **마이그레이션 불필요**. 배포 후 `POST /api/champions/sync` **1회**로 기존 행이 CommunityDragon URL로 백필된다. (현재 DB 행은 ddragon 값이며, 이 PR이 배포돼야 sync가 새 URL을 기록한다.)

## 검증
- `PlayerCardServiceTest` 갱신(컬럼 passthrough) — 통과, CI green
- 변경된 native 쿼리를 prod DB에서 직접 실행해 SQL·컬럼 반환 확인
- `compileJava`/`compileTestJava` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)