### PR TITLE
feat: 모바일 경기 일정 필터 리그 전체(ALL) 선택 옵션 추가 (warding #33)

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
+++ b/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
@@ -30,7 +30,7 @@ public class MobileMatchController {
 					+ "시즌 필터 옵션은 /api/mobile/schedules/filters 응답의 seasons에서 가져옵니다.")
 	@GetMapping
 	public ResponseEntity<MobileMatchPageResponse> getMatches(
-			@Parameter(description = "리그", example = "LCK")
+			@Parameter(description = "리그 (전체는 ALL)", example = "LCK")
 			@RequestParam(defaultValue = "LCK") String league,
 			@Parameter(description = "팀 ID", example = "1")
 			@RequestParam(required = false) Long teamId,

--- a/src/main/java/com/toy/nar/api/mobile/schedule/MobileScheduleController.java
+++ b/src/main/java/com/toy/nar/api/mobile/schedule/MobileScheduleController.java
@@ -29,7 +29,7 @@ public class MobileScheduleController {
 	@Operation(summary = "모바일 일정 필터 조회", description = "모바일 경기일정/경기리스트 화면의 리그와 팀 필터 옵션을 조회합니다.")
 	@GetMapping("/filters")
 	public ResponseEntity<MobileScheduleFilterResponse> getFilters(
-			@Parameter(description = "팀 옵션을 조회할 리그", example = "LCK")
+			@Parameter(description = "팀 옵션을 조회할 리그 (전체는 ALL)", example = "LCK")
 			@RequestParam(defaultValue = "LCK") String league) {
 		return ResponseEntity.ok(mobileScheduleService.getFilters(league));
 	}
@@ -39,7 +39,7 @@ public class MobileScheduleController {
 	public ResponseEntity<MobileScheduleCalendarResponse> getCalendar(
 			@Parameter(description = "조회 월", example = "2026-04")
 			@RequestParam("month") @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
-			@Parameter(description = "리그", example = "LCK")
+			@Parameter(description = "리그 (전체는 ALL)", example = "LCK")
 			@RequestParam(defaultValue = "LCK") String league,
 			@Parameter(description = "팀 ID", example = "1")
 			@RequestParam(required = false) Long teamId) {
@@ -51,7 +51,7 @@ public class MobileScheduleController {
 	public ResponseEntity<MobileScheduleListResponse> getDailySchedules(
 			@Parameter(description = "조회 일자", example = "2026-04-01")
 			@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-			@Parameter(description = "리그", example = "LCK")
+			@Parameter(description = "리그 (전체는 ALL)", example = "LCK")
 			@RequestParam(defaultValue = "LCK") String league,
 			@Parameter(description = "팀 ID", example = "1")
 			@RequestParam(required = false) Long teamId) {

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -45,7 +45,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE m.leagueName = :leagueName
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
 			  AND m.matchDate >= :start
 			  AND m.matchDate < :end
 			ORDER BY m.matchDate ASC
@@ -58,7 +58,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE m.leagueName = :leagueName
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
 			  AND m.matchDate >= :start
 			  AND m.matchDate < :end
 			  AND (
@@ -79,7 +79,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE m.leagueName = :leagueName
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
 			  AND (:seasonYear IS NULL OR m.seasonYear = :seasonYear)
 			  AND (:seasonSplit IS NULL OR m.seasonSplit = :seasonSplit)
 			  AND (:cursorId IS NULL
@@ -98,7 +98,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE m.leagueName = :leagueName
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
 			  AND (:seasonYear IS NULL OR m.seasonYear = :seasonYear)
 			  AND (:seasonSplit IS NULL OR m.seasonSplit = :seasonSplit)
 			  AND (
@@ -131,7 +131,7 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT DISTINCT m.seasonYear AS seasonYear, m.seasonSplit AS seasonSplit
 			FROM LeagueMatch m
-			WHERE m.leagueName = :leagueName
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
 			  AND m.seasonYear IS NOT NULL
 			  AND m.seasonSplit IS NOT NULL
 			ORDER BY m.seasonYear DESC, m.seasonSplit ASC

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 public class MobileScheduleService {
 
 	private static final String DEFAULT_LEAGUE = "LCK";
+	private static final String ALL_LEAGUES = "ALL";
 	private static final int DEFAULT_TEAM_YEAR = 2026;
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 	private static final ZoneId UTC = ZoneId.of("UTC");
@@ -67,15 +68,19 @@ public class MobileScheduleService {
 
 	public MobileScheduleFilterResponse getFilters(String league) {
 		String normalizedLeague = normalizeLeague(league);
-		List<MobileScheduleFilterResponse.LeagueOption> leagues = LeagueConstants.ALLOWED_LEAGUES.stream()
+		List<MobileScheduleFilterResponse.LeagueOption> leagues = new ArrayList<>();
+		leagues.add(new MobileScheduleFilterResponse.LeagueOption(ALL_LEAGUES, "전체"));
+		LeagueConstants.ALLOWED_LEAGUES.stream()
 				.sorted()
-				.map(code -> new MobileScheduleFilterResponse.LeagueOption(code, code))
-				.toList();
-		List<MobileScheduleFilterResponse.TeamOption> teams = findFilterTeams(normalizedLeague).stream()
-				.map(this::toTeamOption)
-				.toList();
+				.forEach(code -> leagues.add(new MobileScheduleFilterResponse.LeagueOption(code, code)));
+		// 전체 리그 선택 시 팀 필터는 비활성(특정 리그 소속이라 의미 없음).
+		List<MobileScheduleFilterResponse.TeamOption> teams = ALL_LEAGUES.equals(normalizedLeague)
+				? List.of()
+				: findFilterTeams(normalizedLeague).stream()
+						.map(this::toTeamOption)
+						.toList();
 		List<MobileScheduleFilterResponse.SeasonOption> seasons = leagueMatchRepository
-				.findSeasonOptions(normalizedLeague).stream()
+				.findSeasonOptions(leagueParam(normalizedLeague)).stream()
 				.map(row -> new MobileScheduleFilterResponse.SeasonOption(
 						row.getSeasonYear(),
 						row.getSeasonSplit(),
@@ -146,6 +151,7 @@ public class MobileScheduleService {
 			String cursor,
 			Integer size) {
 		String normalizedLeague = normalizeLeague(league);
+		String leagueParam = leagueParam(normalizedLeague);
 		TeamFilter teamFilter = resolveTeamFilter(teamId);
 		String normalizedSplit = seasonSplit == null || seasonSplit.isBlank() ? null : seasonSplit.trim();
 		int pageSize = size == null
@@ -156,14 +162,14 @@ public class MobileScheduleService {
 
 		List<LeagueMatch> fetched = teamFilter == null
 				? leagueMatchRepository.findMobileMatchPage(
-						normalizedLeague,
+						leagueParam,
 						seasonYear,
 						normalizedSplit,
 						matchCursor != null ? matchCursor.matchDate() : null,
 						matchCursor != null ? matchCursor.matchId() : null,
 						fetchLimit)
 				: leagueMatchRepository.findMobileTeamMatchPage(
-						normalizedLeague,
+						leagueParam,
 						teamFilter.name(),
 						teamFilter.code(),
 						seasonYear,
@@ -233,11 +239,12 @@ public class MobileScheduleService {
 			TeamFilter teamFilter,
 			LocalDateTime startUtc,
 			LocalDateTime endUtc) {
+		String leagueParam = leagueParam(league);
 		if (teamFilter == null) {
-			return leagueMatchRepository.findMobileMatchesInRange(league, startUtc, endUtc);
+			return leagueMatchRepository.findMobileMatchesInRange(leagueParam, startUtc, endUtc);
 		}
 		return leagueMatchRepository.findMobileTeamMatchesInRange(
-				league,
+				leagueParam,
 				teamFilter.name(),
 				teamFilter.code(),
 				startUtc,
@@ -456,10 +463,18 @@ public class MobileScheduleService {
 		String normalized = league == null || league.isBlank()
 				? DEFAULT_LEAGUE
 				: league.trim().toUpperCase(Locale.ROOT);
+		if (ALL_LEAGUES.equals(normalized)) {
+			return ALL_LEAGUES;
+		}
 		if (!LeagueConstants.ALLOWED_LEAGUES.contains(normalized)) {
 			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
 		}
 		return normalized;
+	}
+
+	/** 리포지토리 필터용 리그 값. 전체(ALL) 선택이면 null 을 반환해 리그 조건을 건다. */
+	private String leagueParam(String normalizedLeague) {
+		return ALL_LEAGUES.equals(normalizedLeague) ? null : normalizedLeague;
 	}
 
 	private record TeamFilter(String name, String code) {

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -326,6 +326,41 @@ class MobileScheduleServiceTest {
 	}
 
 	@Test
+	void allLeagueQueriesWithoutLeagueFilter() {
+		when(leagueMatchRepository.findMobileMatchesInRange(
+				null,
+				LocalDateTime.of(2026, 3, 31, 15, 0),
+				LocalDateTime.of(2026, 4, 1, 15, 0)))
+				.thenReturn(List.of(
+						match("m-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed"),
+						match("m-2", "LPL", LocalDateTime.of(2026, 4, 1, 11, 0), "BLG", "JDG", "completed")));
+
+		MobileScheduleListResponse response = service.getDailySchedules(LocalDate.of(2026, 4, 1), "ALL", null);
+
+		assertThat(response.league()).isEqualTo("ALL");
+		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
+				.containsExactly("m-1", "m-2");
+		verify(leagueMatchRepository).findMobileMatchesInRange(
+				null,
+				LocalDateTime.of(2026, 3, 31, 15, 0),
+				LocalDateTime.of(2026, 4, 1, 15, 0));
+	}
+
+	@Test
+	void getFiltersForAllLeagueOmitsTeamsAndAddsAllOption() {
+		when(leagueMatchRepository.findSeasonOptions(null)).thenReturn(List.of());
+
+		MobileScheduleFilterResponse response = service.getFilters("ALL");
+
+		assertThat(response.leagues()).first()
+				.extracting(MobileScheduleFilterResponse.LeagueOption::code,
+						MobileScheduleFilterResponse.LeagueOption::name)
+				.containsExactly("ALL", "전체");
+		assertThat(response.teams()).isEmpty();
+		verifyNoInteractions(teamRepository);
+	}
+
+	@Test
 	void unknownTeamThrowsDataNotFound() {
 		when(teamRepository.findById(999L)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## 개요
warding #33 — 모바일 경기 일정 필터에 리그 **전체 선택** 옵션 추가.

## 변경
- `getFilters` 응답 리그 목록 최상단에 `전체`(code=`ALL`) 옵션 추가
- `league=ALL` 시 캘린더/일별 리스트/매치 페이지가 리그 조건 없이 전체 리그 조회
  - 리포지토리 모바일 쿼리 `leagueName` 조건을 nullable 화 (`:leagueName IS NULL OR m.leagueName = :leagueName`)
  - 서비스: `ALL` → 리포지토리 파라미터 `null` 변환 (`leagueParam`)
- 전체 선택 시 팀 필터는 비활성(특정 리그 소속이라 무의미) → 빈 목록 반환
- Swagger 파라미터 설명에 `전체는 ALL` 명시

## 테스트
- `MobileScheduleServiceTest`: ALL 조회 시 리그 필터 없이 쿼리 / 필터 응답에 ALL 옵션·팀 비움 검증 추가
- 모바일 schedule·match 컨트롤러/서비스 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)