### PR TITLE
fix: 세트 종료 푸시 반복 발송 (dedup found-rows 결함 + 1회 가드)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -51,6 +51,13 @@ public class LivePollingScheduler {
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.stale-threshold-ms:180000}")
 	private long staleThresholdMs;
 
+	/**
+	 * SET_END 푸시를 이미 보낸 gameId. notDiscovered 는 stale 제거 전까지 매 사이클 참이라
+	 * 여기서 1회로 제한한다(같은 세트 종료 반복 발송 방지). 게임이 피드에 다시 나타나면
+	 * 오탐(일시 누락)으로 보고 해제한다.
+	 */
+	private final java.util.Set<String> setEndNotifiedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.max-consecutive-failures:6}")
 	private int maxConsecutiveFailures;
 
@@ -122,6 +129,8 @@ public class LivePollingScheduler {
 								blueExternalId,
 								redExternalId);
 						activeGames.put(gameId, next);
+						// 피드에 다시 나타났으면 SET_END 오탐(일시 누락)이었으므로 재발송 가능하게 해제.
+						setEndNotifiedGameIds.remove(gameId);
 						liveGameMetadataService.remember(next);
 
 						if (liveNotificationEnabled && current == null && isNotifiableLeague(resolvedLeagueName)) {
@@ -169,7 +178,8 @@ public class LivePollingScheduler {
 			// 빠지면(=notDiscovered) 세트 종료로 본다. 플래그 게이트 + dedup 으로 1회만 발송된다.
 			// 플래그가 꺼져 있으면 어떤 부작용도 없다(기존 cleanup 동작과 바이트 동일).
 			if (notDiscovered && teamLiveEventPushService.isEnabled()
-					&& isNotifiableLeague(activeGame.leagueName())) {
+					&& isNotifiableLeague(activeGame.leagueName())
+					&& setEndNotifiedGameIds.add(activeGame.gameId())) {
 				fireSetEndNotification(activeGame);
 			}
 
@@ -181,6 +191,7 @@ public class LivePollingScheduler {
 		toRemove.forEach(gameId -> {
 			liveStateStore.removeGame(gameId);
 			liveObjectEventRecorder.evict(gameId);
+			setEndNotifiedGameIds.remove(gameId);
 		});
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -86,7 +86,7 @@ public class PlayerSoloRankPushService {
 			String gameId,
 			MobilePushMessage message) {
 		try {
-			if (deliveryRepository.reserve(memberId, player.getId(), gameId) == 0) {
+			if (!deliveryRepository.reserve(memberId, player.getId(), gameId)) {
 				return;
 			}
 			List<String> tokens = devices.stream().map(MemberDevice::getFcmToken).toList();

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -160,7 +160,7 @@ public class TeamLiveEventPushService {
 			MobilePushMessage message) {
 		try {
 			// dedup: 양 팀 구독자라도 (member, matchId, setNumber, eventType, eventOrder) 1회만 통과한다.
-			if (deliveryRepository.reserve(memberId, matchId, setNumber, eventType, eventOrder) == 0) {
+			if (!deliveryRepository.reserve(memberId, matchId, setNumber, eventType, eventOrder)) {
 				return;
 			}
 			List<String> tokens = devices.stream().map(MemberDevice::getFcmToken).toList();

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
@@ -15,54 +15,62 @@ import org.springframework.transaction.annotation.Transactional;
 public interface MemberTeamEventPushDeliveryRepository
 		extends JpaRepository<MemberTeamEventPushDelivery, Long> {
 
+	/*
+	 * [중복 발송 버그 수정] 기존 reserve 는 INSERT ... ON DUPLICATE KEY UPDATE + IF 패턴으로
+	 * "변경된 행 수 0 = 이미 처리됨"을 판정했다. 그러나 MySQL Connector/J 기본 설정
+	 * (CLIENT_FOUND_ROWS)에서는 값이 바뀌지 않은 duplicate 도 0이 아닌 값을 반환해
+	 * 이미 SENT 인 건이 매번 dedup 을 통과했다(세트 종료 알림 반복 발송의 원인).
+	 * 아래처럼 INSERT IGNORE(신규)와 WHERE 조건 UPDATE(재예약)로 분리하면
+	 * found-rows 모드에서도 반환값이 정확하다 — WHERE 가 대상 행을 필터하기 때문.
+	 */
+
+	/** 신규 예약. 이미 같은 키가 있으면 0. */
 	@Modifying
 	@Transactional
 	@Query(value = """
 			INSERT IGNORE INTO member_team_event_push_delivery (
-				member_id,
-				match_id,
-				set_number,
-				event_type,
-				event_order,
-				status,
-				created_at,
-				updated_at
+				member_id, match_id, set_number, event_type, event_order,
+				status, created_at, updated_at
 			) VALUES (
-				:memberId,
-				:matchId,
-				:setNumber,
-				:eventType,
-				:eventOrder,
-				'PENDING',
-				NOW(),
-				NOW()
+				:memberId, :matchId, :setNumber, :eventType, :eventOrder,
+				'PENDING', NOW(), NOW()
 			)
-			ON DUPLICATE KEY UPDATE
-				error_message = IF(
-					status = 'FAILED'
-						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
-					NULL,
-					error_message
-				),
-				updated_at = IF(
-					status = 'FAILED'
-						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
-					NOW(),
-					updated_at
-				),
-				status = IF(
-					status = 'FAILED'
-						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
-					'PENDING',
-					status
-				)
 			""", nativeQuery = true)
-	int reserve(
+	int insertIfAbsent(
 			@Param("memberId") Long memberId,
 			@Param("matchId") String matchId,
 			@Param("setNumber") int setNumber,
 			@Param("eventType") String eventType,
 			@Param("eventOrder") long eventOrder);
+
+	/** 재예약. 실패했거나 5분 넘게 PENDING 으로 방치된 건만 되살린다. SENT 는 절대 재예약되지 않는다. */
+	@Modifying
+	@Transactional
+	@Query(value = """
+			UPDATE member_team_event_push_delivery
+			SET status = 'PENDING', error_message = NULL, updated_at = NOW()
+			WHERE member_id = :memberId
+			  AND match_id = :matchId
+			  AND set_number = :setNumber
+			  AND event_type = :eventType
+			  AND event_order = :eventOrder
+			  AND (status = 'FAILED'
+					OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)))
+			""", nativeQuery = true)
+	int reactivateStale(
+			@Param("memberId") Long memberId,
+			@Param("matchId") String matchId,
+			@Param("setNumber") int setNumber,
+			@Param("eventType") String eventType,
+			@Param("eventOrder") long eventOrder);
+
+	/** 발송 예약. 신규이거나 재시도 대상일 때만 true. */
+	default boolean reserve(Long memberId, String matchId, int setNumber, String eventType, long eventOrder) {
+		if (insertIfAbsent(memberId, matchId, setNumber, eventType, eventOrder) > 0) {
+			return true;
+		}
+		return reactivateStale(memberId, matchId, setNumber, eventType, eventOrder) > 0;
+	}
 
 	@Modifying
 	@Transactional

--- a/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepository.java
@@ -10,48 +10,52 @@ import org.springframework.transaction.annotation.Transactional;
 public interface PlayerSoloRankPushDeliveryRepository
 		extends JpaRepository<PlayerSoloRankPushDelivery, Long> {
 
+/*
+	 * [중복 발송 버그 수정] 기존 reserve 는 ON DUPLICATE KEY UPDATE + IF 패턴이라
+	 * MySQL CLIENT_FOUND_ROWS(커넥터 기본) 모드에서 이미 SENT 인 건도 0이 아닌 값을
+	 * 반환해 dedup 이 무력화됐다. INSERT IGNORE(신규) + WHERE 조건 UPDATE(재예약)로
+	 * 분리해 found-rows 모드에서도 정확하게 동작한다.
+	 */
+
+	/** 신규 예약. 이미 같은 키가 있으면 0. */
 	@Modifying
 	@Transactional
 	@Query(value = """
 			INSERT IGNORE INTO player_solo_rank_push_delivery (
-				member_id,
-				player_id,
-				game_id,
-				status,
-				created_at,
-				updated_at
+				member_id, player_id, game_id, status, created_at, updated_at
 			) VALUES (
-				:memberId,
-				:playerId,
-				:gameId,
-				'PENDING',
-				NOW(),
-				NOW()
+				:memberId, :playerId, :gameId, 'PENDING', NOW(), NOW()
 			)
-			ON DUPLICATE KEY UPDATE
-				error_message = IF(
-					status = 'FAILED'
-						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
-					NULL,
-					error_message
-				),
-				updated_at = IF(
-					status = 'FAILED'
-						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
-					NOW(),
-					updated_at
-				),
-				status = IF(
-					status = 'FAILED'
-						OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)),
-					'PENDING',
-					status
-				)
 			""", nativeQuery = true)
-	int reserve(
+	int insertIfAbsent(
 			@Param("memberId") Long memberId,
 			@Param("playerId") Long playerId,
 			@Param("gameId") String gameId);
+
+	/** 재예약. 실패했거나 5분 넘게 PENDING 으로 방치된 건만 되살린다. SENT 는 재예약되지 않는다. */
+	@Modifying
+	@Transactional
+	@Query(value = """
+			UPDATE player_solo_rank_push_delivery
+			SET status = 'PENDING', error_message = NULL, updated_at = NOW()
+			WHERE member_id = :memberId
+			  AND player_id = :playerId
+			  AND game_id = :gameId
+			  AND (status = 'FAILED'
+					OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)))
+			""", nativeQuery = true)
+	int reactivateStale(
+			@Param("memberId") Long memberId,
+			@Param("playerId") Long playerId,
+			@Param("gameId") String gameId);
+
+	/** 발송 예약. 신규이거나 재시도 대상일 때만 true. */
+	default boolean reserve(Long memberId, Long playerId, String gameId) {
+		if (insertIfAbsent(memberId, playerId, gameId) > 0) {
+			return true;
+		}
+		return reactivateStale(memberId, playerId, gameId) > 0;
+	}
 
 	@Modifying
 	@Transactional

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
@@ -59,7 +59,7 @@ class PlayerSoloRankPushServiceTest {
 
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L))
 				.thenReturn(List.of(first, second));
-		when(deliveryRepository.reserve(any(), eq(10L), eq("game-1"))).thenReturn(1);
+		when(deliveryRepository.reserve(any(), eq(10L), eq("game-1"))).thenReturn(true);
 		when(pushGateway.send(any(), any()))
 				.thenReturn(new MobilePushResult(1, 0, List.of()))
 				.thenReturn(new MobilePushResult(0, 1, List.of("token-2")));
@@ -86,7 +86,7 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		MemberDevice device = device(1L, member(7L), "token");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
-		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(1);
+		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(true);
 		when(pushGateway.send(any(), any())).thenReturn(new MobilePushResult(1, 0, List.of()));
 		doThrow(new IllegalStateException("topic down"))
 				.when(pushGateway).sendToTopic(any(), any());
@@ -101,7 +101,7 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		MemberDevice device = device(1L, member(7L), "token");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
-		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(0);
+		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(false);
 
 		service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1");
 
@@ -113,7 +113,7 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		MemberDevice device = device(1L, member(7L), "token");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
-		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(1);
+		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(true);
 		when(pushGateway.send(any(), any())).thenThrow(new IllegalStateException("firebase down"));
 
 		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1"))

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 3, Title: 푼 ㅈㄴ 잘하네ㅋㅋㅋㅋㅋㅋㅋ
-[2] Vote: 3, Title: TES는 상대가 세트 픽하면 필패냐?
-[3] Vote: 23, Title: 오늘 티원 밴픽 요약
-[4] Vote: 17, Title: 대대대 개빡쳐서 스테프한테 항의했다네
-[5] Vote: 2, Title: 문도 누가 잡냐
+[1] Vote: 3, Title: 문도 누가 잡냐
+[2] Vote: 3, Title: 푼 ㅈㄴ 잘하네ㅋㅋㅋㅋㅋㅋㅋ
+[3] Vote: 3, Title: TES는 상대가 세트 픽하면 필패냐?
+[4] Vote: 23, Title: 오늘 티원 밴픽 요약
+[5] Vote: 17, Title: 대대대 개빡쳐서 스테프한테 항의했다네
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 한화가 3대1 정도로 이길것같음
-[2] Vote: 추천 1, Title: 어제 티원보다 욕더처먹겠네
-[3] Vote: , Title: 테스야 여론 잠잠해질 때 까지 잠깐 잠적하자
-[4] Vote: , Title: 비원딜 카운터 문도는 진국이긴하네
-[5] Vote: , Title: 작년 롤드컵 이후 롤 안봤는데 요새 미드라이너들 폼 어떰?
+[1] Vote: , Title: 제카 진짜개 쩐다 요네,사일 ㅋㅋㅋ
+[2] Vote: , Title: 워윅이랑 야스오를 다뽑네 ㅎ
+[3] Vote: , Title: 브브야 이래 된거 리븐 가자
+[4] Vote: , Title: 지투 계속 깜짝깜짝 놀라게 하네 밴픽에서
+[5] Vote: , Title: 오늘 BB는 즐겜이네.


### PR DESCRIPTION
## 증상
같은 세트의 SET_END 푸시가 반복 발송됨 (유저 알림함에 동일 세트 종료 다수).

## 원인
**1. dedup 무력화 — MySQL found-rows 함정**
`reserve` 가 `INSERT ... ON DUPLICATE KEY UPDATE + IF` 패턴으로 "affected rows 0 = 이미 처리"를 판정. 그러나 Connector/J 기본(`useAffectedRows=false` → CLIENT_FOUND_ROWS)에서는 **값이 안 바뀐 duplicate 도 0이 아닌 값**을 반환 → 이미 SENT 인 건이 매번 통과.

**2. 반복 호출 구조**
SET_END 는 `notDiscovered` 가 stale 제거(3분)까지 매 discovery(10초)마다 참 → 세트 종료 후 3분간 ~18회 발송 시도. dedup 이 뚫린 상태라 그대로 다 나감.

(SET_START/라이브 이벤트는 1회 호출 구조라 증상이 없었지만 dedup 결함은 공유 — 함께 수리)

## 수정
- `reserve` → `insertIfAbsent`(INSERT IGNORE) + `reactivateStale`(WHERE 조건 UPDATE) 분리, default 메서드로 boolean 조합. WHERE 필터라 found-rows 모드에서도 정확
- `PlayerSoloRankPushDeliveryRepository` 동일 패턴 함께 수정
- `LivePollingScheduler`: `setEndNotifiedGameIds` 로 SET_END 발송 1회 제한, 피드 재등장 시(오탐) 해제, stale 제거 시 정리

## 검증
- `./gradlew build` 전체 통과 (테스트 스텁 int→boolean 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)