### PR TITLE
feat: 라이브 푸시 문구 개선 (선수명·양팀 카운트·매치 스코어)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,13 +77,18 @@ public class LiveObjectEventRecorder {
 				continue;
 			}
 			if (previous != null) {
-				recordObjectDiff(activeGame, "Blue", previous.blue(), snapshot.blue(), snapshot.frameTimestampUtc());
-				recordObjectDiff(activeGame, "Red", previous.red(), snapshot.red(), snapshot.frameTimestampUtc());
+				int gameTotalPrevKills = previous.blue().kills() + previous.red().kills();
+				recordObjectDiff(activeGame, "Blue", previous.blue(), snapshot.blue(), snapshot.red(),
+						snapshot.frameTimestampUtc());
+				recordObjectDiff(activeGame, "Red", previous.red(), snapshot.red(), snapshot.blue(),
+						snapshot.frameTimestampUtc());
 				recordKills(activeGame, "Blue", previous.blue().kills(), snapshot.blue().kills(),
+						snapshot.red().kills(), gameTotalPrevKills,
 						previous.blueParticipants(), snapshot.blueParticipants(),
 						previous.redParticipants(), snapshot.redParticipants(),
 						metadata, snapshot.frameTimestampUtc());
 				recordKills(activeGame, "Red", previous.red().kills(), snapshot.red().kills(),
+						snapshot.blue().kills(), gameTotalPrevKills,
 						previous.redParticipants(), snapshot.redParticipants(),
 						previous.blueParticipants(), snapshot.blueParticipants(),
 						metadata, snapshot.frameTimestampUtc());
@@ -118,12 +124,16 @@ public class LiveObjectEventRecorder {
 			String teamSide,
 			TeamObjectState previous,
 			TeamObjectState current,
+			TeamObjectState opponentCurrent,
 			LocalDateTime frameTimestampUtc) {
-		recordCounterEvents(activeGame, teamSide, EVENT_TOWER, previous.towers(), current.towers(), frameTimestampUtc);
-		recordCounterEvents(activeGame, teamSide, EVENT_BARON, previous.barons(), current.barons(), frameTimestampUtc);
+		recordCounterEvents(activeGame, teamSide, EVENT_TOWER, previous.towers(), current.towers(),
+				opponentCurrent.towers(), frameTimestampUtc);
+		recordCounterEvents(activeGame, teamSide, EVENT_BARON, previous.barons(), current.barons(),
+				opponentCurrent.barons(), frameTimestampUtc);
 		recordCounterEvents(activeGame, teamSide, EVENT_INHIBITOR, previous.inhibitors(), current.inhibitors(),
-				frameTimestampUtc);
-		recordDragonEvents(activeGame, teamSide, previous.dragons(), current.dragons(), frameTimestampUtc);
+				opponentCurrent.inhibitors(), frameTimestampUtc);
+		recordDragonEvents(activeGame, teamSide, previous.dragons(), current.dragons(),
+				opponentCurrent.dragons().size(), frameTimestampUtc);
 	}
 
 	/**
@@ -136,6 +146,8 @@ public class LiveObjectEventRecorder {
 			String killerSide,
 			int previousTeamKills,
 			int currentTeamKills,
+			int opponentCurrentKills,
+			int gameTotalPrevKills,
 			Map<Integer, Kd> killerPrevKd,
 			Map<Integer, Kd> killerCurKd,
 			Map<Integer, Kd> victimPrevKd,
@@ -154,8 +166,10 @@ public class LiveObjectEventRecorder {
 			int order = previousTeamKills + 1 + i;
 			Integer killerId = i < killers.size() ? killers.get(i) : null;
 			Integer victimId = i < victims.size() ? victims.get(i) : null;
-			saveKillEventIfAbsent(activeGame, killerSide, order, currentTeamKills, killerId, victimId, metadata,
-					frameTimestampUtc);
+			// 선취점: 이 프레임 이전까지 양팀 킬 합이 0이고, 이 팀의 첫 킬일 때.
+			boolean firstBlood = gameTotalPrevKills == 0 && order == 1 && i == 0;
+			saveKillEventIfAbsent(activeGame, killerSide, order, currentTeamKills, opponentCurrentKills,
+					firstBlood, killerId, victimId, metadata, frameTimestampUtc);
 		}
 	}
 
@@ -165,6 +179,7 @@ public class LiveObjectEventRecorder {
 			String eventType,
 			int previousValue,
 			int currentValue,
+			int opponentCurrentValue,
 			LocalDateTime frameTimestampUtc) {
 		if (currentValue <= previousValue) {
 			return;
@@ -178,6 +193,7 @@ public class LiveObjectEventRecorder {
 					null,
 					order,
 					order,
+					opponentCurrentValue,
 					frameTimestampUtc);
 		}
 	}
@@ -187,6 +203,7 @@ public class LiveObjectEventRecorder {
 			String teamSide,
 			List<String> previousDragons,
 			List<String> currentDragons,
+			int opponentDragonCount,
 			LocalDateTime frameTimestampUtc) {
 		if (currentDragons.size() <= previousDragons.size()) {
 			return;
@@ -201,6 +218,7 @@ public class LiveObjectEventRecorder {
 					dragonType,
 					index + 1,
 					index + 1,
+					opponentDragonCount,
 					frameTimestampUtc);
 		}
 	}
@@ -212,6 +230,7 @@ public class LiveObjectEventRecorder {
 			String eventSubType,
 			int eventOrder,
 			int valueAfter,
+			int opponentCurrentValue,
 			LocalDateTime frameTimestampUtc) {
 		boolean exists = objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
 				activeGame.gameId(), teamSide, eventType, eventOrder);
@@ -247,7 +266,10 @@ public class LiveObjectEventRecorder {
 		// [FCM #21] LIVE_EVENT 푸시. live.notification.fcm.enabled 플래그로 게이트.
 		// 멱등 키 event_order 는 킬/오브젝트 충돌을 막기 위해 저장된 이벤트의 전역 id 를 쓴다.
 		if (teamLiveEventPushService.isEnabled() && isNotifiableLeague(activeGame.leagueName())) {
-			fireLiveEventPush(activeGame, teamSide, objectEventLabel(eventType, eventSubType), event.getId());
+			fireLiveEventPush(activeGame, teamSide,
+					objectEventTitle(activeGame, teamSide, eventType, eventSubType, valueAfter),
+					objectEventBody(activeGame, teamSide, eventType, valueAfter, opponentCurrentValue),
+					event.getId());
 		}
 	}
 
@@ -256,6 +278,8 @@ public class LiveObjectEventRecorder {
 			String killerSide,
 			int eventOrder,
 			int teamKillsAfter,
+			int opponentKillsCurrent,
+			boolean firstBlood,
 			Integer killerId,
 			Integer victimId,
 			Map<Integer, ParticipantMeta> metadata,
@@ -306,7 +330,16 @@ public class LiveObjectEventRecorder {
 
 		// [FCM #21] LIVE_EVENT(킬) 푸시. live.notification.fcm.enabled 플래그로 게이트.
 		if (teamLiveEventPushService.isEnabled() && isNotifiableLeague(activeGame.leagueName())) {
-			fireLiveEventPush(activeGame, killerSide, killEventLabel(killerSide, teamKillsAfter), event.getId());
+			fireLiveEventPush(activeGame, killerSide,
+					killEventTitle(activeGame, killerSide, firstBlood,
+							killer == null ? null : killer.summonerName(),
+							victim == null ? null : victim.summonerName(),
+							teamKillsAfter),
+					killEventBody(activeGame, killerSide, firstBlood,
+							killer == null ? null : killer.summonerName(),
+							victim == null ? null : victim.summonerName(),
+							teamKillsAfter, opponentKillsCurrent),
+					event.getId());
 		}
 	}
 
@@ -391,45 +424,107 @@ public class LiveObjectEventRecorder {
 	}
 
 	/** [FCM #21] LIVE_EVENT 푸시 호출. 진영별 esportsTeamId(window 기준)로 이벤트를 일으킨 팀 구독자에게 발송. */
