### PR TITLE
chore: 라이브 알림 대상 리그에 MSI 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,7 @@ jobs:
               -e CLOUDINARY_API_SECRET="${{ secrets.CLOUDINARY_API_SECRET }}" \
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
+              -e LOLESPORTS_LIVE_NOTIFICATION_LEAGUES="LCK,MSI" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               "${APP_IMAGE}"


### PR DESCRIPTION
## 문제
라이브 3종 푸시(#234)가 켜졌지만 MSI 경기에서 알림이 오지 않았다. 원인은 `lolesports.live.notification.leagues` 기본값이 `LCK` 뿐이라 `isNotifiableLeague("MSI")` 가드에서 걸러진 것.

## 변경
`deploy.yml`에 `LOLESPORTS_LIVE_NOTIFICATION_LEAGUES="LCK,MSI"` 추가.

## 검증 근거
- 선수 구독 푸시는 정상 수신됨 → FCM/APNs/토큰 파이프라인 정상
- `MatchResultDto.leagueName` 은 슬러그 형태("LCK, LPL, WORLDS...")이고 fallback 도 active-leagues 슬러그라 "MSI" 문자열 매칭 성립

## 배포 후
다음 MSI 경기부터 팀 구독자에게 세트 시작/종료(기본 ON), 라이브 이벤트(토글 ON 시) 푸시 발송.

🤖 Generated with [Claude Code](https://claude.com/claude-code)