### PR TITLE
feat: 백오피스 admin API + DB role 기반 인증

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,7 @@ jobs:
               -e NAVER_CLIENT_ID="${{ secrets.NAVER_CLIENT_ID }}" \
               -e NAVER_CLIENT_SECRET="${{ secrets.NAVER_CLIENT_SECRET }}" \
               -e FRONTEND_URL="${{ secrets.FRONTEND_URL }}" \
+              -e BACKOFFICE_URL="https://admin.nar.kr" \
               -e CLOUDINARY_CLOUD_NAME="${{ secrets.CLOUDINARY_CLOUD_NAME }}" \
               -e CLOUDINARY_API_KEY="${{ secrets.CLOUDINARY_API_KEY }}" \
               -e CLOUDINARY_API_SECRET="${{ secrets.CLOUDINARY_API_SECRET }}" \

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -1,0 +1,89 @@
+package com.toy.nar.api.admin;
+
+import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.participant.repository.PlayerRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 백오피스 조회 전용 API. {@code /api/admin/**} 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ * 응답은 Spring {@link Page} 형식({@code content}, {@code totalElements}) 그대로 — FE 데이터프로바이더가 흡수한다.
+ */
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class BackofficeController {
+
+    private final MemberRepository memberRepository;
+    private final PlayerRepository playerRepository;
+    private final TeamRepository teamRepository;
+
+    @GetMapping("/members")
+    public Page<MemberRow> members(Pageable pageable) {
+        return memberRepository.findAll(pageable)
+                .map(m -> new MemberRow(m.getId(), m.getNickname(), m.getEmail(),
+                        m.getFavoriteLeagueName(), m.getCreatedAt()));
+    }
+
+    @GetMapping("/players")
+    public Page<PlayerRow> players(Pageable pageable) {
+        return playerRepository.findAll(pageable)
+                .map(p -> new PlayerRow(p.getId(), p.getName(), p.getRealName(),
+                        p.getRole(), p.getAge()));
+    }
+
+    @GetMapping("/teams")
+    public Page<TeamRow> teams(Pageable pageable) {
+        return teamRepository.findAll(pageable)
+                .map(t -> new TeamRow(t.getId(), t.getName(), t.getCode()));
+    }
+
+    @GetMapping("/cron-jobs")
+    public List<CronJob> cronJobs() {
+        return CRON_CATALOG;
+    }
+
+    public record MemberRow(Long id, String name, String email,
+                            String favoriteLeagueName, LocalDateTime createdAt) {}
+
+    public record PlayerRow(Long id, String name, String realName,
+                            String role, Integer age) {}
+
+    public record TeamRow(Long id, String name, String code) {}
+
+    /**
+     * @param type        CRON(달력 기준) | INTERVAL(간격 기준)
+     * @param schedule    사람이 읽는 주기 (예: "매일 09:00", "60초마다")
+     * @param expression  원본 표기 (cron 식 또는 fixedDelay/fixedRate)
+     */
+    public record CronJob(String name, String type, String schedule, String expression, String description) {}
+
+    // ponytail: @Scheduled 작업 정적 카탈로그. 16개라 잘 안 바뀜.
+    // 실행 성공/실패 이력까지 필요해지면 SchedulerAlertService 저장소 연결, 존재/스케줄 자동추적이 필요하면 ScheduledTaskHolder 도입.
+    private static final List<CronJob> CRON_CATALOG = List.of(
+            new CronJob("sendDailySummary", "CRON", "매일 09:00", "0 0 9 * * * (KST)", "전일 스케줄러 작업 통계 일일 요약 전송"),
+            new CronJob("pollRankedSoloPlayers", "INTERVAL", "60초마다", "fixedDelay 60s", "Riot API 랭크 솔로 추적 선수 모니터링"),
+            new CronJob("syncAllLeagues", "CRON", "6시간마다", "0 0 */6 * * *", "전체 리그 경기 데이터 동기화"),
+            new CronJob("syncTeamMetadataDaily", "CRON", "매일 04:15", "0 15 4 * * *", "팀 메타데이터 일일 동기화"),
+            new CronJob("reconcile", "INTERVAL", "60초마다", "fixedDelay 60s", "라이브/배치 게임 데이터 재조정"),
+            new CronJob("discoverLiveGames", "INTERVAL", "60초마다", "fixedDelay 60s", "진행 중 라이브 게임 발견"),
+            new CronJob("pollLiveGames", "INTERVAL", "5초마다", "fixedDelay 5s", "라이브 게임 상태 폴링"),
+            new CronJob("scheduleRecentCommentsSync", "CRON", "매시 정각", "0 0 * * * *", "유튜브 최근 24h 영상 댓글 동기화"),
+            new CronJob("scheduleRecentThreeHoursVideosStatsSync", "CRON", "10분마다", "0 0/10 * * * *", "유튜브 최근 3h 영상 통계 갱신"),
+            new CronJob("scheduleRecentDayVideosStatsSync", "CRON", "매시 정각", "0 0 * * * *", "유튜브 최근 24h 영상 통계 갱신"),
+            new CronJob("scheduleLastWeekVideosSync", "CRON", "매일 03:00", "0 0 3 * * * (KST)", "유튜브 주간 영상/통계 동기화"),
+            new CronJob("syncCommunityData", "CRON", "10분마다", "0 0/10 * * * *", "커뮤니티/뉴스 데이터 동기화"),
+            new CronJob("cleanupOldData", "CRON", "매일 04:00", "0 0 4 * * *", "7일 지난 커뮤니티 게시글 삭제"),
+            new CronJob("refreshSubscription", "CRON", "매일 04:00", "0 0 4 * * *", "유튜브 PubSub 구독 갱신"),
+            new CronJob("scheduledSyncFromGoogleDrive", "CRON", "매일 04:30/10:30/16:30/22:30", "0 30 4,10,16,22 * * ? (KST)", "Google Drive CSV 경기 데이터 동기화"),
+            new CronJob("checkUserCountAndNotify", "INTERVAL", "60초마다", "fixedRate 60s", "실시간 접속자 수 모니터링")
+    );
+}

--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -186,7 +186,7 @@ public class AuthController {
         }
 
         Member member = stored.getMember();
-        String newAccessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded());
+        String newAccessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded(), member.getRole().name());
         String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
 
         refreshTokenRepository.delete(stored);

