### PR TITLE
feat: 라이브 중계 채널 다중 링크(치지직/SOOP 선택)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -65,4 +65,47 @@ public final class LeagueConstants {
         }
         return LIVE_STREAM_URLS.getOrDefault(leagueName.toUpperCase(), DEFAULT_STREAM_URL);
     }
+
+    /**
+     * 라이브 중계 채널 링크. 앱에서 유저가 플랫폼을 골라 시청할 수 있게 리그당 여러 개를 내려준다.
+     */
+    public record StreamLink(String provider, String label, String description, String url) {
+    }
+
+    /** 치지직 LCK 공식 채널 — 2026~ 네이버가 LCK·글로벌 대회 한국어 중계권 보유. */
+    private static final StreamLink CHZZK_LCK = new StreamLink(
+            "chzzk", "치지직", "LCK 공식 채널 · 한국어",
+            "https://chzzk.naver.com/9381e7d6816e6d915a44a13c0195b202");
+
+    /** SOOP(아프리카TV) 공식 롤 중계 채널. */
+    private static final StreamLink SOOP_AFLOL = new StreamLink(
+            "soop", "SOOP", "aflol · 한국어",
+            "https://play.sooplive.co.kr/aflol");
+
+    private static final StreamLink CHZZK_LPL = new StreamLink(
+            "chzzk", "치지직", "LPL 한국어 중계",
+            "https://chzzk.naver.com/live/92b762ef6fac0cc8c68bc080868ad582");
+
+    /**
+     * 리그별 중계 채널 목록. 한국어 중계가 복수인 리그(LCK·국제전)는 치지직/SOOP 둘 다 내려주고,
+     * 그 외 리그는 기존 단일 링크를 유지한다.
+     */
+    public static final Map<String, List<StreamLink>> STREAM_LINKS = Map.of(
+            "LCK", List.of(CHZZK_LCK, SOOP_AFLOL),
+            "MSI", List.of(CHZZK_LCK, SOOP_AFLOL),
+            "WORLDS", List.of(CHZZK_LCK, SOOP_AFLOL),
+            "FIRST_STAND", List.of(CHZZK_LCK, SOOP_AFLOL),
+            "LPL", List.of(CHZZK_LPL),
+            "LEC", List.of(new StreamLink("twitch", "Twitch", "LEC 공식", "https://www.twitch.tv/lec")),
+            "LCS", List.of(new StreamLink("twitch", "Twitch", "LCS 공식", "https://www.twitch.tv/lcs")));
+
+    /**
+     * 리그의 중계 채널 목록 반환. 매핑이 없으면 SOOP 단일 링크로 폴백.
+     */
+    public static List<StreamLink> getStreamLinks(String leagueName) {
+        if (leagueName == null) {
+            return List.of(SOOP_AFLOL);
+        }
+        return STREAM_LINKS.getOrDefault(leagueName.toUpperCase(), List.of(SOOP_AFLOL));
+    }
 }

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -310,6 +310,7 @@ public class MobileScheduleService {
 						match.getRedTeamImageUrl(),
 						match.getRedScore()),
 				liveStreamUrl(match),
+				streamLinks(match),
 				gamesByMatchId.getOrDefault(match.getId(), List.of()));
 	}
 
@@ -435,10 +436,24 @@ public class MobileScheduleService {
 	}
 
 	private String liveStreamUrl(LeagueMatch match) {
+		// 하위호환: 구버전 앱이 쓰는 단일 링크. streamLinks 의 첫 번째(대표 채널)와 동일하게 유지한다.
 		if ("inProgress".equalsIgnoreCase(match.getState())) {
-			return LeagueConstants.getLiveStreamUrl(match.getLeagueName());
+			return LeagueConstants.getStreamLinks(match.getLeagueName()).get(0).url();
 		}
 		return null;
+	}
+
+	/**
+	 * 라이브 중계 채널 목록. 진행 중 경기에서만 채워지고, 복수면 앱이 선택 시트를 띄운다.
+	 */
+	private List<MobileScheduleListResponse.MobileStreamLink> streamLinks(LeagueMatch match) {
+		if (!"inProgress".equalsIgnoreCase(match.getState())) {
+			return List.of();
+		}
+		return LeagueConstants.getStreamLinks(match.getLeagueName()).stream()
+				.map(link -> new MobileScheduleListResponse.MobileStreamLink(
+						link.provider(), link.label(), link.description(), link.url()))
+				.toList();
 	}
 
 	private String toScheduledTime(LeagueMatch match) {

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
@@ -21,8 +21,22 @@ public record MobileScheduleListResponse(
 			MobileTeamResult blueTeam,
 			MobileTeamResult redTeam,
 			String liveStreamUrl,
+			@Schema(description = "라이브 중계 채널 목록. 진행 중 경기에서만 채워지며, 복수면 앱이 선택 시트를 띄운다. "
+					+ "liveStreamUrl 은 하위호환용(첫 번째 링크와 동일)")
+			List<MobileStreamLink> streamLinks,
 			@Schema(description = "매치에 속한 세트(게임) 목록. 아직 세트가 생성되지 않은 매치는 빈 배열")
 			List<MobileGameSummary> games) {
+	}
+
+	public record MobileStreamLink(
+			@Schema(description = "플랫폼 식별자", example = "chzzk")
+			String provider,
+			@Schema(description = "표시 이름", example = "치지직")
+			String label,
+			@Schema(description = "부가 설명", example = "LCK 공식 채널 · 한국어")
+			String description,
+			@Schema(description = "중계 URL", example = "https://chzzk.naver.com/9381e7d6816e6d915a44a13c0195b202")
+			String url) {
 	}
 
 	public record MobileGameSummary(

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -49,6 +49,7 @@ class MobileMatchControllerTest {
 								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 2),
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 1),
 								null,
+								List.of(),
 								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, "ENDED", null)))),
 						"cursor-token",
 						true));

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -105,6 +105,7 @@ class MobileScheduleControllerTest {
 								new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 0),
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 0),
 								null,
