### PR TITLE
feat: 소셜 로그인 이메일 기준 계정 자동 연동

### DIFF
--- a/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
+++ b/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Optional;
+
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
@@ -80,14 +82,10 @@ public class SocialLoginService {
 	}
 
 	private Member createMember(SocialAccountInfo accountInfo) {
-		NicknameGenerator.GeneratedNickname nickname = nicknameGenerator.generate();
-		Member member = memberRepository.save(
-				Member.builder()
-						.name(nickname.name())
-						.tag(nickname.tag())
-						.email(accountInfo.email())
-						.build()
-		);
+		// 같은 이메일의 기존 회원이 있으면 새 계정을 만들지 않고 소셜 계정만 연동한다.
+		// (카카오/구글/네이버 모두 공급자가 검증한 이메일을 내려주므로 이메일 기준 연동이 안전)
+		Member member = findLinkTargetByEmail(accountInfo.email())
+				.orElseGet(() -> newMember(accountInfo));
 		memberSocialRepository.save(
 				MemberSocial.builder()
 						.member(member)
@@ -96,5 +94,23 @@ public class SocialLoginService {
 						.build()
 		);
 		return member;
+	}
+
+	private Optional<Member> findLinkTargetByEmail(String email) {
+		if (email == null || email.isBlank()) {
+			return Optional.empty();
+		}
+		return memberRepository.findFirstByEmailOrderByIdAsc(email);
+	}
+
+	private Member newMember(SocialAccountInfo accountInfo) {
+		NicknameGenerator.GeneratedNickname nickname = nicknameGenerator.generate();
+		return memberRepository.save(
+				Member.builder()
+						.name(nickname.name())
+						.tag(nickname.tag())
+						.email(accountInfo.email())
+						.build()
+		);
 	}
 }

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNameAndTag(String name, String tag);
     Optional<Member> findByEmail(String email);
+    // 이메일 자동 연동용. 혹시 중복 이메일이 있어도 가장 오래된 계정으로 안전하게 연결한다.
+    Optional<Member> findFirstByEmailOrderByIdAsc(String email);
 }

--- a/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
@@ -120,6 +120,58 @@ class SocialLoginServiceTest {
 	}
 
 	@Test
