### PR TITLE
feat: 라이브 경기 중에도 선수 평점 허용

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -74,7 +74,7 @@ public class MobileLivePlayerRatingService {
 
 		return new LivePlayerRatingListResponse(
 				gameId,
-				isRateable(gameId),
+				true,
 				buildTeamSummaries(state, aggregates),
 				summaries);
 	}
@@ -111,7 +111,7 @@ public class MobileLivePlayerRatingService {
 
 		return new LivePlayerRatingDetailResponse(
 				gameId,
-				isRateable(gameId),
+				true,
 				new LivePlayerRatingDetailResponse.PlayerHeader(
 						participant.participantId(),
 						player != null ? player.getId() : null,
@@ -143,9 +143,7 @@ public class MobileLivePlayerRatingService {
 		if (memberId == null) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
 		}
-		if (!isRateable(gameId)) {
-			throw new ResponseStatusException(HttpStatus.CONFLICT, "세트 종료 후 평가할 수 있습니다.");
-		}
+		// 라이브 경기 중에도 평가 허용(세트 종료 제한 해제). 평가는 라이브 상태가 존재하면 언제든 가능.
 		LiveGameState state = requireState(gameId);
 		LiveParticipantState participant = requireParticipant(state, participantId);
 		Member member = memberRepository.findById(memberId)
@@ -219,24 +217,6 @@ public class MobileLivePlayerRatingService {
 				.filter(participant -> participant.participantId().equals(participantId))
 				.findFirst()
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "선수 정보를 찾을 수 없습니다."));
-	}
-
-	private boolean isRateable(String gameId) {
-		Optional<LeagueMatchGame> matchGame = leagueMatchGameRepository.findWithMatchByGameId(gameId);
-		if (matchGame.isEmpty()) {
-			return false;
-		}
-		LeagueMatchGame game = matchGame.get();
-		if ("completed".equalsIgnoreCase(game.getLeagueMatch().getState())) {
-			return true;
-		}
-		Integer gameOrder = game.getGameOrder();
-		Integer blueScore = game.getLeagueMatch().getBlueScore();
-		Integer redScore = game.getLeagueMatch().getRedScore();
-		return gameOrder != null
-				&& blueScore != null
-				&& redScore != null
-				&& blueScore + redScore >= gameOrder;
 	}
 
 	private Map<Integer, Player> resolvePlayers(List<LiveParticipantState> participants) {

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -60,27 +60,9 @@ class MobileLivePlayerRatingServiceTest {
 	}
 
 	@Test
-	void cannotRateBeforeSetEnds() {
-		when(leagueMatchGameRepository.findWithMatchByGameId("game-1"))
-				.thenReturn(Optional.of(matchGame("inProgress", 0, 0, 1)));
-
-		assertThatThrownBy(() -> service.save(
-				"game-1",
-				1,
-				7L,
-				new LivePlayerRatingRequest(5, "좋은 경기")))
-				.isInstanceOf(ResponseStatusException.class)
-				.hasMessageContaining("409 CONFLICT");
-
-		verify(ratingRepository, never()).save(any());
-	}
-
-	@Test
-	void createsRatingAfterSetEnds() {
+	void 라이브_경기_중에도_평가를_저장한다() {
 		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		Player player = Player.builder().name("Faker").imageUrl("faker.png").build();
-		when(leagueMatchGameRepository.findWithMatchByGameId("game-1"))
-				.thenReturn(Optional.of(matchGame("inProgress", 1, 0, 1)));
 		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
 		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.of(player));
@@ -109,8 +91,6 @@ class MobileLivePlayerRatingServiceTest {
 		when(aggregate.getRatingCount()).thenReturn(2L);
 		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
 		when(ratingRepository.aggregateByGameId("game-1")).thenReturn(List.of(aggregate));
-		when(leagueMatchGameRepository.findWithMatchByGameId("game-1"))
-				.thenReturn(Optional.of(matchGame("completed", 2, 1, 1)));
 		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.empty());
 		when(playerRepository.findByName("Faker")).thenReturn(Optional.empty());
 
@@ -146,8 +126,6 @@ class MobileLivePlayerRatingServiceTest {
 		when(ratingRepository.distribution("game-1", 1)).thenReturn(List.of(fiveStars, fourStars));
 		when(ratingRepository.findByLiveGameIdAndLiveParticipantIdAndMember_Id("game-1", 1, 7L))
 				.thenReturn(Optional.of(rating));
-		when(leagueMatchGameRepository.findWithMatchByGameId("game-1"))
-				.thenReturn(Optional.of(matchGame("completed", 2, 1, 1)));
 
 		LivePlayerRatingDetailResponse response = service.getDetail("game-1", 1, 7L, 0, 20);
 
@@ -177,8 +155,6 @@ class MobileLivePlayerRatingServiceTest {
 	void updatesExistingRatingAndDeletesIt() {
 		Member member = member(7L, "용맹한바론");
 		LivePlayerRating existing = rating(member, 3, "무난했습니다");
-		when(leagueMatchGameRepository.findWithMatchByGameId("game-1"))
-				.thenReturn(Optional.of(matchGame("completed", 2, 1, 1)));
 		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
 		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.empty());
@@ -316,16 +292,5 @@ class MobileLivePlayerRatingServiceTest {
 						null,
 						List.of())),
 				List.of());
-	}
-
-	private LeagueMatchGame matchGame(String state, int blueScore, int redScore, int gameOrder) {
-		LeagueMatch match = LeagueMatch.builder()
-				.id("match-1")
-				.leagueName("LCK")
-				.state(state)
-				.blueScore(blueScore)
-				.redScore(redScore)
-				.build();
-		return new LeagueMatchGame(match, "game-1", gameOrder);
 	}
 }


### PR DESCRIPTION
## 배경
선수 평점이 **세트 종료 후에만** 가능했다. `isRateable(gameId)`가 매치 completed 또는 세트 스코어 반영 시에만 true라, 라이브 진행 중에는:
- `save()`가 409 CONFLICT로 막힘
- 응답 `rateable=false` → 앱 '평점 남기기' 버튼 비활성

## 변경
라이브 진행 중에도 평가 허용:
- `getRatings`/`getDetail` 응답 `rateable` 항상 `true`
- `save()`의 세트 종료 가드 제거 (라이브 상태 존재 시 평가 가능)
- 미사용된 `isRateable()` 제거 (`leagueMatchGameRepository`는 내 평가 목록의 매치 정보 조회에 계속 사용 → 유지)

## 검증
- `MobileLivePlayerRatingServiceTest`: 게이트 테스트를 라이브 중 저장 케이스로 대체, 전체 통과
- 앱은 `d.rateable` 그대로 사용 → 배포 후 버튼 자동 활성, 앱 변경 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)