### PR TITLE
feat: 모바일 Google/Naver 소셜 로그인 검증 API 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -1,15 +1,19 @@
 package com.toy.nar.api.auth;
 
+import com.toy.nar.api.auth.dto.GoogleMobileLoginRequest;
 import com.toy.nar.api.auth.dto.KakaoMobileLoginRequest;
 import com.toy.nar.api.auth.dto.MemberResponse;
+import com.toy.nar.api.auth.dto.NaverMobileLoginRequest;
 import com.toy.nar.api.auth.dto.OnboardingLeagueOptionResponse;
 import com.toy.nar.api.auth.dto.OnboardingPlayerOptionResponse;
 import com.toy.nar.api.auth.dto.OnboardingRequest;
 import com.toy.nar.api.auth.dto.OnboardingTeamOptionResponse;
 import com.toy.nar.api.auth.dto.TokenResponse;
 import com.toy.nar.app.auth.AuthTokens;
+import com.toy.nar.app.auth.GoogleUserClient;
 import com.toy.nar.app.auth.JwtTokenProvider;
 import com.toy.nar.app.auth.KakaoUserClient;
+import com.toy.nar.app.auth.NaverUserClient;
 import com.toy.nar.app.auth.SocialAccountInfo;
 import com.toy.nar.app.auth.SocialLoginService;
 import com.toy.nar.app.auth.profile.CloudinarySignatureService;