+	void loginLinksNewProviderToExistingMemberWithSameEmail() {
+		// 카카오로 가입된 회원이 같은 이메일의 네이버로 로그인 → 새 계정 생성 없이 소셜만 연동
+		Member existing = member("same@naver.com", 21L);
+		SocialAccountInfo accountInfo = new SocialAccountInfo(
+				OAuthProvider.NAVER,
+				"naver-1",
+				"same@naver.com"
+		);
+
+		when(memberSocialRepository.findByProviderAndProviderId(OAuthProvider.NAVER, "naver-1"))
+				.thenReturn(Optional.empty());
+		when(memberRepository.findFirstByEmailOrderByIdAsc("same@naver.com"))
+				.thenReturn(Optional.of(existing));
+		when(jwtTokenProvider.createAccessToken(21L, false, "USER")).thenReturn("linked-access");
+		when(jwtTokenProvider.createRefreshToken(21L)).thenReturn("linked-refresh");
+		when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(14));
+
+		AuthTokens tokens = socialLoginService.login(accountInfo);
+
+		assertThat(tokens.accessToken()).isEqualTo("linked-access");
+		verify(memberRepository, never()).save(any()); // 새 회원 생성 없음
+		ArgumentCaptor<MemberSocial> socialCaptor = ArgumentCaptor.forClass(MemberSocial.class);
+		verify(memberSocialRepository).save(socialCaptor.capture());
+		assertThat(socialCaptor.getValue().getMember()).isSameAs(existing);
+		assertThat(socialCaptor.getValue().getProvider()).isEqualTo(OAuthProvider.NAVER);
+	}
+
+	@Test
+	void loginSkipsEmailLinkingWhenEmailMissing() {
+		// 이메일 미동의(null) 계정은 연동하지 않고 신규 생성
+		SocialAccountInfo accountInfo = new SocialAccountInfo(OAuthProvider.KAKAO, "k-null", null);
+
+		when(memberSocialRepository.findByProviderAndProviderId(OAuthProvider.KAKAO, "k-null"))
+				.thenReturn(Optional.empty());
+		when(nicknameGenerator.generate())
+				.thenReturn(new NicknameGenerator.GeneratedNickname("nar", "9999"));
+		when(memberRepository.save(any(Member.class))).thenAnswer(invocation -> {
+			Member saved = invocation.getArgument(0);
+			ReflectionTestUtils.setField(saved, "id", 31L);
+			return saved;
+		});
+		when(jwtTokenProvider.createAccessToken(31L, false, "USER")).thenReturn("a");
+		when(jwtTokenProvider.createRefreshToken(31L)).thenReturn("r");
+		when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(14));
+
+		socialLoginService.login(accountInfo);
+
+		verify(memberRepository, never()).findFirstByEmailOrderByIdAsc(any());
+		verify(memberRepository).save(any(Member.class));
+	}
+
+	@Test
 	void findAdminMemberReturnsAdmin() {
 		Member member = member("admin@example.com", 2L);
 		ReflectionTestUtils.setField(member, "role", MemberRole.ADMIN);

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 3, Title: 왜이렇게 많이 땄나요 !!
+[1] Vote: 6, Title: 왜이렇게 많이 땄나요 !!
 [2] Vote: 37, Title: MSI 대진표 나옴(일정은 추후 공지할 예정)
 [3] Vote: 24, Title: 슬슬 고소장 또 모으는 LCK
 [4] Vote: 3, Title: lck 3-파이널라운드 경기 일정
-[5] Vote: 24, Title: 어메이징 T1 서커스
+[5] Vote: 25, Title: 어메이징 T1 서커스
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 증바람 탱이 체력 2만인데 피바는 애 사는거임?
-[2] Vote: , Title: LOL MSI 배당 ★티원 약정배
-[3] Vote: , Title: 양탕국을 너무 마셔서 소피가 마렵다는데
-[4] Vote: , Title: 이사람 조심하세요
-[5] Vote: , Title: 변방 ㅈ밥팀 잡고 도란 폼 돌아왔다도르 짜치지않냐 ㅋㅋ
+[1] Vote: , Title: 헐 진짜 T1 사옥에 트럭 박았네
+[2] Vote: , Title: 유튜브 검색 마이크로 노래 흥얼거리면 찾아주네 ㄷㄷ
+[3] Vote: 추천 1, Title: 아오 도란좀냅둬라 시밸럼들아
+[4] Vote: , Title: 증바람 탱이 체력 2만인데 피바는 애 사는거임?
+[5] Vote: , Title: LOL MSI 배당 ★티원 약정배


### PR DESCRIPTION
## 문제
카카오로 가입한 유저가 같은 이메일의 네이버/구글로 로그인하면 별개 계정이 새로 생김 — 온보딩·즐겨찾기가 따로 놀고 유저는 같은 계정이라고 인식.

## 해결
`SocialLoginService.createMember` 에서 신규 생성 전에 같은 이메일의 기존 회원을 조회, 있으면 그 회원에 `MemberSocial`만 연동한다.

- 카카오/구글/네이버 모두 공급자가 검증한 이메일을 내려주므로 이메일 기준 연동은 계정 탈취 위험이 낮음
- 이메일 미동의(null) → 기존대로 신규 생성
- `findFirstByEmailOrderByIdAsc` 사용 — 혹시 이미 중복 이메일 계정이 있어도 예외 없이 가장 오래된 계정으로 연결

## 검증
- `SocialLoginServiceTest` 케이스 2개 추가 (연동 / 이메일 null 스킵)
- `./gradlew build` 전체 통과

## 배포 후 별도 작업
- prod에 이미 생성된 중복 계정(menten4859@naver.com 2건) 수동 정리 필요 — SQL 별도 전달

🤖 Generated with [Claude Code](https://claude.com/claude-code)