### PR TITLE
feat: 라이브 선수 평점 세트 단위 → 매치 단위 전환

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -53,23 +53,25 @@ public class MobileLivePlayerRatingService {
 
 	public LivePlayerRatingListResponse getRatings(String gameId, String teamSide, Long memberId) {
 		LiveGameState state = requireState(gameId);
-		Map<Integer, LivePlayerRatingRepository.ParticipantRatingAggregate> aggregates = ratingRepository
-				.aggregateByGameId(gameId).stream()
+		String matchId = state.matchId();
+		Map<String, LivePlayerRatingRepository.PlayerRatingAggregate> aggregates = ratingRepository
+				.aggregateByMatchId(matchId).stream()
 				.collect(Collectors.toMap(
-						LivePlayerRatingRepository.ParticipantRatingAggregate::getParticipantId,
+						LivePlayerRatingRepository.PlayerRatingAggregate::getPlayerRef,
 						Function.identity()));
-		Map<Integer, Integer> myRatings = memberId == null
+		Map<String, Integer> myRatings = memberId == null
 				? Map.of()
-				: ratingRepository.findByLiveGameIdAndMember_Id(gameId, memberId).stream()
-						.collect(Collectors.toMap(LivePlayerRating::getLiveParticipantId, LivePlayerRating::getRating));
+				: ratingRepository.findByMatchIdAndMember_Id(matchId, memberId).stream()
+						.collect(Collectors.toMap(LivePlayerRating::getPlayerRef, LivePlayerRating::getRating,
+								(left, right) -> left));
 		Map<Integer, Player> players = resolvePlayers(state.participants());
 
 		List<LivePlayerRatingListResponse.PlayerRatingSummary> summaries = state.participants().stream()
 				.filter(participant -> teamSide == null
 						|| "ALL".equalsIgnoreCase(teamSide)
 						|| teamSide.equalsIgnoreCase(participant.teamSide()))
-				.map(participant -> toSummary(participant, aggregates.get(participant.participantId()),
-						players.get(participant.participantId()), myRatings.get(participant.participantId())))
+				.map(participant -> toSummary(participant, aggregates.get(playerRef(participant)),
+						players.get(participant.participantId()), myRatings.get(playerRef(participant))))
 				.toList();
 
 		return new LivePlayerRatingListResponse(
@@ -87,17 +89,19 @@ public class MobileLivePlayerRatingService {
 			int size) {
 		LiveGameState state = requireState(gameId);
 		LiveParticipantState participant = requireParticipant(state, participantId);
+		String matchId = state.matchId();
+		String playerRef = playerRef(participant);
 		Player player = resolvePlayer(participant).orElse(null);
 		int safePage = Math.max(0, page);
 		int safeSize = Math.max(1, Math.min(size, 100));
 		Page<LivePlayerRating> ratings = ratingRepository
-				.findByLiveGameIdAndLiveParticipantIdOrderByCreatedAtDesc(
-						gameId,
-						participantId,
+				.findByMatchIdAndPlayerRefOrderByCreatedAtDesc(
+						matchId,
+						playerRef,
 						PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "createdAt")));
 		long total = ratings.getTotalElements();
 		List<LivePlayerRatingRepository.RatingDistributionAggregate> distributionValues =
-				ratingRepository.distribution(gameId, participantId);
+				ratingRepository.distribution(matchId, playerRef);
 		double average = averageFromDistribution(distributionValues);
 		Map<Integer, Long> distribution = distributionValues.stream()
 				.collect(Collectors.toMap(
@@ -105,7 +109,7 @@ public class MobileLivePlayerRatingService {
 						LivePlayerRatingRepository.RatingDistributionAggregate::getRatingCount));
 		LivePlayerRatingDetailResponse.MyRating myRating = memberId == null
 				? null
-				: ratingRepository.findByLiveGameIdAndLiveParticipantIdAndMember_Id(gameId, participantId, memberId)
+				: ratingRepository.findByMatchIdAndPlayerRefAndMember_Id(matchId, playerRef, memberId)
 						.map(this::toMyRating)
 						.orElse(null);
 
@@ -146,15 +150,19 @@ public class MobileLivePlayerRatingService {
 		// 라이브 경기 중에도 평가 허용(세트 종료 제한 해제). 평가는 라이브 상태가 존재하면 언제든 가능.
 		LiveGameState state = requireState(gameId);
 		LiveParticipantState participant = requireParticipant(state, participantId);
+		String matchId = state.matchId();
+		String playerRef = playerRef(participant);
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
 		Player player = resolvePlayer(participant).orElse(null);
 
 		LivePlayerRating rating = ratingRepository
-				.findByLiveGameIdAndLiveParticipantIdAndMember_Id(gameId, participantId, memberId)
+				.findByMatchIdAndPlayerRefAndMember_Id(matchId, playerRef, memberId)
 				.orElseGet(() -> new LivePlayerRating(
+						matchId,
 						gameId,
 						participantId,
+						playerRef,
 						member,
 						player,
 						participant.teamSide(),
@@ -201,8 +209,10 @@ public class MobileLivePlayerRatingService {
 		if (memberId == null) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
 		}
+		LiveGameState state = requireState(gameId);
+		LiveParticipantState participant = requireParticipant(state, participantId);
 		LivePlayerRating rating = ratingRepository
-				.findByLiveGameIdAndLiveParticipantIdAndMember_Id(gameId, participantId, memberId)
+				.findByMatchIdAndPlayerRefAndMember_Id(state.matchId(), playerRef(participant), memberId)
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "내 평가를 찾을 수 없습니다."));
 		ratingRepository.delete(rating);
 	}
@@ -251,9 +261,17 @@ public class MobileLivePlayerRatingService {
 		return Optional.empty();
 	}
 
+	private String playerRef(LiveParticipantState participant) {
+		String esportsPlayerId = participant.esportsPlayerId();
+		if (esportsPlayerId != null && !esportsPlayerId.isBlank()) {
+			return esportsPlayerId;
+		}
+		return "name:" + participant.playerName();
+	}
+
 	private LivePlayerRatingListResponse.PlayerRatingSummary toSummary(
 			LiveParticipantState participant,
-			LivePlayerRatingRepository.ParticipantRatingAggregate aggregate,
+			LivePlayerRatingRepository.PlayerRatingAggregate aggregate,
 			Player player,
 			Integer myRating) {
 		return new LivePlayerRatingListResponse.PlayerRatingSummary(
@@ -271,13 +289,13 @@ public class MobileLivePlayerRatingService {
 
 	private List<LivePlayerRatingListResponse.TeamRatingSummary> buildTeamSummaries(
 			LiveGameState state,
-			Map<Integer, LivePlayerRatingRepository.ParticipantRatingAggregate> aggregates) {
+			Map<String, LivePlayerRatingRepository.PlayerRatingAggregate> aggregates) {
 		Map<String, TeamAccumulator> bySide = new LinkedHashMap<>();
 		for (LiveParticipantState participant : state.participants()) {
 			TeamAccumulator accumulator = bySide.computeIfAbsent(
 					participant.teamSide(),
 					side -> new TeamAccumulator(side, teamName(state, side)));
-			LivePlayerRatingRepository.ParticipantRatingAggregate aggregate = aggregates.get(participant.participantId());
+			LivePlayerRatingRepository.PlayerRatingAggregate aggregate = aggregates.get(playerRef(participant));
 			if (aggregate != null) {
 				accumulator.ratingSum += aggregate.getAverageRating() * aggregate.getRatingCount();
 				accumulator.ratingCount += aggregate.getRatingCount();

--- a/src/main/java/com/toy/nar/domain/rating/entity/LivePlayerRating.java
+++ b/src/main/java/com/toy/nar/domain/rating/entity/LivePlayerRating.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 @Entity
 @Table(name = "live_player_rating", uniqueConstraints = {
 		@UniqueConstraint(
-				name = "uk_live_player_rating_member_target",
-				columnNames = { "live_game_id", "live_participant_id", "member_id" })
+				name = "uk_live_player_rating_match_player_member",
+				columnNames = { "match_id", "player_ref", "member_id" })
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +35,15 @@ public class LivePlayerRating {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	// 매치 단위 리뷰 식별: (match_id, player_ref, member). 한 매치에서 선수 1명당 리뷰 1개.
+	@Column(name = "match_id", nullable = false, length = 64)
+	private String matchId;
+
+	// 세트 무관 선수 식별 키. esportsPlayerId 우선, 없으면 "name:{playerName}".
+	@Column(name = "player_ref", nullable = false, length = 128)
+	private String playerRef;
+
+	// 리뷰가 작성된 세트 메타(디버깅/표시용)
 	@Column(name = "live_game_id", nullable = false, length = 64)
 	private String liveGameId;
 
@@ -77,8 +86,10 @@ public class LivePlayerRating {
 	private LocalDateTime updatedAt;
 
 	public LivePlayerRating(
+			String matchId,
 			String liveGameId,
 			Integer liveParticipantId,
+			String playerRef,
 			Member member,
 			Player player,
 			String teamSide,
@@ -88,6 +99,8 @@ public class LivePlayerRating {
 			String championName,
 			Integer rating,
 			String comment) {
+		this.matchId = Objects.requireNonNull(matchId);
+		this.playerRef = Objects.requireNonNull(playerRef);
 		this.liveGameId = Objects.requireNonNull(liveGameId);
 		this.liveParticipantId = Objects.requireNonNull(liveParticipantId);
 		this.member = Objects.requireNonNull(member);

--- a/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
+++ b/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
@@ -13,46 +13,46 @@ import java.util.Optional;
 
 public interface LivePlayerRatingRepository extends JpaRepository<LivePlayerRating, Long> {
 
-	Optional<LivePlayerRating> findByLiveGameIdAndLiveParticipantIdAndMember_Id(
-			String liveGameId,
-			Integer liveParticipantId,
+	Optional<LivePlayerRating> findByMatchIdAndPlayerRefAndMember_Id(
+			String matchId,
+			String playerRef,
 			Long memberId);
 
-	List<LivePlayerRating> findByLiveGameIdAndMember_Id(String liveGameId, Long memberId);
+	List<LivePlayerRating> findByMatchIdAndMember_Id(String matchId, Long memberId);
 
 	@EntityGraph(attributePaths = "player")
 	Page<LivePlayerRating> findByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"member", "member.favoriteTeam"})
-	Page<LivePlayerRating> findByLiveGameIdAndLiveParticipantIdOrderByCreatedAtDesc(
-			String liveGameId,
-			Integer liveParticipantId,
+	Page<LivePlayerRating> findByMatchIdAndPlayerRefOrderByCreatedAtDesc(
+			String matchId,
+			String playerRef,
 			Pageable pageable);
 
 	@Query("""
-			SELECT r.liveParticipantId AS participantId,
+			SELECT r.playerRef AS playerRef,
 			       AVG(r.rating) AS averageRating,
 			       COUNT(r.id) AS ratingCount
 			FROM LivePlayerRating r
-			WHERE r.liveGameId = :gameId
-			GROUP BY r.liveParticipantId
+			WHERE r.matchId = :matchId
+			GROUP BY r.playerRef
 			""")
-	List<ParticipantRatingAggregate> aggregateByGameId(@Param("gameId") String gameId);
+	List<PlayerRatingAggregate> aggregateByMatchId(@Param("matchId") String matchId);
 
 	@Query("""
 			SELECT r.rating AS rating,
 			       COUNT(r.id) AS ratingCount
 			FROM LivePlayerRating r
-			WHERE r.liveGameId = :gameId
-			  AND r.liveParticipantId = :participantId
+			WHERE r.matchId = :matchId
+			  AND r.playerRef = :playerRef
 			GROUP BY r.rating
 			""")
 	List<RatingDistributionAggregate> distribution(
-			@Param("gameId") String gameId,
-			@Param("participantId") Integer participantId);
+			@Param("matchId") String matchId,
+			@Param("playerRef") String playerRef);
 
-	interface ParticipantRatingAggregate {
-		Integer getParticipantId();
+	interface PlayerRatingAggregate {
+		String getPlayerRef();
 		Double getAverageRating();
 		Long getRatingCount();
 	}

--- a/src/main/resources/db/migration/V49__Scope_live_player_rating_to_match.sql
+++ b/src/main/resources/db/migration/V49__Scope_live_player_rating_to_match.sql
@@ -1,0 +1,19 @@
+-- 리뷰를 세트 단위에서 매치 단위로 전환.
+-- 한 매치에서 선수 1명당 리뷰 1개: (match_id, player_ref, member_id) 유니크.
+-- player_ref = esportsPlayerId 우선, 없으면 "name:{playerName}" (세트 무관 선수 식별 키).
+-- 기존 row는 세트별 테스트 데이터뿐이라 정리 후 새 키로 시작한다.
+DELETE FROM live_player_rating;
+
+ALTER TABLE live_player_rating
+    ADD COLUMN match_id VARCHAR(64) NOT NULL AFTER id,
+    ADD COLUMN player_ref VARCHAR(128) NOT NULL AFTER live_participant_id;
+
+ALTER TABLE live_player_rating
+    DROP INDEX uk_live_player_rating_member_target;
+
+ALTER TABLE live_player_rating
+    ADD CONSTRAINT uk_live_player_rating_match_player_member
+        UNIQUE (match_id, player_ref, member_id);
+
+ALTER TABLE live_player_rating
+    ADD INDEX idx_live_player_rating_match_player (match_id, player_ref);

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -37,6 +37,8 @@ import static org.mockito.Mockito.when;
 
 class MobileLivePlayerRatingServiceTest {
 
+	private static final String PLAYER_REF = "oe:player:faker";
+
 	private LiveStateQueryService liveStateQueryService;
 	private LivePlayerRatingRepository ratingRepository;
 	private MemberRepository memberRepository;
@@ -60,22 +62,18 @@ class MobileLivePlayerRatingServiceTest {
 	}
 
 	@Test
-	void 라이브_경기_중에도_평가를_저장한다() {
+	void canRateEvenBeforeSetEnds() {
 		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		Player player = Player.builder().name("Faker").imageUrl("faker.png").build();
-		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
+		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state("game-1", 1)));
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
-		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.of(player));
-		when(ratingRepository.findByLiveGameIdAndLiveParticipantIdAndMember_Id("game-1", 1, 7L))
+		when(playerRepository.findByPlayerOriginId(PLAYER_REF)).thenReturn(Optional.of(player));
+		when(ratingRepository.findByMatchIdAndPlayerRefAndMember_Id("match-1", PLAYER_REF, 7L))
 				.thenReturn(Optional.empty());
 		when(ratingRepository.save(any(LivePlayerRating.class)))
 				.thenAnswer(invocation -> invocation.getArgument(0));
 
-		var response = service.save(
-				"game-1",
-				1,
-				7L,
-				new LivePlayerRatingRequest(5, "캐리했습니다"));
+		var response = service.save("game-1", 1, 7L, new LivePlayerRatingRequest(5, "캐리했습니다"));
 
 		assertThat(response.rating()).isEqualTo(5);
 		assertThat(response.comment()).isEqualTo("캐리했습니다");
@@ -83,15 +81,36 @@ class MobileLivePlayerRatingServiceTest {
 	}
 
 	@Test
-	void returnsTeamAndPlayerRatingSummaries() {
-		LivePlayerRatingRepository.ParticipantRatingAggregate aggregate = mock(
-				LivePlayerRatingRepository.ParticipantRatingAggregate.class);
-		when(aggregate.getParticipantId()).thenReturn(1);
+	void ratingSamePlayerInAnotherSetUpdatesSameMatchReview() {
+		Member member = member(7L, "용맹한바론");
+		LivePlayerRating existing = rating(member, 3, "1세트는 무난");
+		when(liveStateQueryService.getLatestState("game-2")).thenReturn(Optional.of(state("game-2", 51)));
+		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(playerRepository.findByPlayerOriginId(PLAYER_REF)).thenReturn(Optional.empty());
+		when(playerRepository.findByName("Faker")).thenReturn(Optional.empty());
+		// 다른 세트(game-2, participant 51)지만 같은 매치+선수라 기존 리뷰를 찾아 갱신해야 한다
+		when(ratingRepository.findByMatchIdAndPlayerRefAndMember_Id("match-1", PLAYER_REF, 7L))
+				.thenReturn(Optional.of(existing));
+		when(ratingRepository.save(existing)).thenReturn(existing);
+
+		var response = service.save("game-2", 51, 7L, new LivePlayerRatingRequest(5, "2세트 캐리"));
+
+		assertThat(response.rating()).isEqualTo(5);
+		assertThat(response.comment()).isEqualTo("2세트 캐리");
+		// 새 엔티티가 아니라 기존(1세트에서 만든) 리뷰를 갱신
+		verify(ratingRepository).save(existing);
+	}
+
+	@Test
+	void returnsTeamAndPlayerRatingSummariesAggregatedByMatch() {
+		LivePlayerRatingRepository.PlayerRatingAggregate aggregate = mock(
+				LivePlayerRatingRepository.PlayerRatingAggregate.class);
+		when(aggregate.getPlayerRef()).thenReturn(PLAYER_REF);
 		when(aggregate.getAverageRating()).thenReturn(4.5);
 		when(aggregate.getRatingCount()).thenReturn(2L);
-		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
-		when(ratingRepository.aggregateByGameId("game-1")).thenReturn(List.of(aggregate));
-		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.empty());
+		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state("game-1", 1)));
+		when(ratingRepository.aggregateByMatchId("match-1")).thenReturn(List.of(aggregate));
+		when(playerRepository.findByPlayerOriginId(PLAYER_REF)).thenReturn(Optional.empty());
 		when(playerRepository.findByName("Faker")).thenReturn(Optional.empty());
 
 		LivePlayerRatingListResponse response = service.getRatings("game-1", "ALL", null);
@@ -116,15 +135,15 @@ class MobileLivePlayerRatingServiceTest {
 
 		LivePlayerRatingRepository.RatingDistributionAggregate fiveStars = distribution(5, 3L);
 		LivePlayerRatingRepository.RatingDistributionAggregate fourStars = distribution(4, 1L);
-		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
-		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.empty());
+		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state("game-1", 1)));
+		when(playerRepository.findByPlayerOriginId(PLAYER_REF)).thenReturn(Optional.empty());
 		when(playerRepository.findByName("Faker")).thenReturn(Optional.empty());
-		when(ratingRepository.findByLiveGameIdAndLiveParticipantIdOrderByCreatedAtDesc(
-				"game-1", 1, PageRequest.of(0, 20, org.springframework.data.domain.Sort.by(
+		when(ratingRepository.findByMatchIdAndPlayerRefOrderByCreatedAtDesc(
+				"match-1", PLAYER_REF, PageRequest.of(0, 20, org.springframework.data.domain.Sort.by(
 						org.springframework.data.domain.Sort.Direction.DESC, "createdAt"))))
 				.thenReturn(new PageImpl<>(List.of(rating, rating, rating, rating), PageRequest.of(0, 20), 4));
-		when(ratingRepository.distribution("game-1", 1)).thenReturn(List.of(fiveStars, fourStars));
-		when(ratingRepository.findByLiveGameIdAndLiveParticipantIdAndMember_Id("game-1", 1, 7L))
+		when(ratingRepository.distribution("match-1", PLAYER_REF)).thenReturn(List.of(fiveStars, fourStars));
+		when(ratingRepository.findByMatchIdAndPlayerRefAndMember_Id("match-1", PLAYER_REF, 7L))
 				.thenReturn(Optional.of(rating));
 
 		LivePlayerRatingDetailResponse response = service.getDetail("game-1", 1, 7L, 0, 20);
@@ -155,11 +174,11 @@ class MobileLivePlayerRatingServiceTest {
 	void updatesExistingRatingAndDeletesIt() {
 		Member member = member(7L, "용맹한바론");
 		LivePlayerRating existing = rating(member, 3, "무난했습니다");
-		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state()));
+		when(liveStateQueryService.getLatestState("game-1")).thenReturn(Optional.of(state("game-1", 1)));
 		when(memberRepository.findById(7L)).thenReturn(Optional.of(member));
-		when(playerRepository.findByPlayerOriginId("oe:player:faker")).thenReturn(Optional.empty());
+		when(playerRepository.findByPlayerOriginId(PLAYER_REF)).thenReturn(Optional.empty());
 		when(playerRepository.findByName("Faker")).thenReturn(Optional.empty());
-		when(ratingRepository.findByLiveGameIdAndLiveParticipantIdAndMember_Id("game-1", 1, 7L))
+		when(ratingRepository.findByMatchIdAndPlayerRefAndMember_Id("match-1", PLAYER_REF, 7L))
 				.thenReturn(Optional.of(existing));
 		when(ratingRepository.save(existing)).thenReturn(existing);
 
@@ -239,14 +258,16 @@ class MobileLivePlayerRatingServiceTest {
 
 	private LivePlayerRating rating(Member member, int score, String comment) {
 		return new LivePlayerRating(
+				"match-1",
 				"game-1",
 				1,
+				PLAYER_REF,
 				member,
 				null,
 				"Red",
 				"mid",
 				"Faker",
-				"oe:player:faker",
+				PLAYER_REF,
 				"Ahri",
 				score,
 				comment);
@@ -260,9 +281,9 @@ class MobileLivePlayerRatingServiceTest {
 		return aggregate;
 	}
 
-	private LiveGameState state() {
+	private LiveGameState state(String gameId, int participantId) {
 		return new LiveGameState(
-				"game-1",
+				gameId,
 				"match-1",
 				"LCK",
 				"DNS",
@@ -270,11 +291,11 @@ class MobileLivePlayerRatingServiceTest {
 				LocalDateTime.of(2026, 6, 6, 12, 30),
 				LocalDateTime.of(2026, 6, 6, 12, 30, 10),
 				List.of(new LiveParticipantState(
-						1,
+						participantId,
 						"Red",
 						"mid",
 						"Faker",
-						"oe:player:faker",
+						PLAYER_REF,
 						"Ahri",
 						18,
 						4,


### PR DESCRIPTION
## 개요
라이브 선수 평점을 **세트(게임) 단위 → 매치 단위**로 전환. 한 매치에서 회원당 선수 1명 평점 1개.

## 변경
- 유니크 키: `(match_id, player_ref, member_id)` — 같은 매치의 다른 세트에서 같은 선수 평가 시 기존 리뷰 갱신
- `player_ref` = esportsPlayerId 우선, 없으면 `name:{선수명}` (세트 무관 식별)
- 집계/조회를 matchId 기준으로 (`aggregateByMatchId`, `findByMatchIdAndPlayerRef...`)
- `V49` 마이그레이션: `match_id`/`player_ref` 컬럼 + 유니크/인덱스 재구성

## 병합 메모 (rebase 충돌 해결)
최신 main(#221 라이브 중 평가 허용, #223 평가 작성자 이미지)에 rebase하며 충돌 3건 해결:
- Repository: match/playerRef 조회 시그니처 + `member.favoriteTeam` EntityGraph(작성자 팀이미지) **둘 다 유지**
- Service: "라이브 중 평가 허용" 동작 유지 + 매치단위 키
- Test: 매치단위 헬퍼로 통일

## 검증
- compileJava / compileTestJava ✓
- `MobileLivePlayerRatingServiceTest` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)