-	private void fireLiveEventPush(ActiveLiveGame activeGame, String teamSide, String eventLabel, long eventOrder) {
+	private void fireLiveEventPush(ActiveLiveGame activeGame, String teamSide, String title, String body,
+			long eventOrder) {
 		try {
 			SideTeamIds sideIds = sideTeamIdsByGame.get(activeGame.gameId());
 			if (sideIds == null) {
 				return;
 			}
-			boolean blue = "Blue".equalsIgnoreCase(teamSide);
-			String actingEsportsTeamId = blue ? sideIds.blue() : sideIds.red();
+			String actingEsportsTeamId = "Blue".equalsIgnoreCase(teamSide) ? sideIds.blue() : sideIds.red();
 			if (actingEsportsTeamId == null || actingEsportsTeamId.isBlank()) {
 				return;
 			}
-			String actingTeamName = teamNameOf(activeGame, teamSide);
-			String opponentTeamName = teamNameOf(activeGame, blue ? "Red" : "Blue");
 			teamLiveEventPushService.notifyLiveEvent(
 					activeGame.matchId(),
 					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
 					eventOrder,
 					actingEsportsTeamId,
-					actingTeamName,
-					opponentTeamName,
-					eventLabel);
+					title,
+					body);
 		} catch (Exception e) {
-			log.warn("[live-notify] live-event FCM failed gameId={} side={}: {}",
-					activeGame.gameId(), teamSide, e.getMessage());
+			log.warn("[live-notify] live-event FCM failed gameId={} matchId={}: {}",
+					activeGame.gameId(), activeGame.matchId(), e.getMessage());
 		}
 	}
 
