### PR TITLE
feat: LCK 선수 프로필 동기화 일일 스케줄러

### DIFF
--- a/src/main/java/com/toy/nar/app/player/PlayerProfileSyncScheduler.java
+++ b/src/main/java/com/toy/nar/app/player/PlayerProfileSyncScheduler.java
@@ -1,0 +1,42 @@
+package com.toy.nar.app.player;
+
+import com.toy.nar.app.monitor.SchedulerAlertService;
+import com.toy.nar.app.participant.service.PlayerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlayerProfileSyncScheduler {
+
+	private final PlayerService playerService;
+	private final SchedulerAlertService schedulerAlertService;
+
+	// LCK 선수 프로필(본명/생년월일/포지션/솔랭 계정) 동기화: 매일 새벽 5시 30분(KST)
+	// 새벽 클러스터(04:00~04:30) 직후 한적한 시간대. cron = "초 분 시 일 월 요일"
+	@Scheduled(cron = "${player.profile-sync.cron:0 30 5 * * *}", zone = "Asia/Seoul")
+	public void syncPlayerProfiles() {
+		log.info("Starting scheduled LCK player profile sync...");
+		long startTime = System.currentTimeMillis();
+		try {
+			PlayerProfileSyncResult result = playerService.syncLckPlayerProfiles();
+			long elapsed = System.currentTimeMillis() - startTime;
+			schedulerAlertService.recordSuccess(
+					"PLAYER_PROFILE_SYNC",
+					"LCK 선수 프로필 동기화 (성공 " + result.getSuccessCount() + "/" + result.getTotalCount()
+							+ ", 실패 " + result.getFailedPlayers() + ")",
+					elapsed);
+		} catch (Exception e) {
+			log.error("Scheduled player profile sync failed", e);
+			schedulerAlertService.recordFailure(
+					"PLAYER_PROFILE_SYNC",
+					"LCK 선수 프로필 동기화",
+					e,
+					"TrackingThePros 크롤링 동기화 중 오류");
+		}
+		log.info("Scheduled LCK player profile sync completed.");
+	}
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -114,6 +114,11 @@ riot:
     target-league: ${RIOT_MONITOR_TARGET_LEAGUE:LCK}
     platform: ${RIOT_MONITOR_PLATFORM:KR}
 
+player:
+  profile-sync:
+    # LCK 선수 프로필 동기화 크론(KST). 기본 매일 새벽 5시 30분
+    cron: ${PLAYER_PROFILE_SYNC_CRON:0 30 5 * * *}
+
 lolesports:
   riot-api:
     key: ${LOL_ESPORTS_KEY}


### PR DESCRIPTION
## 무엇

`POST /api/players/sync-profiles`(TrackingThePros 크롤링 → DB 저장)를 **매일 새벽 5시 30분(KST)** 자동 실행하는 스케줄러 추가.

## 왜 이 시간대

| 시간(KST) | 기존 작업 |
|---|---|
| 03:00 | 유튜브 |
| 04:00 | 커뮤니티 정리 / 유튜브 구독 |
| 04:15 | 팀 메타데이터 |
| 04:30 | 구글드라이브 |
| **05:30** | **← 신규 (빈 슬롯)** |
| 09:00 | 디스코드 요약 |

KR 솔랭 래더가 끝나 티어 안정화되고 트래픽 최저인 새벽, 기존 크론 클러스터 직후.

## 변경

- `PlayerProfileSyncScheduler` 신규 — `@Scheduled(cron = "\${player.profile-sync.cron:0 30 5 * * *}", zone = "Asia/Seoul")`
- `PLAYER_PROFILE_SYNC_CRON` 환경변수로 운영 조정 가능 (application-prod.yml)
- 결과(성공/실패 수)는 기존 `SchedulerAlertService`로 기록 → 디스코드 일일 요약에 포함

## 검증

- `./gradlew compileJava` 통과
- prod 수동 호출 결과: 84명 중 83명 성공, Fenrir 1명 실패(TTP 슬러그 302 — 이름 매칭 이슈, 별도 건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)