--- a/src/main/java/com/toy/nar/app/auth/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/toy/nar/app/auth/CookieOAuth2AuthorizationRequestRepository.java
@@ -18,6 +18,7 @@ public class CookieOAuth2AuthorizationRequestRepository
     private static final String REDIRECT_TARGET_COOKIE_NAME = "oauth2_redirect_target";
     private static final int COOKIE_MAX_AGE = 180;
     private static final String MOBILE_TARGET = "mobile";
+    private static final String BACKOFFICE_TARGET = "backoffice";
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
@@ -48,6 +49,14 @@ public class CookieOAuth2AuthorizationRequestRepository
         return request0;
     }
 
+    /** 현재 요청이 백오피스 로그인 흐름인지(쿠키만 확인, 제거하지 않음). */
+    public boolean isBackofficeLogin(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, REDIRECT_TARGET_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .filter(BACKOFFICE_TARGET::equals)
+                .isPresent();
+    }
+
     public String removeRedirectTarget(HttpServletRequest request, HttpServletResponse response) {
         String target = CookieUtils.getCookie(request, REDIRECT_TARGET_COOKIE_NAME)
                 .map(Cookie::getValue)
@@ -58,8 +67,9 @@ public class CookieOAuth2AuthorizationRequestRepository
 
     private void saveRedirectTarget(HttpServletRequest request, HttpServletResponse response) {
         String target = request.getParameter("target");
-        if (MOBILE_TARGET.equalsIgnoreCase(target)) {
-            CookieUtils.addCookie(response, REDIRECT_TARGET_COOKIE_NAME, MOBILE_TARGET, COOKIE_MAX_AGE);
+        if (MOBILE_TARGET.equalsIgnoreCase(target) || BACKOFFICE_TARGET.equalsIgnoreCase(target)) {
+            CookieUtils.addCookie(response, REDIRECT_TARGET_COOKIE_NAME,
+                    target.toLowerCase(), COOKIE_MAX_AGE);
             return;
         }
         CookieUtils.deleteCookie(request, response, REDIRECT_TARGET_COOKIE_NAME);

--- a/src/main/java/com/toy/nar/app/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/toy/nar/app/auth/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.toy.nar.app.auth;
 
 import com.toy.nar.domain.member.entity.Member;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -9,6 +10,8 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Collections;
 import java.util.Map;
@@ -18,6 +21,7 @@ import java.util.Map;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final SocialLoginService socialLoginService;
+    private final CookieOAuth2AuthorizationRequestRepository authorizationRequestRepository;
 
     @Override
     @Transactional
@@ -26,14 +30,24 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuthAttributes attrs = OAuthAttributes.of(registrationId, oAuth2User.getAttributes());
 
-        Member member = socialLoginService.findOrCreateMember(
-                new SocialAccountInfo(attrs.getProvider(), attrs.getProviderId(), attrs.getEmail())
-        );
+        SocialAccountInfo info = new SocialAccountInfo(attrs.getProvider(), attrs.getProviderId(), attrs.getEmail());
+        // 백오피스 로그인은 기존 ADMIN 회원만 허용(회원 생성 안 함). 일반 로그인은 없으면 생성.
+        Member member = isBackofficeLogin()
+                ? socialLoginService.findAdminMember(info)
+                : socialLoginService.findOrCreateMember(info);
 
         Map<String, Object> principalAttrs = Map.of(
                 "memberId", member.getId(),
                 "isOnboarded", member.isOnboarded()
         );
         return new DefaultOAuth2User(Collections.emptyList(), principalAttrs, "memberId");
+    }
+
+    private boolean isBackofficeLogin() {
+        if (RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes sra) {
+            HttpServletRequest request = sra.getRequest();
+            return authorizationRequestRepository.isBackofficeLogin(request);
+        }
+        return false;
     }
 }

--- a/src/main/java/com/toy/nar/app/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/toy/nar/app/auth/JwtAuthenticationFilter.java
@@ -6,12 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -25,7 +26,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
         if (StringUtils.hasText(token) && jwtTokenProvider.validate(token)) {
             Long memberId = jwtTokenProvider.getMemberId(token);
-            var auth = new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+            // role 은 토큰 발급 시점의 member.role. DB 변경은 토큰 재발급(최대 30분) 후 반영.
+            var authorities = "ADMIN".equals(jwtTokenProvider.getRole(token))
+                    ? List.of(new SimpleGrantedAuthority("ROLE_USER"), new SimpleGrantedAuthority("ROLE_ADMIN"))
+                    : List.of(new SimpleGrantedAuthority("ROLE_USER"));
+            var auth = new UsernamePasswordAuthenticationToken(memberId, null, authorities);
             SecurityContextHolder.getContext().setAuthentication(auth);
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/toy/nar/app/auth/JwtTokenProvider.java
+++ b/src/main/java/com/toy/nar/app/auth/JwtTokenProvider.java
@@ -24,10 +24,11 @@ public class JwtTokenProvider {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createAccessToken(Long memberId, boolean isOnboarded) {
+    public String createAccessToken(Long memberId, boolean isOnboarded, String role) {
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
                 .claim("onboarded", isOnboarded)
+                .claim("role", role)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRY_MS))
                 .signWith(secretKey)
@@ -49,6 +50,12 @@ public class JwtTokenProvider {
 
     public Long getMemberId(String token) {
         return Long.parseLong(parseClaims(token).getSubject());
+    }
+
+    /** 토큰의 role claim. 구버전 토큰(claim 없음)은 USER 로 간주. */
+    public String getRole(String token) {
+        String role = parseClaims(token).get("role", String.class);
+        return role != null ? role : "USER";
     }
 
     public boolean validate(String token) {

--- a/src/main/java/com/toy/nar/app/auth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/toy/nar/app/auth/OAuth2AuthenticationFailureHandler.java
@@ -25,6 +25,9 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
     @Value("${app.mobile-redirect-url:nar://oauth/callback}")
     private String mobileRedirectUrl;
 
+    @Value("${app.backoffice-url:http://localhost:5173}")
+    private String backofficeUrl;
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
@@ -41,6 +44,9 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
         String target = authorizationRequestRepository.removeRedirectTarget(request, response);
         if ("mobile".equals(target)) {
             return mobileRedirectUrl;
+        }
+        if ("backoffice".equals(target)) {
+            return backofficeUrl + "/login";
         }
         return frontendUrl + "/oauth/callback";
     }

--- a/src/main/java/com/toy/nar/app/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/toy/nar/app/auth/OAuth2AuthenticationSuccessHandler.java
@@ -26,6 +26,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     @Value("${app.mobile-redirect-url:nar://oauth/callback}")
     private String mobileRedirectUrl;
 
+    @Value("${app.backoffice-url:http://localhost:5173}")
+    private String backofficeUrl;
+
     @Override
     @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request,
@@ -49,6 +52,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String target = authorizationRequestRepository.removeRedirectTarget(request, response);
         if ("mobile".equals(target)) {
             return mobileRedirectUrl;
+        }
+        if ("backoffice".equals(target)) {
+            return backofficeUrl + "/oauth/callback";
         }
         return frontendUrl + "/oauth/callback";
     }

--- a/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
+++ b/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
@@ -1,12 +1,15 @@
 package com.toy.nar.app.auth;
 
 import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberRole;
 import com.toy.nar.domain.member.entity.MemberSocial;
 import com.toy.nar.domain.member.entity.RefreshToken;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.MemberSocialRepository;
 import com.toy.nar.domain.member.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -31,6 +34,24 @@ public class SocialLoginService {
 				.orElseGet(() -> createMember(accountInfo));
 	}
 
+	/**
+	 * 백오피스 로그인 전용. 기존 회원이면서 ADMIN 인 경우만 통과. 회원을 생성하지 않는다.
+	 * 미등록/비ADMIN 이면 OAuth2AuthenticationException → 실패 핸들러로.
+	 */
+	@Transactional(readOnly = true)
+	public Member findAdminMember(SocialAccountInfo accountInfo) {
+		Member member = memberSocialRepository
+				.findByProviderAndProviderId(accountInfo.provider(), accountInfo.providerId())
+				.map(MemberSocial::getMember)
+				.orElseThrow(() -> new OAuth2AuthenticationException(
+						new OAuth2Error("access_denied"), "백오피스에 등록되지 않은 계정입니다"));
+		if (member.getRole() != MemberRole.ADMIN) {
+			throw new OAuth2AuthenticationException(
+					new OAuth2Error("access_denied"), "관리자 권한이 없습니다");
+		}
+		return member;
+	}
+
 	@Transactional
 	public AuthTokens login(SocialAccountInfo accountInfo) {
 		Member member = findOrCreateMember(accountInfo);
@@ -45,7 +66,7 @@ public class SocialLoginService {
 	}
 
 	private AuthTokens issueTokens(Member member) {
-		String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded());
+		String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded(), member.getRole().name());
 		String refreshTokenValue = jwtTokenProvider.createRefreshToken(member.getId());
 
 		refreshTokenRepository.deleteByMemberId(member.getId());

--- a/src/main/java/com/toy/nar/config/CorsConfig.java
+++ b/src/main/java/com/toy/nar/config/CorsConfig.java
@@ -17,8 +17,8 @@ public class CorsConfig implements WebMvcConfigurer {
 		"http://localhost:3000",
 		"http://localhost:5173",   // 백오피스(Vite) 로컬 개발
 		"https://d1q54t7r1dfm7m.cloudfront.net",
-		"https://nar.kr"
-		// 백오피스 배포 도메인 정해지면 여기 추가
+		"https://nar.kr",
+		"https://admin.nar.kr"     // 백오피스 배포
 	);
 
 	private static final List<String> ALLOWED_METHODS = List.of(

--- a/src/main/java/com/toy/nar/config/CorsConfig.java
+++ b/src/main/java/com/toy/nar/config/CorsConfig.java
@@ -15,8 +15,10 @@ public class CorsConfig implements WebMvcConfigurer {
 
 	private static final List<String> ALLOWED_ORIGINS = List.of(
 		"http://localhost:3000",
+		"http://localhost:5173",   // 백오피스(Vite) 로컬 개발
 		"https://d1q54t7r1dfm7m.cloudfront.net",
 		"https://nar.kr"
+		// 백오피스 배포 도메인 정해지면 여기 추가
 	);
 
 	private static final List<String> ALLOWED_METHODS = List.of(

--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -56,6 +56,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/me", "/api/auth/logout", "/api/auth/onboarding"
                         ).authenticated()
+                        // 백오피스 admin 영역. /api/** permitAll 보다 먼저 와야 적용된다(순서 우선).
+                        .requestMatchers("/api/admin/**", "/api/debug/**").hasRole("ADMIN")
                         .requestMatchers(
                                 "/api/**",
                                 "/oauth2/**", "/login/oauth2/**",

--- a/src/main/java/com/toy/nar/domain/member/entity/Member.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/Member.java
@@ -45,6 +45,10 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberFavoritePlayer> favoritePlayers = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberRole role = MemberRole.USER;
+
     @Column(name = "onboarded_at")
     private LocalDateTime onboardedAt;
 

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberRole.java
@@ -1,0 +1,7 @@
+package com.toy.nar.domain.member.entity;
+
+/** 회원 권한. 백오피스 admin 여부 판별에 사용. */
+public enum MemberRole {
+    USER,
+    ADMIN
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,8 @@ springdoc:
     operations-sorter: alpha
 
 app:
+  # 백오피스 웹 OAuth 콜백 베이스 URL. target=backoffice 로 로그인 시 여기로 토큰 리다이렉트.
+  backoffice-url: ${BACKOFFICE_URL:http://localhost:5173}
   youtube:
     seed-channels:
       PRO_TEAMS:

--- a/src/main/resources/db/migration/V48__Add_role_to_member.sql
+++ b/src/main/resources/db/migration/V48__Add_role_to_member.sql
@@ -1,0 +1,3 @@
+-- 백오피스 admin 권한을 DB에서 관리. 기본 USER, admin 부여는 UPDATE member SET role='ADMIN' WHERE id=?
+ALTER TABLE member
+    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER';

--- a/src/test/java/com/toy/nar/app/auth/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/toy/nar/app/auth/JwtAuthenticationFilterTest.java
@@ -1,0 +1,64 @@
+package com.toy.nar.app.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET = "test-secret-key-must-be-at-least-32-bytes-long!!";
+    private final JwtTokenProvider tokenProvider = new JwtTokenProvider(SECRET);
+
+    @AfterEach
+    void clear() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private boolean hasRole(Authentication auth, String role) {
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(role::equals);
+    }
+
+    private Authentication runFilterWithToken(String token) throws Exception {
+        var filter = new JwtAuthenticationFilter(tokenProvider);
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    @Test
+    void role_ADMIN_토큰이면_ROLE_ADMIN_부여() throws Exception {
+        Authentication auth = runFilterWithToken(tokenProvider.createAccessToken(7L, true, "ADMIN"));
+        assertThat(hasRole(auth, "ROLE_ADMIN")).isTrue();
+        assertThat(hasRole(auth, "ROLE_USER")).isTrue();
+    }
+
+    @Test
+    void role_USER_토큰이면_ROLE_USER만() throws Exception {
+        Authentication auth = runFilterWithToken(tokenProvider.createAccessToken(99L, true, "USER"));
+        assertThat(hasRole(auth, "ROLE_ADMIN")).isFalse();
+        assertThat(hasRole(auth, "ROLE_USER")).isTrue();
+    }
+
+    @Test
+    void role_claim_없는_구버전토큰이면_USER로_간주() throws Exception {
+        // createAccessToken 의 3-인자 시그니처 이전(=role 미포함) 토큰 호환성.
+        String legacy = io.jsonwebtoken.Jwts.builder()
+                .subject("1")
+                .claim("onboarded", true)
+                .signWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(SECRET.getBytes()))
+                .compact();
+        Authentication auth = runFilterWithToken(legacy);
+        assertThat(hasRole(auth, "ROLE_ADMIN")).isFalse();
+        assertThat(hasRole(auth, "ROLE_USER")).isTrue();
+    }
+}

--- a/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
@@ -1,9 +1,11 @@
 package com.toy.nar.app.auth;
 
 import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberRole;
 import com.toy.nar.domain.member.entity.MemberSocial;
 import com.toy.nar.domain.member.entity.OAuthProvider;
 import com.toy.nar.domain.member.entity.RefreshToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.MemberSocialRepository;
 import com.toy.nar.domain.member.repository.RefreshTokenRepository;
@@ -19,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -66,7 +69,7 @@ class SocialLoginServiceTest {
 						.provider(OAuthProvider.KAKAO)
 						.providerId("12345")
 						.build()));
-		when(jwtTokenProvider.createAccessToken(7L, false)).thenReturn("access-token");
+		when(jwtTokenProvider.createAccessToken(7L, false, "USER")).thenReturn("access-token");
 		when(jwtTokenProvider.createRefreshToken(7L)).thenReturn("refresh-token");
 		when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(14));
 
@@ -98,7 +101,7 @@ class SocialLoginServiceTest {
 			ReflectionTestUtils.setField(saved, "id", 11L);
 			return saved;
 		});
-		when(jwtTokenProvider.createAccessToken(11L, false)).thenReturn("new-access-token");
+		when(jwtTokenProvider.createAccessToken(11L, false, "USER")).thenReturn("new-access-token");
 		when(jwtTokenProvider.createRefreshToken(11L)).thenReturn("new-refresh-token");
 		when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(14));
 
@@ -114,6 +117,43 @@ class SocialLoginServiceTest {
 		assertThat(socialCaptor.getValue().getProviderId()).isEqualTo("67890");
 		assertThat(socialCaptor.getValue().getMember().getEmail()).isEqualTo("new-user@example.com");
 		verify(refreshTokenRepository).deleteByMemberId(11L);
+	}
+
+	@Test
+	void findAdminMemberReturnsAdmin() {
+		Member member = member("admin@example.com", 2L);
+		ReflectionTestUtils.setField(member, "role", MemberRole.ADMIN);
+		SocialAccountInfo info = new SocialAccountInfo(OAuthProvider.GOOGLE, "g-1", "admin@example.com");
+		when(memberSocialRepository.findByProviderAndProviderId(OAuthProvider.GOOGLE, "g-1"))
+				.thenReturn(Optional.of(MemberSocial.builder()
+						.member(member).provider(OAuthProvider.GOOGLE).providerId("g-1").build()));
+
+		assertThat(socialLoginService.findAdminMember(info)).isSameAs(member);
+	}
+
+	@Test
+	void findAdminMemberRejectsNonAdmin() {
+		Member member = member("user@example.com", 3L); // 기본 role USER
+		SocialAccountInfo info = new SocialAccountInfo(OAuthProvider.GOOGLE, "g-2", "user@example.com");
+		when(memberSocialRepository.findByProviderAndProviderId(OAuthProvider.GOOGLE, "g-2"))
+				.thenReturn(Optional.of(MemberSocial.builder()
+						.member(member).provider(OAuthProvider.GOOGLE).providerId("g-2").build()));
+
+		assertThatThrownBy(() -> socialLoginService.findAdminMember(info))
+				.isInstanceOf(OAuth2AuthenticationException.class);
+		verify(memberRepository, never()).save(any());
+	}
+
+	@Test
+	void findAdminMemberRejectsUnknownAccountWithoutCreating() {
+		SocialAccountInfo info = new SocialAccountInfo(OAuthProvider.GOOGLE, "g-x", "nobody@example.com");
+		when(memberSocialRepository.findByProviderAndProviderId(OAuthProvider.GOOGLE, "g-x"))
+				.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> socialLoginService.findAdminMember(info))
+				.isInstanceOf(OAuth2AuthenticationException.class);
+		verify(memberRepository, never()).save(any());
+		verify(memberSocialRepository, never()).save(any());
 	}
 
 	private Member member(String email, Long id) {


### PR DESCRIPTION
## 개요
백오피스(warding-backoffice-fe)용 admin 조회 API + 권한 인증 추가.

## 변경
### admin 조회 API (`/api/admin/**`, 조회 전용)
- `GET /members` · `/players` · `/teams` — Spring `Page` 페이징/정렬
- `GET /cron-jobs` — @Scheduled 작업 카탈로그(유형/주기/원본/설명)

### 인증/인가
- `/api/admin/**`, `/api/debug/**` → `hasRole("ADMIN")`. **기존 `/api/**` permitAll 로 admin 엔드포인트가 공개돼있던 구멍 차단.**
- `member.role` 컬럼 추가(`V48`) + JWT `role` claim. 필터가 claim 으로 판별 → 요청마다 DB조회 없음.
- 권한 부여 = `UPDATE member SET role='ADMIN' WHERE id=?` (재배포 불필요, 재로그인 시 반영).

### 백오피스 OAuth (웹, 브라우저 리다이렉트)
- `?target=backoffice` 콜백 분기 (`app.backoffice-url`).
- 백오피스 로그인은 **기존 ADMIN 회원만 허용, 회원 생성 안 함**. 미등록/비ADMIN 은 거부 후 `/login` 리다이렉트.
- 기존 모바일(SDK)·웹 일반 로그인 흐름 영향 없음.

### 기타
- CORS 에 `localhost:5173`(백오피스 dev) 추가.

## 테스트
- `JwtAuthenticationFilterTest` — role=ADMIN/USER/claim없음 권한 분기
- `SocialLoginServiceTest` — `findAdminMember` admin통과/비admin거부/미등록거부(+회원 미생성)
- 로컬 E2E: 비admin 토큰 403, admin 토큰 200, 페이징/정렬 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)