-	private String objectEventLabel(String eventType, String eventSubType) {
-		return switch (eventType) {
-			case EVENT_DRAGON -> "드래곤 처치";
-			case EVENT_BARON -> "바론 처치";
-			case EVENT_TOWER -> "포탑 파괴";
-			case EVENT_INHIBITOR -> "억제기 파괴";
-			default -> eventType;
+	/* ---------- 푸시 문구 빌더 (경기 흐름을 알 수 있게 상대 카운트를 함께 보여준다) ---------- */
+
+	private String opponentNameOf(ActiveLiveGame activeGame, String teamSide) {
+		return "Blue".equalsIgnoreCase(teamSide) ? activeGame.redTeamName() : activeGame.blueTeamName();
+	}
+
+	private String setSuffix(ActiveLiveGame activeGame) {
+		Integer setNumber = activeGame.setNumber();
+		return setNumber == null || setNumber <= 0 ? "" : " · " + setNumber + "세트";
+	}
+
+	private String dragonKo(String dragonType) {
+		if (dragonType == null) {
+			return "드래곤";
+		}
+		return switch (dragonType.toLowerCase(Locale.ROOT)) {
+			case "cloud" -> "바람용";
+			case "ocean" -> "바다용";
+			case "mountain" -> "대지용";
+			case "infernal" -> "화염용";
+			case "hextech" -> "마공학용";
+			case "chemtech" -> "화학공학용";
+			case "elder" -> "장로용";
+			default -> "드래곤";
 		};
 	}
 
-	private String killEventLabel(String killerSide, int teamKillsAfter) {
-		return teamKillsAfter + "킬 달성";
+	private String objectEventTitle(ActiveLiveGame activeGame, String teamSide, String eventType,
+			String eventSubType, int valueAfter) {
+		String acting = teamNameOf(activeGame, teamSide);
+		return switch (eventType) {
+			case EVENT_DRAGON -> acting + " " + dragonKo(eventSubType) + " 처치";
+			case EVENT_BARON -> acting + " 바론 처치";
+			case EVENT_TOWER -> acting + " " + valueAfter + "번째 포탑 파괴";
+			case EVENT_INHIBITOR -> acting + " 억제기 파괴";
+			default -> acting + " " + eventType;
+		};
+	}
+
+	private String objectEventBody(ActiveLiveGame activeGame, String teamSide, String eventType,
+			int valueAfter, int opponentValue) {
+		String acting = teamNameOf(activeGame, teamSide);
+		String opponent = opponentNameOf(activeGame, teamSide);
+		String counts = switch (eventType) {
+			case EVENT_DRAGON -> acting + " " + valueAfter + "용 vs " + opponentValue + "용 " + opponent;
+			case EVENT_BARON -> acting + " 바론 " + valueAfter + " vs " + opponentValue + " " + opponent;
+			case EVENT_TOWER -> acting + " 포탑 " + valueAfter + " vs " + opponentValue + " " + opponent;
+			case EVENT_INHIBITOR -> acting + " 억제기 " + valueAfter + " vs " + opponentValue + " " + opponent;
+			default -> acting + " " + valueAfter + " vs " + opponentValue + " " + opponent;
+		};
+		return counts + setSuffix(activeGame);
+	}
+
+	private String killEventTitle(ActiveLiveGame activeGame, String killerSide, boolean firstBlood,
+			String killerName, String victimName, int teamKillsAfter) {
+		String acting = teamNameOf(activeGame, killerSide);
+		if (killerName == null) {
+			return acting + " " + teamKillsAfter + "킬 달성";
+		}
+		if (firstBlood) {
+			return acting + " " + killerName + " 선취점 달성";
+		}
+		String opponent = opponentNameOf(activeGame, killerSide);
+		String victim = victimName == null ? opponent : opponent + " " + victimName;
+		return acting + " " + killerName + "님이 " + victim + "님을 처치했습니다";
+	}
+
+	private String killEventBody(ActiveLiveGame activeGame, String killerSide, boolean firstBlood,
+			String killerName, String victimName, int teamKillsAfter, int opponentKills) {
+		String acting = teamNameOf(activeGame, killerSide);
+		String opponent = opponentNameOf(activeGame, killerSide);
+		if (firstBlood && killerName != null && victimName != null) {
+			return acting + " " + killerName + "님이 " + opponent + " " + victimName + "님을 처치했습니다"
+					+ setSuffix(activeGame);
+		}
+		return acting + " " + teamKillsAfter + " Kill vs " + opponentKills + " Kill " + opponent
+				+ setSuffix(activeGame);
 	}
 
 	private String textOrNull(JsonNode node, String field) {

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -1,5 +1,6 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
 import com.toy.nar.app.mobile.notification.MemberNotificationService;
 import com.toy.nar.domain.member.entity.MemberDevice;
 import com.toy.nar.domain.member.entity.MemberNotificationType;
@@ -47,6 +48,7 @@ public class TeamLiveEventPushService {
 	private final MemberDeviceRepository deviceRepository;
 	private final MemberTeamEventPushDeliveryRepository deliveryRepository;
 	private final TeamExternalIdentityRepository teamExternalIdentityRepository;
+	private final LeagueMatchRepository leagueMatchRepository;
 	private final MobilePushGateway pushGateway;
 	private final MemberNotificationService notificationService;
 
@@ -71,10 +73,33 @@ public class TeamLiveEventPushService {
 		if (!isReady() || matchId == null || matchId.isBlank()) {
 			return;
 		}
+		// SET_END 는 매치 스코어를 함께 보여준다. 같은 폴링 사이클에서 스코어 sync 가
+		// 발송보다 먼저 실행되므로 대부분 최신이지만, 합계가 0이면(미동기화) 생략한다.
+		String matchScoreLine = TYPE_SET_END.equals(eventType) ? buildMatchScoreLine(matchId) : null;
 		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
-				blueEsportsTeamId, blueTeamName, redTeamName, true);
+				blueEsportsTeamId, blueTeamName, redTeamName, true, matchScoreLine);
 		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
-				redEsportsTeamId, redTeamName, blueTeamName, false);
+				redEsportsTeamId, redTeamName, blueTeamName, false, matchScoreLine);
+	}
+
+	/** 발송 직전 DB 매치 스코어로 "T1 1 vs 2 HLE" 라인을 만든다. 스코어가 아직 0:0 이면 null. */
+	private String buildMatchScoreLine(String matchId) {
+		try {
+			return leagueMatchRepository.findById(matchId)
+					.map(match -> {
+						Integer blueScore = match.getBlueScore();
+						Integer redScore = match.getRedScore();
+						if (blueScore == null || redScore == null || blueScore + redScore <= 0) {
+							return null;
+						}
+						return matchup(match.getBlueTeamName(), match.getRedTeamName())
+								.replace(" vs ", " " + blueScore + " vs " + redScore + " ");
+					})
+					.orElse(null);
+		} catch (Exception e) {
+			log.warn("Failed to load match score for set-end push matchId={}", matchId, e);
+			return null;
+		}
 	}
 
 	/**
@@ -86,21 +111,20 @@ public class TeamLiveEventPushService {
 			int setNumber,
 			long eventOrder,
 			String actingEsportsTeamId,
-			String actingTeamName,
-			String opponentTeamName,
-			String eventLabel) {
+			String title,
+			String body) {
 		if (!isReady() || matchId == null || matchId.isBlank()) {
 			return;
 		}
+		// 문구(title/body)는 이벤트 상세(킬러/피해자·양팀 카운트)를 아는 LiveObjectEventRecorder 가 완성한다.
+		// 여기서는 구독 매칭용 팀 해석과 발송만 담당한다.
 		Optional<Team> team = resolveLckTeam(actingEsportsTeamId);
 		if (team.isEmpty()) {
 			return;
 		}
-		Team resolved = team.get();
-		String teamName = preferDisplayName(actingTeamName, resolved.getName());
-		MobilePushMessage message = buildLiveEventMessage(
-				matchId, setNumber, teamName, eventLabel);
-		fanOut(TYPE_LIVE_EVENT, matchId, setNumber, eventOrder, resolved.getId(), message);
+		MobilePushMessage message = new MobilePushMessage(
+				title, body, baseData(TYPE_LIVE_EVENT, matchId, setNumber));
+		fanOut(TYPE_LIVE_EVENT, matchId, setNumber, eventOrder, team.get().getId(), message);
 	}
 
 	private void notifyTeamSide(
@@ -111,7 +135,8 @@ public class TeamLiveEventPushService {
 			String esportsTeamId,
 			String teamName,
 			String opponentTeamName,
-			boolean blueSide) {
+			boolean blueSide,
+			String matchScoreLine) {
 		Optional<Team> team = resolveLckTeam(esportsTeamId);
 		if (team.isEmpty()) {
 			return;
@@ -122,7 +147,7 @@ public class TeamLiveEventPushService {
 		String blue = blueSide ? displayName : opponent;
 		String red = blueSide ? opponent : displayName;
 		MobilePushMessage message = buildMatchEventMessage(
-				eventType, matchId, setNumber, displayName, blue, red);
+				eventType, matchId, setNumber, displayName, blue, red, matchScoreLine);
 		fanOut(eventType, matchId, setNumber, eventOrder, resolved.getId(), message);
 	}
 
@@ -237,29 +262,22 @@ public class TeamLiveEventPushService {
 			int setNumber,
 			String teamName,
 			String blueTeamName,
-			String redTeamName) {
+			String redTeamName,
+			String matchScoreLine) {
 		String matchup = matchup(blueTeamName, redTeamName);
 		String title;
 		String body;
 		if (TYPE_SET_END.equals(eventType)) {
-			title = teamName + " 세트 종료";
-			body = matchup + " · " + setNumber + "세트 종료";
+			title = teamName + " " + setNumber + "세트 종료";
+			// 매치 스코어를 알면 "T1 1 vs 2 HLE" 로 경기 흐름을 보여준다.
+			body = matchScoreLine != null
+					? matchScoreLine + " · " + setNumber + "세트 종료"
+					: matchup + " · " + setNumber + "세트 종료";
 		} else {
 			title = teamName + " 세트 시작";
 			body = matchup + " · " + setNumber + "세트 시작";
 		}
 		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber));
-	}
-
-	private MobilePushMessage buildLiveEventMessage(
-			String matchId,
-			int setNumber,
-			String teamName,
-			String eventLabel) {
-		String label = eventLabel == null || eventLabel.isBlank() ? "라이브 이벤트" : eventLabel;
-		String title = teamName + " " + label;
-		String body = teamName + " " + label + " · " + setNumber + "세트";
-		return new MobilePushMessage(title, body, baseData(TYPE_LIVE_EVENT, matchId, setNumber));
 	}
 
 	/** 모바일 계약: data.type / data.matchId / data.setNumber 는 모두 String. */

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 5, Title: 프로 챔피언 티어리스트
+[1] Vote: 6, Title: 프로 챔피언 티어리스트
 [2] Vote: 2, Title: ??? : 케틀 잡았다!(넥서스가 부숴지며)
 [3] Vote: 2, Title: 티원 조합 뭐여?
-[4] Vote: 1, Title: 지금상태로 티원은 우승 못함
-[5] Vote: 2, Title: 난 도란의 고점 시절은 오히려 kt때 같음
+[4] Vote: 1, Title: 대회 비원딜 계속 나오네
+[5] Vote: 1, Title: 지금상태로 티원은 우승 못함
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 근데 헬리오스 오늘은 좀 괜찮네.
-[2] Vote: , Title: 근데 여자아이돌 av야동배우 닉 다 이해가 가는데
-[3] Vote: , Title: 아무리 생각해도 밴픽 순서가 이상하긴 해
-[4] Vote: , Title: 카나비와 오너의차이점
-[5] Vote: , Title: 자기 닉을 여자 아이돌 이름으로 하는건 뭔심리일까
+[1] Vote: , Title: 근데 정보통신망법 저거 실효성이 있을꺼 같음?
+[2] Vote: , Title: 오랜만에 칼바람 한판했는데 재밌네 ㅋㅋ
+[3] Vote: , Title: T1이 진 걸 떠나서 신선한 챔프 픽 보니 좋네.
+[4] Vote: , Title: 한화팬아닌데도 나는 딜라이트 씹호감임
+[5] Vote: , Title: 풀경기 볼만함?


### PR DESCRIPTION
## 배경
알림만으로 경기 흐름 파악이 어렵다는 피드백. 킬러/피해자 선수명과 용 종류는 이미 DB 에 저장하면서 문구에는 쓰지 않고 있었다.

## 문구 변경 (before → after)

| 이벤트 | before | after |
|---|---|---|
| 선취점 | HLE 1킬 달성 | **HLE Zeka 선취점 달성** / HLE Zeka님이 G2 Gaps님을 처치했습니다 · 3세트 |
| 킬 | G2 11킬 달성 | **G2 Gaps님이 HLE Zeka님을 처치했습니다** / G2 11 Kill vs 3 Kill HLE · 3세트 |
| 용 | HLE 드래곤 처치 | **HLE 바람용 처치** / HLE 3용 vs 2용 G2 · 3세트 |
| 포탑 | HLE 포탑 파괴 | **HLE 5번째 포탑 파괴** / HLE 포탑 5 vs 1 G2 · 3세트 |
| 세트 종료 | HLE 세트 종료 / G2 vs HLE · 3세트 종료 | **HLE 3세트 종료** / **G2 1 vs 2 HLE** · 3세트 종료 |

- 포탑 라인/차수(예: 블루 미드 1차)는 감지가 카운터 diff 방식이라 데이터가 없어 순번으로 표기
- 선수명 페어링 실패(한타 근사) 시 기존 "N킬 달성" 폴백

## 세트 종료 매치 스코어의 정확성
같은 폴링 사이클에서 `syncRealtimeMatchStatus`(스코어 DB 반영)가 SET_END 발송보다 먼저 실행된다. 발송 직전 DB 를 조회하고, 합계가 0(미동기화)이면 스코어 줄을 생략한다.

## 구조
- 문구 조립을 `LiveObjectEventRecorder` 로 이동 (이벤트 상세를 아는 곳)
- `notifyLiveEvent` 는 title/body 를 받아 구독 매칭·발송만 담당
- `dragonType` 한글 매핑 (cloud→바람용 등 7종)

## 검증
- `./gradlew build` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)