### PR TITLE
feat: 선수 Riot 계정 동기화 daily 스케줄러 추가

### DIFF
--- a/src/main/java/com/toy/nar/app/riot/PlayerRiotAccountSyncScheduler.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerRiotAccountSyncScheduler.java
@@ -1,0 +1,49 @@
+package com.toy.nar.app.riot;
+
+import com.toy.nar.app.monitor.SchedulerAlertService;
+import com.toy.nar.app.riot.dto.PlayerRiotAccountSyncResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlayerRiotAccountSyncScheduler {
+
+	private final PlayerRiotAccountSyncService playerRiotAccountSyncService;
+	private final RiotApiProperties riotApiProperties;
+	private final SchedulerAlertService schedulerAlertService;
+
+	// LCK 선수 주 계정 Riot 식별자(puuid/gameName) 동기화: 매일 새벽 6시(KST).
+	// 프로필 크롤러(05:30)가 gameAccounts 를 갱신한 직후 실행해, 선수가 솔랭 닉을
+	// 바꿔도 추적 테이블(player_riot_account)이 자동으로 따라가게 한다.
+	// (기존에는 수동 API 호출뿐이라 닉 변경 시 stale 계정으로 남는 문제가 있었다)
+	@Scheduled(cron = "${riot.account-sync.cron:0 0 6 * * *}", zone = "Asia/Seoul")
+	public void syncPrimaryRiotAccounts() {
+		if (!riotApiProperties.isEnabled()) {
+			log.info("Riot API disabled. Skipping scheduled riot account sync.");
+			return;
+		}
+		log.info("Starting scheduled riot primary account sync...");
+		long startTime = System.currentTimeMillis();
+		try {
+			PlayerRiotAccountSyncResult result = playerRiotAccountSyncService.syncPrimaryAccounts();
+			long elapsed = System.currentTimeMillis() - startTime;
+			schedulerAlertService.recordSuccess(
+					"PLAYER_RIOT_ACCOUNT_SYNC",
+					"LCK 선수 Riot 계정 동기화 (동기화 " + result.syncedCount() + "/" + result.totalPlayers()
+							+ ", 스킵 " + result.skippedPlayers() + ", 실패 " + result.failedPlayers() + ")",
+					elapsed);
+		} catch (Exception e) {
+			log.error("Scheduled riot account sync failed", e);
+			schedulerAlertService.recordFailure(
+					"PLAYER_RIOT_ACCOUNT_SYNC",
+					"LCK 선수 Riot 계정 동기화",
+					e,
+					"Riot by-riot-id 계정 동기화 중 오류");
+		}
+		log.info("Scheduled riot primary account sync completed.");
+	}
+}


### PR DESCRIPTION
## 문제
Zeka가 솔랭 닉을 `dlwlrma` → `suis#kr7` 로 바꿨는데 추적 테이블(`player_riot_account`)에 옛 계정이 남아 있었다.

- 원천(`player.gameAccounts`)은 TrackingThePros 크롤러가 **매일 05:30 자동 갱신** — 이미 최신이었음
- 그런데 Riot 식별자 동기화(`syncPrimaryAccounts`)는 **수동 API**(`POST /api/players/riot/sync-primary-accounts`)뿐이라 아무도 안 돌리면 stale

## 변경
- `PlayerRiotAccountSyncScheduler` 신설 — **매일 06:00 KST** (크롤러 05:30 직후) 자동 동기화
- `riot.api.enabled=false` 환경(dev)에서는 조용히 스킵
- `SchedulerAlertService` 성공/실패 기록 (기존 `PlayerProfileSyncScheduler` 패턴 동일)
- cron 은 `riot.account-sync.cron` 프로퍼티로 오버라이드 가능

## 참고
- prod 는 수동 sync 1회로 이미 정리됨 (82/84 성공, Zeka 갱신 확인)
- 실패 1건(Clear)은 별도 확인 필요 — riotId 형식 문제로 추정

## 검증
- `./gradlew compileJava` 통과
- 스케줄러 스레드풀(5개) 내 신규 cron 1개 추가 — 새벽 시간대 분산(04:15 팀메타 / 05:30 크롤러 / 06:00 본 건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)