### PR TITLE
feat: 내 평가 목록에 작성자 프로필·응원팀 이미지 추가

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -322,6 +322,8 @@ public class MobileLivePlayerRatingService {
 
 	private MyRatingListResponse.MyRatingItem toMyRatingItem(LivePlayerRating rating, LeagueMatchGame matchGame) {
 		Player player = rating.getPlayer();
+		Member member = rating.getMember();
+		Team favoriteTeam = member != null ? member.getFavoriteTeam() : null;
 		return new MyRatingListResponse.MyRatingItem(
 				rating.getId(),
 				rating.getLiveGameId(),
@@ -336,6 +338,8 @@ public class MobileLivePlayerRatingService {
 				rating.getComment(),
 				rating.getCreatedAt(),
 				rating.getUpdatedAt(),
+				member != null ? member.getProfileImageUrl() : null,
+				favoriteTeam != null ? favoriteTeam.getImageUrl() : null,
 				toMatchInfo(matchGame));
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/rating/dto/MyRatingListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/dto/MyRatingListResponse.java
@@ -28,6 +28,10 @@ public record MyRatingListResponse(
 			String comment,
 			LocalDateTime createdAt,
 			LocalDateTime updatedAt,
+			@Schema(description = "작성자(나) 프로필 이미지 URL. 없으면 null", nullable = true)
+			String profileImageUrl,
+			@Schema(description = "작성자(나) 응원팀 로고 URL. 없으면 null", nullable = true)
+			String teamImageUrl,
 			@Schema(description = "세트가 속한 매치 정보. 매핑이 없으면 null", nullable = true)
 			MatchInfo match) {
 	}


### PR DESCRIPTION
## 배경
마이페이지 > 내 리뷰/평점에서 작성자(나) 프로필 이미지·응원팀 로고가 안 떴다. `GET /api/mobile/me/ratings`의 `MyRatingItem`에 평가 대상 **선수** 이미지만 있고 **작성자** 정보가 없었기 때문.

## 변경
- `MyRatingItem`에 `profileImageUrl`·`teamImageUrl` 추가
- `toMyRatingItem`에서 `rating.getMember()` 프로필 + `favoriteTeam` 로고로 채움 (리뷰 상세 #42와 동일 패턴). member/team 없으면 null.

## 검증
- `MobileLivePlayerRatingServiceTest` 통과
- JSON name 기반이라 필드 추가는 하위호환

🤖 Generated with [Claude Code](https://claude.com/claude-code)