### PR TITLE
fix: 모바일 챔피언 픽 카드에 고화질 로딩 이미지 사용

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/match/MobileLiveGameService.java
+++ b/src/main/java/com/toy/nar/app/mobile/match/MobileLiveGameService.java
@@ -173,7 +173,7 @@ public class MobileLiveGameService {
 				.map(p -> new LiveGameChampionsResponse.Pick(
 						canonicalPosition(p.role()),
 						p.championName(),
-						resolveChampionImageUrl(p.championName()),
+						resolveChampionLoadingImageUrl(p.championName()),
 						p.playerName()))
 				.toList();
 		// 밴은 reconcile 된 배치 데이터에서 채운다(라이브 피드엔 밴이 없음). 없으면 빈 목록.
@@ -232,7 +232,7 @@ public class MobileLiveGameService {
 		};
 	}
 
-	/** 영문 챔피언명으로 이미지 URL 을 조회한다. 매핑이 없으면 null (Flutter 가 Data Dragon 으로 폴백). */
+	/** 영문 챔피언명으로 정사각 아이콘 URL 을 조회한다. 작은 아이콘(킬 피드 등)용. 매핑 없으면 null (Flutter 가 Data Dragon 폴백). */
 	private String resolveChampionImageUrl(String championName) {
 		if (championName == null || championName.isBlank()) {
 			return null;
@@ -240,6 +240,22 @@ public class MobileLiveGameService {
 		String normalized = NameNormalizer.normalizeChampionName(championName);
 		return championRepository.findByChampionNameEn(normalized)
 				.map(Champion::getImageUrl)
+				.orElse(null);
+	}
+
+	/**
+	 * 챔피언 픽 카드(세로)용 고화질 로딩 이미지 URL. loading_image_url(CommunityDragon centered splash)이
+	 * 비면 정사각 아이콘으로 폴백한다. 정사각을 세로로 늘리면 화질이 저하되므로 픽에는 이쪽을 쓴다.
+	 */
+	private String resolveChampionLoadingImageUrl(String championName) {
+		if (championName == null || championName.isBlank()) {
+			return null;
+		}
+		String normalized = NameNormalizer.normalizeChampionName(championName);
+		return championRepository.findByChampionNameEn(normalized)
+				.map(c -> c.getLoadingImageUrl() != null && !c.getLoadingImageUrl().isBlank()
+						? c.getLoadingImageUrl()
+						: c.getImageUrl())
 				.orElse(null);
 	}
 

--- a/src/test/java/com/toy/nar/app/mobile/match/MobileLiveGameServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/match/MobileLiveGameServiceTest.java
@@ -6,9 +6,11 @@ import com.toy.nar.app.lolesports.live.entity.LiveGameMapping;
 import com.toy.nar.app.lolesports.live.repository.LiveGameMappingRepository;
 import com.toy.nar.app.lolesports.live.repository.LiveGameMinuteSnapshotRepository;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
 import com.toy.nar.app.mobile.match.dto.LiveBanRow;
 import com.toy.nar.app.mobile.match.dto.LiveGameChampionsResponse;
 import com.toy.nar.domain.game.repository.BanRepository;
+import com.toy.nar.domain.participant.entity.Champion;
 import com.toy.nar.domain.participant.repository.ChampionRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
 import org.junit.jupiter.api.Test;
@@ -90,6 +92,41 @@ class MobileLiveGameServiceTest {
 		assertThat(response.redTeam().bans())
 				.extracting(LiveGameChampionsResponse.Ban::championName)
 				.containsExactly("Yasuo");
+	}
+
+	private LiveParticipantState pick(String side, String role, String championName, String playerName) {
+		return new LiveParticipantState(
+				1, side, role, playerName, null, championName,
+				null, null, null, null, null, null, null, null,
+				List.of(), List.of(), List.of(), null, null, null, List.of());
+	}
+
+	@Test
+	void getChampions_픽은_고화질_로딩이미지를_쓰고_없으면_정사각으로_폴백한다() {
+		LiveGameState state = new LiveGameState("LIVE_G", "M1", "LCK", "T1", "Gen.G", null, null,
+				List.of(pick("BLUE", "top", "Renekton", "Kiin"),
+						pick("RED", "mid", "Azir", "Chovy")),
+				List.of());
+		when(liveStateQueryService.getLatestState("LIVE_G")).thenReturn(Optional.of(state));
+		when(liveGameMappingRepository.findByLiveGameId("LIVE_G")).thenReturn(Optional.empty());
+
+		// loading_image_url 있는 챔피언 → 고화질 splash 사용
+		when(championRepository.findByChampionNameEn("Renekton")).thenReturn(Optional.of(Champion.builder()
+				.championNameKr("레넥톤").championNameEn("Renekton")
+				.imageUrl("sq/renekton.png")
+				.loadingImageUrl("https://cdn.communitydragon.org/latest/champion/58/splash-art/centered")
+				.build()));
+		// loading_image_url 없는 챔피언 → 정사각 아이콘으로 폴백
+		when(championRepository.findByChampionNameEn("Azir")).thenReturn(Optional.of(Champion.builder()
+				.championNameKr("아지르").championNameEn("Azir")
+				.imageUrl("sq/azir.png")
+				.build()));
+
+		LiveGameChampionsResponse response = service.getChampions("LIVE_G");
+
+		assertThat(response.blueTeam().picks().get(0).championImageUrl())
+				.isEqualTo("https://cdn.communitydragon.org/latest/champion/58/splash-art/centered");
+		assertThat(response.redTeam().picks().get(0).championImageUrl()).isEqualTo("sq/azir.png");
 	}
 
 	@Test


### PR DESCRIPTION
## 배경
모바일 앱 **챔피언 픽** 탭의 세로 카드가 흐리게 보였다. 원인: `MobileLiveGameService.resolveChampionImageUrl`이 정사각 아이콘(`image_url`, 120×120)을 반환했고, 픽 카드가 이를 세로로 늘려 표시 → 업스케일로 화질 저하.

## 변경
- 픽 카드 전용 `resolveChampionLoadingImageUrl` 추가: `loading_image_url`(CommunityDragon centered splash, 고화질) 반환, 비면 정사각으로 폴백.
- 킬 피드 등 작은 아이콘은 기존 정사각 resolver 유지(splash로 늘리면 부적합).

`loading_image_url` 백필은 선행 PR [#219](https://github.com/NAR-GG/nar-back-repo/pull/219)에서 완료(173/173 CommunityDragon).

## 앱 영향
앱은 `championImageUrl`을 그대로 세로 카드에 렌더(`object-fit:cover` 격)하므로 **앱 빌드 불필요**. 배포 후 챔피언 픽 화면 재진입 시 고화질로 표시된다.

## 검증
- `MobileLiveGameServiceTest`에 픽=고화질 사용 + loading 없으면 정사각 폴백 케이스 추가 — 통과
- 전체 컴파일 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)