### PR TITLE
feat: 라이브 디스커버리 대상 리그 축소 + 폴링 10초 단축

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -81,6 +81,11 @@ public class LeagueMatchService {
 		syncMatches(leagueSlug, false);
 	}
 
+	/** [Scheduler용] 주어진 기간에 경기가 있는 리그명 목록(중복 제거). 라이브 디스커버리 대상을 좁힌다. */
+	public List<String> findLeaguesWithMatchesBetween(LocalDateTime start, LocalDateTime end) {
+		return leagueMatchRepository.findDistinctLeagueNamesByDateRange(start, end);
+	}
+
 	public boolean syncRealtimeMatchStatus(MatchResultDto match, String fallbackLeagueSlug) {
 		if (match == null || match.getMatchId() == null || match.getMatchId().isBlank()) {
 			return false;

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -1,7 +1,6 @@
 package com.toy.nar.app.lolesports.live;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.toy.nar.app.lolesports.LeagueConstants;
 import com.toy.nar.app.lolesports.LeagueMatchService;
 import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
@@ -70,7 +69,20 @@ public class LivePollingScheduler {
 		LocalDateTime nowUtc = LocalDateTime.now(ZoneOffset.UTC);
 		boolean scheduleCacheDirty = false;
 
-		for (String league : LeagueConstants.TARGET_LEAGUES) {
+		// 디스커버리 대상 리그를 좁힌다(9개 전부 매 틱 외부 호출하던 것을 줄임):
+		//  (1) 현재 active 게임의 리그 — 진행 중인 라이브가 끊기지 않도록 무조건 포함
+		//  (2) 오늘 ±1일에 경기가 있는 리그 — 곧 시작/방금 끝난 경기 커버
+		// 둘 다 없으면(경기 없는 시간대) 외부 호출 0회. 무효 리그명은 WorldsService 가 알아서 skip.
+		Set<String> leaguesToPoll = new HashSet<>();
+		for (ActiveLiveGame activeGame : activeGames.values()) {
+			if (activeGame.leagueName() != null && !activeGame.leagueName().isBlank()) {
+				leaguesToPoll.add(activeGame.leagueName());
+			}
+		}
+		leaguesToPoll.addAll(
+				leagueMatchService.findLeaguesWithMatchesBetween(nowUtc.minusDays(1), nowUtc.plusDays(1)));
+
+		for (String league : leaguesToPoll) {
 			try {
 				MatchResponseWrapper response = worldsService.getWorldsMatches(null, league);
 				for (MatchResultDto match : response.getMatches()) {

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -42,6 +42,10 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("SELECT m FROM LeagueMatch m WHERE m.matchDate >= :start AND m.matchDate <= :end ORDER BY m.matchDate DESC")
 	List<LeagueMatch> findByDateRange(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
+	/** 주어진 기간에 경기가 있는 리그명(중복 제거). 라이브 디스커버리 대상 리그를 좁히는 데 쓴다. */
+	@Query("SELECT DISTINCT m.leagueName FROM LeagueMatch m WHERE m.matchDate >= :start AND m.matchDate <= :end")
+	List<String> findDistinctLeagueNamesByDateRange(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -128,7 +128,9 @@ lolesports:
     active-leagues: ${LOL_ACTIVE_LEAGUES:LCK,LPL,LEC,LCS,LCP,CBLOL,MSI,WORLDS,FIRST_STAND}
   live:
     enabled: ${LOL_LIVE_ENABLED:false}
-    discovery-interval-ms: 60000
+    # 디스커버리 대상 리그를 active+오늘경기 리그로 좁혔으므로(보통 0~2개) 10초로 단축.
+    # 라이브 시작 인식 지연을 줄인다. 경기 없는 시간대엔 외부 호출 0회.
+    discovery-interval-ms: 10000
     poll-interval-ms: 5000
     stale-threshold-ms: 180000
     request-timeout-ms: 3000

--- a/src/main/resources/db/migration/V50__Add_match_date_index_for_live_discovery.sql
+++ b/src/main/resources/db/migration/V50__Add_match_date_index_for_live_discovery.sql
@@ -1,0 +1,11 @@
+-- 라이브 디스커버리 스케줄러가 10초마다 matchDate 범위로 경기 있는 리그를
+-- distinct 조회한다(findDistinctLeagueNamesByDateRange). 기존 인덱스는 모두
+-- league_name 선두 복합이라 이 쿼리는 full table scan을 탄다.
+-- (match_date, league_name) 인덱스로 range + covering(DISTINCT league_name) 처리한다.
+SET @stmt := IF(
+    (SELECT COUNT(1) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'league_match'
+       AND INDEX_NAME = 'idx_league_match_date_league') = 0,
+    'CREATE INDEX idx_league_match_date_league ON league_match (match_date, league_name)',
+    'SELECT 1');
+PREPARE s FROM @stmt; EXECUTE s; DEALLOCATE PREPARE s;


### PR DESCRIPTION
## 배경
라이브 경기 시작 인식이 느림. `LivePollingScheduler.discoverLiveGames`가 **매 틱 TARGET_LEAGUES 9개 전부** 외부 lolesports API(`getWorldsMatches`)를 호출 + discovery 간격 60초라 지연.

## 변경
- **디스커버리 대상 리그 축소**: 9리그 고정 → `현재 active 게임 리그 ∪ 오늘±1일 경기 있는 리그`
  - active 게임 리그는 **무조건 포함** → 진행 중 라이브 끊김 방지
  - 둘 다 없으면(경기 없는 시간대) **외부 호출 0회**
- **discovery 간격 60초 → 10초**: 대상이 보통 0~2개로 줄어 부하 여유 생김. 라이브 시작 인식 지연 ↓
- **인덱스 추가(V50)**: `(match_date, league_name)` — 10초마다 도는 distinct 리그 조회의 full scan 방지

## 부하 비교
- 기존: 9리그 × 60초 = 분당 9 호출
- 변경: MSI 기간 보통 1~2리그 × 10초 = 분당 6~12 (비슷한 수준에서 인식은 6배 빠름), 경기 없으면 0

## 변경 파일
- `LeagueMatchRepository` — `findDistinctLeagueNamesByDateRange`
- `LeagueMatchService` — `findLeaguesWithMatchesBetween`
- `LivePollingScheduler.discoverLiveGames` — 대상 리그 축소
- `application-prod.yml` — `discovery-interval-ms 60000→10000`
- `V50` migration — 인덱스

## 검증
`./gradlew compileJava` BUILD SUCCESSFUL. 디스커버리 실동작은 실제 라이브 경기 때만 확인 가능.

## 비고
- ±1일 윈도우(48h)로 UTC/KST 시차 흡수
- `fixedDelay`라 실행시간이 간격 초과해도 오버랩 없음
- 진짜 지연 주범이 lolesports의 `inProgress` 반영 지연이면 체감 효과는 제한될 수 있음 (별도 측정 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)