@@ -89,6 +93,8 @@ public class AuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoUserClient kakaoUserClient;
+    private final GoogleUserClient googleUserClient;
+    private final NaverUserClient naverUserClient;
     private final SocialLoginService socialLoginService;
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -111,6 +117,46 @@ public class AuthController {
     public ResponseEntity<TokenResponse> loginWithKakaoAccessToken(
             @Valid @RequestBody KakaoMobileLoginRequest request) {
         SocialAccountInfo accountInfo = kakaoUserClient.fetchUser(request.accessToken());
+        AuthTokens tokens = socialLoginService.login(accountInfo);
+        return ResponseEntity.ok(new TokenResponse(
+                tokens.accessToken(),
+                tokens.refreshToken(),
+                tokens.isOnboarded()
+        ));
+    }
+
+    @Operation(
+            summary = "모바일 Google 로그인",
+            description = "Google Sign-In SDK에서 발급받은 ID Token을 검증하고 서비스 JWT를 발급합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "모바일 Google 로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 Google ID Token")
+    })
+    @PostMapping("/mobile/google")
+    public ResponseEntity<TokenResponse> loginWithGoogleIdToken(
+            @Valid @RequestBody GoogleMobileLoginRequest request) {
+        SocialAccountInfo accountInfo = googleUserClient.fetchUser(request.idToken());
+        AuthTokens tokens = socialLoginService.login(accountInfo);
+        return ResponseEntity.ok(new TokenResponse(
+                tokens.accessToken(),
+                tokens.refreshToken(),
+                tokens.isOnboarded()
+        ));
+    }
+
+    @Operation(
+            summary = "모바일 Naver 로그인",
+            description = "Naver Login SDK에서 발급받은 Access Token을 검증하고 서비스 JWT를 발급합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "모바일 Naver 로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 Naver Access Token")
+    })
+    @PostMapping("/mobile/naver")
+    public ResponseEntity<TokenResponse> loginWithNaverAccessToken(
+            @Valid @RequestBody NaverMobileLoginRequest request) {
+        SocialAccountInfo accountInfo = naverUserClient.fetchUser(request.accessToken());
         AuthTokens tokens = socialLoginService.login(accountInfo);
         return ResponseEntity.ok(new TokenResponse(
                 tokens.accessToken(),

--- a/src/main/java/com/toy/nar/api/auth/dto/GoogleMobileLoginRequest.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/GoogleMobileLoginRequest.java
@@ -1,0 +1,11 @@
+package com.toy.nar.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "모바일 Google 로그인 요청")
+public record GoogleMobileLoginRequest(
+		@NotBlank
+		@Schema(description = "Google Sign-In SDK에서 발급받은 ID Token", requiredMode = Schema.RequiredMode.REQUIRED)
+		String idToken) {
+}

--- a/src/main/java/com/toy/nar/api/auth/dto/NaverMobileLoginRequest.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/NaverMobileLoginRequest.java
@@ -1,0 +1,11 @@
+package com.toy.nar.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "모바일 Naver 로그인 요청")
+public record NaverMobileLoginRequest(
+		@NotBlank
+		@Schema(description = "Naver Login SDK에서 발급받은 Access Token", requiredMode = Schema.RequiredMode.REQUIRED)
+		String accessToken) {
+}

--- a/src/main/java/com/toy/nar/app/auth/GoogleUserClient.java
+++ b/src/main/java/com/toy/nar/app/auth/GoogleUserClient.java
@@ -1,0 +1,85 @@
+package com.toy.nar.app.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.domain.member.entity.OAuthProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Service
+public class GoogleUserClient {
+
+	// Google이 서명·만료를 검증해주므로 tokeninfo 200 응답이면 유효한 idToken.
+	// aud(발급 대상)는 우리가 직접 허용 목록과 대조해야 한다.
+	private static final String GOOGLE_TOKENINFO_URL = "https://oauth2.googleapis.com/tokeninfo";
+
+	private final WebClient webClient;
+	private final List<String> allowedAudiences;
+
+	public GoogleUserClient(WebClient webClient,
+			@Value("${oauth.google.mobile.client-ids:}") String clientIds) {
+		this.webClient = webClient;
+		this.allowedAudiences = Arrays.stream(clientIds.split(","))
+				.map(String::trim)
+				.filter(StringUtils::hasText)
+				.toList();
+	}
+
+	public SocialAccountInfo fetchUser(String idToken) {
+		if (!StringUtils.hasText(idToken)) {
+			throw new ResponseStatusException(UNAUTHORIZED, "Google ID 토큰이 필요합니다");
+		}
+
+		JsonNode payload = requestTokenInfo(idToken);
+		if (payload == null) {
+			throw new ResponseStatusException(BAD_GATEWAY, "Google 토큰 검증 응답이 비어 있습니다");
+		}
+
+		String audience = payload.path("aud").asText(null);
+		if (!allowedAudiences.isEmpty() && !allowedAudiences.contains(audience)) {
+			throw new ResponseStatusException(UNAUTHORIZED, "허용되지 않은 Google 클라이언트에서 발급된 토큰입니다");
+		}
+
+		String providerId = payload.path("sub").asText(null);
+		if (!StringUtils.hasText(providerId)) {
+			throw new ResponseStatusException(UNAUTHORIZED, "Google 사용자 정보를 확인할 수 없습니다");
+		}
+
+		String email = payload.path("email").asText(null);
+		if (!StringUtils.hasText(email)) {
+			email = null;
+		}
+
+		return new SocialAccountInfo(OAuthProvider.GOOGLE, providerId, email);
+	}
+
+	private JsonNode requestTokenInfo(String idToken) {
+		String uri = UriComponentsBuilder.fromHttpUrl(GOOGLE_TOKENINFO_URL)
+				.queryParam("id_token", idToken)
+				.toUriString();
+		try {
+			return webClient.get()
+					.uri(uri)
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+		} catch (WebClientResponseException e) {
+			HttpStatusCode status = e.getStatusCode();
+			if (status.is4xxClientError()) {
+				throw new ResponseStatusException(UNAUTHORIZED, "유효하지 않은 Google ID 토큰", e);
+			}
+			throw new ResponseStatusException(BAD_GATEWAY, "Google 토큰 검증에 실패했습니다", e);
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/auth/NaverUserClient.java
+++ b/src/main/java/com/toy/nar/app/auth/NaverUserClient.java
@@ -1,0 +1,70 @@
+package com.toy.nar.app.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.domain.member.entity.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Service
+@RequiredArgsConstructor
+public class NaverUserClient {
+
+	private static final String NAVER_USER_ME_URL = "https://openapi.naver.com/v1/nid/me";
+
+	private final WebClient webClient;
+
+	public SocialAccountInfo fetchUser(String naverAccessToken) {
+		if (!StringUtils.hasText(naverAccessToken)) {
+			throw new ResponseStatusException(UNAUTHORIZED, "네이버 액세스 토큰이 필요합니다");
+		}
+
+		JsonNode body = requestUserInfo(naverAccessToken);
+		if (body == null) {
+			throw new ResponseStatusException(BAD_GATEWAY, "네이버 사용자 정보 응답이 비어 있습니다");
+		}
+
+		// 네이버는 프로필을 response 하위에 담고, resultcode "00"이 성공이다.
+		String resultCode = body.path("resultcode").asText(null);
+		if (!"00".equals(resultCode)) {
+			throw new ResponseStatusException(UNAUTHORIZED, "유효하지 않은 네이버 액세스 토큰");
+		}
+
+		JsonNode response = body.path("response");
+		String providerId = response.path("id").asText(null);
+		if (!StringUtils.hasText(providerId)) {
+			throw new ResponseStatusException(UNAUTHORIZED, "네이버 사용자 정보를 확인할 수 없습니다");
+		}
+
+		String email = response.path("email").asText(null);
+		if (!StringUtils.hasText(email)) {
+			email = null;
+		}
+
+		return new SocialAccountInfo(OAuthProvider.NAVER, providerId, email);
+	}
+
+	private JsonNode requestUserInfo(String naverAccessToken) {
+		try {
+			return webClient.get()
+					.uri(NAVER_USER_ME_URL)
+					.headers(headers -> headers.setBearerAuth(naverAccessToken))
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+		} catch (WebClientResponseException e) {
+			HttpStatusCode status = e.getStatusCode();
+			if (status.is4xxClientError()) {
+				throw new ResponseStatusException(UNAUTHORIZED, "유효하지 않은 네이버 액세스 토큰", e);
+			}
+			throw new ResponseStatusException(BAD_GATEWAY, "네이버 사용자 정보 조회에 실패했습니다", e);
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,11 @@ cloudinary:
   cloud-name: ${CLOUDINARY_CLOUD_NAME:}
   api-key: ${CLOUDINARY_API_KEY:}
   api-secret: ${CLOUDINARY_API_SECRET:}
+
+# 모바일 소셜 로그인 설정.
+oauth:
+  google:
+    mobile:
+      # Google 로그인 idToken 검증 시 허용할 aud(클라이언트 ID) 목록. 쉼표 구분.
+      # 웹/iOS 클라이언트 ID가 다르면 둘 다 넣는다. 비워두면 aud 검증을 건너뛴다.
+      client-ids: ${GOOGLE_MOBILE_CLIENT_IDS:12814317442-egra6e1lni0dmepp793sj5389qpsf1r0.apps.googleusercontent.com}

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -2,7 +2,9 @@ package com.toy.nar.api.auth;
 
 import com.toy.nar.api.auth.dto.OnboardingRequest;
 import com.toy.nar.app.auth.JwtTokenProvider;
+import com.toy.nar.app.auth.GoogleUserClient;
 import com.toy.nar.app.auth.KakaoUserClient;
+import com.toy.nar.app.auth.NaverUserClient;
 import com.toy.nar.app.auth.SocialLoginService;
 import com.toy.nar.app.auth.profile.CloudinarySignatureService;
 import com.toy.nar.app.mobile.device.MobileDeviceService;
@@ -45,6 +47,8 @@ class AuthControllerOnboardingNotificationTest {
 		AuthController controller = new AuthController(
 				jwtTokenProvider,
 				kakaoUserClient,
+				mock(GoogleUserClient.class),
+				mock(NaverUserClient.class),
 				socialLoginService,
 				memberRepository,
 				refreshTokenRepository,
@@ -180,6 +184,8 @@ class AuthControllerOnboardingNotificationTest {
 		AuthController controller = new AuthController(
 				jwtTokenProvider,
 				kakaoUserClient,
+				mock(GoogleUserClient.class),
+				mock(NaverUserClient.class),
 				socialLoginService,
 				memberRepository,
 				refreshTokenRepository,

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 3, Title: 클템:젠지는 축구로 치면 브라질이다
-[2] Vote: 20, Title: Official) DNS Sharvel 영입
-[3] Vote: 15, Title: 케리아: 내 바드 그 정도 아니다
-[4] Vote: 2, Title: 요즘 티원 안정적으로 이길판 다 이기면서 잘하내,,
-[5] Vote: 2, Title: 소신발언)샤벨은 농심가는게 더 나아보이는데
+[1] Vote: 3, Title: 왜이렇게 많이 땄나요 !!
+[2] Vote: 37, Title: MSI 대진표 나옴(일정은 추후 공지할 예정)
+[3] Vote: 24, Title: 슬슬 고소장 또 모으는 LCK
+[4] Vote: 3, Title: lck 3-파이널라운드 경기 일정
+[5] Vote: 24, Title: 어메이징 T1 서커스
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 아니 이걸 치감을 안간다고?
-[2] Vote: , Title: 바루스템 저리가는거 맞음?
-[3] Vote: , Title: 결국 한국인이 많은 팀이 이기는건가 ㅋㅋ
-[4] Vote: , Title: kc 치감 절대 안가네 ㅋㅋㅋ
-[5] Vote: , Title: 끼얏호우 치감 안 가고 역보 끼야아아아악
+[1] Vote: , Title: 증바람 탱이 체력 2만인데 피바는 애 사는거임?
+[2] Vote: , Title: LOL MSI 배당 ★티원 약정배
+[3] Vote: , Title: 양탕국을 너무 마셔서 소피가 마렵다는데
+[4] Vote: , Title: 이사람 조심하세요
+[5] Vote: , Title: 변방 ㅈ밥팀 잡고 도란 폼 돌아왔다도르 짜치지않냐 ㅋㅋ


### PR DESCRIPTION
## 배경
모바일 앱이 Google `idToken` / Naver `accessToken` 을 백엔드로 보내 검증받고 서비스 JWT를 발급받는 엔드포인트가 없어 404가 발생했다. 기존 카카오(`/api/auth/mobile/kakao`) 패턴을 그대로 확장한다.

## 변경
- `POST /api/auth/mobile/google` : Google `idToken`을 `tokeninfo`로 검증하고 `aud`(클라이언트 ID)를 대조한 뒤 JWT 발급
- `POST /api/auth/mobile/naver` : Naver `accessToken`으로 `nid/me` 프로필을 조회해 JWT 발급
- `SocialLoginService` / `SocialAccountInfo` (제공자 중립) 재사용 — 회원 자동 생성·온보딩·응답 포맷 카카오와 동일
- 허용 Google `aud` 목록은 `oauth.google.mobile.client-ids` (env `GOOGLE_MOBILE_CLIENT_IDS`) 로 설정. 기본값은 모바일 web 클라이언트 ID

## 응답
`TokenResponse { accessToken, refreshToken, isOnboarded }` — 카카오와 동일

## 검증
- `./gradlew compileJava` 통과
- Naver 검증은 Client Secret 불필요(프로필 조회만), Google은 serverClientId(web) 기준 aud 검증

## 배포 시 확인
- prod에서 iOS 클라이언트가 web과 다른 aud로 idToken을 발급하면 `GOOGLE_MOBILE_CLIENT_IDS`에 쉼표로 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)