+								List.of(),
 								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, null, null))))));
 
 		mockMvc.perform(get("/api/mobile/schedules")

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -131,7 +131,13 @@ class MobileScheduleServiceTest {
 					assertThat(match.matchStatus()).isEqualTo("inProgress");
 					assertThat(match.blueTeam().teamName()).isEqualTo("T1");
 					assertThat(match.redTeam().teamName()).isEqualTo("Gen.g");
-					assertThat(match.liveStreamUrl()).isEqualTo("https://play.sooplive.co.kr/aflol");
+					// 대표 링크는 streamLinks 첫 번째(치지직 LCK 공식)와 동일해야 한다.
+					assertThat(match.liveStreamUrl())
+							.isEqualTo("https://chzzk.naver.com/9381e7d6816e6d915a44a13c0195b202");
+					assertThat(match.streamLinks()).hasSize(2);
+					assertThat(match.streamLinks().get(0).provider()).isEqualTo("chzzk");
+					assertThat(match.streamLinks().get(1).provider()).isEqualTo("soop");
+					assertThat(match.liveStreamUrl()).isEqualTo(match.streamLinks().get(0).url());
 				});
 	}
 

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 6, Title: 왜이렇게 많이 땄나요 !!
-[2] Vote: 37, Title: MSI 대진표 나옴(일정은 추후 공지할 예정)
-[3] Vote: 24, Title: 슬슬 고소장 또 모으는 LCK
-[4] Vote: 3, Title: lck 3-파이널라운드 경기 일정
-[5] Vote: 25, Title: 어메이징 T1 서커스
+[1] Vote: 3, Title: 푼 ㅈㄴ 잘하네ㅋㅋㅋㅋㅋㅋㅋ
+[2] Vote: 3, Title: TES는 상대가 세트 픽하면 필패냐?
+[3] Vote: 23, Title: 오늘 티원 밴픽 요약
+[4] Vote: 17, Title: 대대대 개빡쳐서 스테프한테 항의했다네
+[5] Vote: 2, Title: 문도 누가 잡냐
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 헐 진짜 T1 사옥에 트럭 박았네
-[2] Vote: , Title: 유튜브 검색 마이크로 노래 흥얼거리면 찾아주네 ㄷㄷ
-[3] Vote: 추천 1, Title: 아오 도란좀냅둬라 시밸럼들아
-[4] Vote: , Title: 증바람 탱이 체력 2만인데 피바는 애 사는거임?
-[5] Vote: , Title: LOL MSI 배당 ★티원 약정배
+[1] Vote: , Title: 한화가 3대1 정도로 이길것같음
+[2] Vote: 추천 1, Title: 어제 티원보다 욕더처먹겠네
+[3] Vote: , Title: 테스야 여론 잠잠해질 때 까지 잠깐 잠적하자
+[4] Vote: , Title: 비원딜 카운터 문도는 진국이긴하네
+[5] Vote: , Title: 작년 롤드컵 이후 롤 안봤는데 요새 미드라이너들 폼 어떰?


### PR DESCRIPTION
## 배경
중계 링크가 리그당 1개(정적 맵)라 LCK/MSI 는 SOOP 로만 열렸다. 치지직이 2026~ LCK·국제전 한국어 중계권을 보유하므로, 완전 교체 대신 **앱에서 유저가 플랫폼을 고르는 방식**으로 간다. (LoL Esports API 는 ko-KR 스트림으로 SOOP 만 내려줘 API 기반 자동은 불가 — 정적 매핑)

## 변경
- `LeagueConstants.STREAM_LINKS` — 리그별 중계 채널 목록
  - LCK/MSI/WORLDS/FIRST_STAND: **치지직(LCK 공식) + SOOP(aflol)** 2개
  - LPL(치지직)/LEC/LCS(트위치): 기존 단일 유지, 미매핑 리그는 SOOP 폴백
- `MobileMatchSummary.streamLinks[]` 추가 (`provider/label/description/url`), 진행 중 경기에서만 채움
- `liveStreamUrl` 하위호환 유지 — 단 streamLinks 첫 번째(대표)와 동일하게 통일되어 **LCK 계열 대표 링크가 SOOP → 치지직으로 변경**

## 클라이언트 (후속 PR, warding-mobile-repo)
경기 상세 '중계 보기' 탭 시 streamLinks 가 2개 이상이면 선택 바텀시트, 1개면 바로 열기.
목업: A안(바텀시트) 확정.

## 검증
- `./gradlew build` 통과 (테스트 기대값 갱신: LCK 대표 링크 치지직 + streamLinks 2건 검증 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)