### PR TITLE
feat: 모바일 매치 단건 조회 API (알림 딥링크용)

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
+++ b/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
@@ -3,6 +3,7 @@ package com.toy.nar.api.mobile.match;
 import com.toy.nar.app.mobile.schedule.MobileScheduleService;
 import com.toy.nar.app.mobile.schedule.dto.MobileMatchGamesResponse;
 import com.toy.nar.app.mobile.schedule.dto.MobileMatchPageResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,6 +44,17 @@ public class MobileMatchController {
 			@Parameter(description = "페이지 크기(1~50)", example = "20")
 			@RequestParam(defaultValue = "20") Integer size) {
 		return ResponseEntity.ok(mobileScheduleService.getMatchPage(league, teamId, seasonYear, split, cursor, size));
+	}
+
+	@Operation(
+			summary = "매치 단건 조회",
+			description = "matchId로 경기 한 건을 조회합니다. 응답은 /api/mobile/schedules 의 "
+					+ "matches 배열 항목과 동일한 형태입니다. 푸시 알림 딥링크 진입 시 경기 정보를 채우는 용도입니다.")
+	@GetMapping("/{matchId}")
+	public ResponseEntity<MobileScheduleListResponse.MobileMatchSummary> getMatch(
+			@Parameter(description = "매치 ID", example = "113990000000000001")
+			@PathVariable String matchId) {
+		return ResponseEntity.ok(mobileScheduleService.getMatch(matchId));
 	}
 
 	@Operation(

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -186,6 +186,16 @@ public class MobileScheduleService {
 		return new MobileMatchPageResponse(normalizedLeague, teamId, matches, nextCursor, nextCursor != null);
 	}
 
+	/**
+	 * 매치 단건 조회. 푸시 알림 딥링크처럼 matchId 만 알고 진입하는 화면이
+	 * 리스트 응답과 동일한 형태(MobileMatchSummary)로 경기 정보를 채울 때 쓴다.
+	 */
+	public MobileScheduleListResponse.MobileMatchSummary getMatch(String matchId) {
+		LeagueMatch match = leagueMatchRepository.findById(matchId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+		return toMatchSummary(match, loadGames(List.of(match)));
+	}
+
 	public MobileMatchGamesResponse getMatchGames(String matchId) {
 		LeagueMatch match = leagueMatchRepository.findById(matchId)
 				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -34,6 +34,32 @@ class MobileMatchControllerTest {
 	}
 
 	@Test
+	void getMatchReturnsSingleMatchSummary() throws Exception {
+		when(mobileScheduleService.getMatch("match-1"))
+				.thenReturn(new MobileScheduleListResponse.MobileMatchSummary(
+						"match-1",
+						"2026-07-06",
+						"17:00",
+						"inProgress",
+						"T1 vs FUR",
+						"MSI",
+						new MobileScheduleListResponse.MobileTeamResult("T1", "T1", "https://example.com/t1.png", 1),
+						new MobileScheduleListResponse.MobileTeamResult("Furia", "FUR", "https://example.com/fur.png", 0),
+						"https://chzzk.naver.com/abc",
+						List.of(new MobileScheduleListResponse.MobileStreamLink(
+								"chzzk", "치지직", "LCK 공식 채널 · 한국어", "https://chzzk.naver.com/abc")),
+						List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", null, "LIVE", null))));
+
+		mockMvc.perform(get("/api/mobile/matches/match-1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.matchId").value("match-1"))
+				.andExpect(jsonPath("$.matchStatus").value("inProgress"))
+				.andExpect(jsonPath("$.blueTeam.teamName").value("T1"))
+				.andExpect(jsonPath("$.blueTeam.score").value(1))
+				.andExpect(jsonPath("$.streamLinks[0].provider").value("chzzk"));
+	}
+
+	@Test
 	void getMatchesReturnsCursorPageShape() throws Exception {
 		when(mobileScheduleService.getMatchPage("LCK", null, null, null, null, 20))
 				.thenReturn(new MobileMatchPageResponse(

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 3, Title: 문도 누가 잡냐
-[2] Vote: 3, Title: 푼 ㅈㄴ 잘하네ㅋㅋㅋㅋㅋㅋㅋ
-[3] Vote: 3, Title: TES는 상대가 세트 픽하면 필패냐?
-[4] Vote: 23, Title: 오늘 티원 밴픽 요약
-[5] Vote: 17, Title: 대대대 개빡쳐서 스테프한테 항의했다네
+[1] Vote: 5, Title: 프로 챔피언 티어리스트
+[2] Vote: 2, Title: ??? : 케틀 잡았다!(넥서스가 부숴지며)
+[3] Vote: 2, Title: 티원 조합 뭐여?
+[4] Vote: 1, Title: 지금상태로 티원은 우승 못함
+[5] Vote: 2, Title: 난 도란의 고점 시절은 오히려 kt때 같음
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 제카 진짜개 쩐다 요네,사일 ㅋㅋㅋ
-[2] Vote: , Title: 워윅이랑 야스오를 다뽑네 ㅎ
-[3] Vote: , Title: 브브야 이래 된거 리븐 가자
-[4] Vote: , Title: 지투 계속 깜짝깜짝 놀라게 하네 밴픽에서
-[5] Vote: , Title: 오늘 BB는 즐겜이네.
+[1] Vote: , Title: 근데 헬리오스 오늘은 좀 괜찮네.
+[2] Vote: , Title: 근데 여자아이돌 av야동배우 닉 다 이해가 가는데
+[3] Vote: , Title: 아무리 생각해도 밴픽 순서가 이상하긴 해
+[4] Vote: , Title: 카나비와 오너의차이점
+[5] Vote: , Title: 자기 닉을 여자 아이돌 이름으로 하는건 뭔심리일까


### PR DESCRIPTION
## 배경
푸시 알림(세트 시작 등)을 탭하면 matchId 만 갖고 경기 상세로 진입하는데, 경기 정보를 채울 단건 API 가 없어 헤더(팀 로고/이름/스코어/상태)가 빈 채로 렌더됐다. 리스트 경유 진입은 match 객체를 통째로 넘겨받아 정상.

## 변경
`GET /api/mobile/matches/{matchId}` 추가.

- 응답: `/api/mobile/schedules` 의 `matches[]` 항목(`MobileMatchSummary`)과 동일 — `streamLinks`, `games` 포함
- 없는 matchId → `DATA_NOT_FOUND`
- 인증 불필요 (기존 모바일 조회 API 와 동일)
- 기존 `toMatchSummary`/`loadGames` 재사용 — 서비스 메서드 1개 + 컨트롤러 엔드포인트 1개

## 클라이언트 (모바일)
알림 딥링크 핸들러에서 이 API 로 match 를 채워 경기 상세를 열면 됨.

## 검증
- `./gradlew build` 전체 통과 (컨트롤러 단건 테스트 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)