### PR TITLE
chore: 라이브 FCM 알림 활성화 (세트 시작/종료/라이브 이벤트)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,7 @@ jobs:
               -e CLOUDINARY_API_KEY="${{ secrets.CLOUDINARY_API_KEY }}" \
               -e CLOUDINARY_API_SECRET="${{ secrets.CLOUDINARY_API_SECRET }}" \
               -e FIREBASE_MESSAGING_ENABLED="true" \
+              -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               "${APP_IMAGE}"


### PR DESCRIPTION
## 변경
`deploy.yml`에 `LIVE_NOTIFICATION_FCM_ENABLED=true` 추가.

## 효과
라이브 3종 알림(세트 시작/세트 종료/라이브 이벤트)의 **서버 마스터 스위치**를 켠다. 코드는 이미 구현돼 있었고 flag만 OFF였다.

- 실제 발송은 유저별 팀 구독 토글로 결정: `setStartEnabled` / `setEndEnabled` / `liveEventEnabled` (`member_team_notification_subscription`)
- 유저가 토글을 켜지 않으면 발송되지 않음
- `FIREBASE_MESSAGING_ENABLED=true`, `GOOGLE_APPLICATION_CREDENTIALS`, APNs 키는 이미 설정 완료
- 선수 구독 알림은 이 flag와 무관하게 이미 활성

## 배포 후
다음 라이브 경기부터 구독 토글을 켠 유저에게 세트 시작/종료/이벤트 푸시가 발송된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)