### PR TITLE
feat: 특정 경기 예약 알림 (match subscription)

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/subscription/MobileMatchSubscriptionController.java
+++ b/src/main/java/com/toy/nar/api/mobile/subscription/MobileMatchSubscriptionController.java
@@ -1,0 +1,56 @@
+package com.toy.nar.api.mobile.subscription;
+
+import com.toy.nar.api.mobile.subscription.dto.MatchSubscribeRequest;
+import com.toy.nar.app.mobile.subscription.MobileMatchSubscriptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Mobile. 경기 예약 알림", description = "특정 경기 예약 알림 구독 API. 팀 구독과 별개로 경기 단위로 세트 시작/종료/라이브 이벤트를 받는다.")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/api/mobile/me/match-subscriptions")
+@RequiredArgsConstructor
+public class MobileMatchSubscriptionController {
+
+	private final MobileMatchSubscriptionService subscriptionService;
+
+	@Operation(summary = "내 경기 예약 구독 목록 조회",
+			description = "구독 중인 경기 ID 목록. 앱이 경기 리스트에서 벨 상태를 표시하는 데 쓴다.")
+	@GetMapping
+	public ResponseEntity<List<String>> getSubscriptions(@AuthenticationPrincipal Long memberId) {
+		return ResponseEntity.ok(subscriptionService.getSubscribedMatchIds(memberId));
+	}
+
+	@Operation(summary = "경기 예약 구독 추가", description = "이미 구독 중이면 멱등하게 통과한다.")
+	@PostMapping
+	public ResponseEntity<Void> subscribe(
+			@AuthenticationPrincipal Long memberId,
+			@Valid @RequestBody MatchSubscribeRequest request) {
+		subscriptionService.subscribe(memberId, request.matchId());
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(summary = "경기 예약 구독 해제")
+	@DeleteMapping("/{matchId}")
+	public ResponseEntity<Void> unsubscribe(
+			@AuthenticationPrincipal Long memberId,
+			@Parameter(description = "구독 해제할 경기 ID") @PathVariable String matchId) {
+		subscriptionService.unsubscribe(memberId, matchId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/toy/nar/api/mobile/subscription/dto/MatchSubscribeRequest.java
+++ b/src/main/java/com/toy/nar/api/mobile/subscription/dto/MatchSubscribeRequest.java
@@ -1,0 +1,11 @@
+package com.toy.nar.api.mobile.subscription.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "경기 예약 알림 구독 요청")
+public record MatchSubscribeRequest(
+		@NotBlank
+		@Schema(description = "구독할 경기 ID", example = "113990000000000001")
+		String matchId) {
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -80,6 +80,56 @@ public class TeamLiveEventPushService {
 				blueEsportsTeamId, blueTeamName, redTeamName, true, matchScoreLine);
 		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
 				redEsportsTeamId, redTeamName, blueTeamName, false, matchScoreLine);
+
+		// 경기 예약 구독자(팀 무관)에게도 발송. 매치 중립 문구를 1회 만들어 fan-out 한다.
+		// dedup 키가 (member, matchId, ...) 라 팀+매치 양쪽 구독자여도 1회만 나간다.
+		MobilePushMessage matchMessage =
+				buildMatchScopedMessage(eventType, matchId, setNumber, blueTeamName, redTeamName, matchScoreLine);
+		fanOutToMatchSubscribers(eventType, matchId, setNumber, NO_EVENT_ORDER, matchMessage);
+	}
+
+	/** 경기 예약 구독자용 중립 문구. 특정 팀 관점이 아니라 대진 기준으로 표기한다. */
+	private MobilePushMessage buildMatchScopedMessage(
+			String eventType,
+			String matchId,
+			int setNumber,
+			String blueTeamName,
+			String redTeamName,
+			String matchScoreLine) {
+		String matchup = matchup(blueTeamName, redTeamName);
+		String title;
+		String body;
+		if (TYPE_SET_END.equals(eventType)) {
+			title = matchup + " " + setNumber + "세트 종료";
+			body = (matchScoreLine != null ? matchScoreLine : matchup) + " · " + setNumber + "세트 종료";
+		} else {
+			title = matchup + " " + setNumber + "세트 시작";
+			body = matchup + " · " + setNumber + "세트 시작";
+		}
+		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber));
+	}
+
+	/** 경기 예약 구독자 fan-out. 팀 구독 fanOut 과 동일하게 sendToMember(dedup) 를 태운다. */
+	private void fanOutToMatchSubscribers(
+			String eventType,
+			String matchId,
+			int setNumber,
+			long eventOrder,
+			MobilePushMessage message) {
+		try {
+			List<MemberDevice> devices = deviceRepository.findActiveDevicesBySubscribedMatchId(matchId);
+			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
+					.collect(Collectors.groupingBy(
+							device -> device.getMember().getId(),
+							LinkedHashMap::new,
+							Collectors.toList()));
+			for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
+				sendToMember(entry.getKey(), entry.getValue(), eventType, matchId, setNumber, eventOrder, message);
+			}
+		} catch (Exception e) {
+			log.warn("Failed to prepare match-subscription pushes eventType={} matchId={} setNumber={}",
+					eventType, matchId, setNumber, e);
+		}
 	}
 
 	/** 발송 직전 DB 매치 스코어로 "T1 1 vs 2 HLE" 라인을 만든다. 스코어가 아직 0:0 이면 null. */
@@ -117,14 +167,14 @@ public class TeamLiveEventPushService {
 			return;
 		}
 		// 문구(title/body)는 이벤트 상세(킬러/피해자·양팀 카운트)를 아는 LiveObjectEventRecorder 가 완성한다.
-		// 여기서는 구독 매칭용 팀 해석과 발송만 담당한다.
-		Optional<Team> team = resolveLckTeam(actingEsportsTeamId);
-		if (team.isEmpty()) {
-			return;
-		}
+		// 여기서는 구독 매칭용 발송만 담당한다.
 		MobilePushMessage message = new MobilePushMessage(
 				title, body, baseData(TYPE_LIVE_EVENT, matchId, setNumber));
-		fanOut(TYPE_LIVE_EVENT, matchId, setNumber, eventOrder, team.get().getId(), message);
+		// 팀 구독자: acting 팀이 LCK 로 해석될 때만. (비LCK 팀은 팀 구독 대상이 아니다)
+		resolveLckTeam(actingEsportsTeamId).ifPresent(team ->
+				fanOut(TYPE_LIVE_EVENT, matchId, setNumber, eventOrder, team.getId(), message));
+		// 경기 예약 구독자: 팀 무관. 비LCK 대진(예: 국제전)이라도 발송된다.
+		fanOutToMatchSubscribers(TYPE_LIVE_EVENT, matchId, setNumber, eventOrder, message);
 	}
 
 	private void notifyTeamSide(

--- a/src/main/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionService.java
+++ b/src/main/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionService.java
@@ -1,0 +1,55 @@
+package com.toy.nar.app.mobile.subscription;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.common.error.ErrorCode;
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberMatchSubscription;
+import com.toy.nar.domain.member.repository.MemberMatchSubscriptionRepository;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 경기 예약 알림 구독. 팀 구독과 별개로 특정 경기를 구독하면
+ * 그 경기의 세트 시작/종료/라이브 이벤트를 받는다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MobileMatchSubscriptionService {
+
+	private final MemberMatchSubscriptionRepository subscriptionRepository;
+	private final MemberRepository memberRepository;
+	private final LeagueMatchRepository leagueMatchRepository;
+
+	/** 내가 구독한 경기 matchId 목록. 앱이 리스트에서 벨 상태를 그리는 데 쓴다. */
+	public List<String> getSubscribedMatchIds(Long memberId) {
+		return subscriptionRepository.findMatchIdsByMemberId(memberId);
+	}
+
+	@Transactional
+	public void subscribe(Long memberId, String matchId) {
+		if (matchId == null || matchId.isBlank()) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+		if (!leagueMatchRepository.existsById(matchId)) {
+			throw new CustomException(ErrorCode.DATA_NOT_FOUND);
+		}
+		// 이미 구독 중이면 조용히 통과(멱등). 유니크 제약이 중복 삽입을 막는다.
+		if (subscriptionRepository.existsByMemberIdAndMatchId(memberId, matchId)) {
+			return;
+		}
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+		subscriptionRepository.save(new MemberMatchSubscription(member, matchId));
+	}
+
+	@Transactional
+	public void unsubscribe(Long memberId, String matchId) {
+		subscriptionRepository.deleteByMemberIdAndMatchId(memberId, matchId);
+	}
+}

--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                         ).authenticated()
                         .requestMatchers(
                                 "/api/mobile/me/notification-subscriptions/**",
-                                "/api/mobile/me/notifications/**"
+                                "/api/mobile/me/notifications/**",
+                                "/api/mobile/me/match-subscriptions/**"
                         ).authenticated()
                         .requestMatchers(
                                 "/api/auth/me", "/api/auth/logout", "/api/auth/onboarding"

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberMatchSubscription.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberMatchSubscription.java
@@ -1,0 +1,59 @@
+package com.toy.nar.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 특정 경기 예약 알림 구독. 팀 구독과 별개로, 유저가 개별 경기를 구독하면
+ * 해당 경기의 세트 시작/종료/라이브 이벤트를 받는다(토글 없이 3종 전부).
+ * match_id 는 league_match.id (외부 경기 식별자, VARCHAR).
+ */
+@Entity
+@Table(name = "member_match_subscription", uniqueConstraints = {
+		@UniqueConstraint(
+				name = "uk_member_match_subscription",
+				columnNames = { "member_id", "match_id" })
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMatchSubscription {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "match_id", nullable = false, length = 50)
+	private String matchId;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	public MemberMatchSubscription(Member member, String matchId) {
+		this.member = Objects.requireNonNull(member);
+		this.matchId = Objects.requireNonNull(matchId);
+	}
+
+	@PrePersist
+	void onCreate() {
+		createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
@@ -58,6 +58,24 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
 			@Param("teamId") Long teamId,
 			@Param("eventType") String eventType);
 
+	/**
+	 * 특정 경기를 예약 구독한 회원들의 활성 기기 목록. 팀 구독과 달리 토글이 없어
+	 * 세트 시작/종료/라이브 이벤트를 구분하지 않고 구독 여부만 본다.
+	 */
+	@EntityGraph(attributePaths = "member")
+	@Query("""
+			SELECT DISTINCT device
+			FROM MemberDevice device
+			WHERE device.active = true
+			  AND EXISTS (
+				  SELECT subscription.id
+				  FROM MemberMatchSubscription subscription
+				  WHERE subscription.member = device.member
+				    AND subscription.matchId = :matchId
+			  )
+			""")
+	List<MemberDevice> findActiveDevicesBySubscribedMatchId(@Param("matchId") String matchId);
+
 	@Modifying(clearAutomatically = true)
 	@Transactional
 	@Query("""

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionRepository.java
@@ -1,0 +1,23 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.MemberMatchSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberMatchSubscriptionRepository
+		extends JpaRepository<MemberMatchSubscription, Long> {
+
+	boolean existsByMemberIdAndMatchId(Long memberId, String matchId);
+
+	void deleteByMemberIdAndMatchId(Long memberId, String matchId);
+
+	@Query("""
+			SELECT subscription.matchId
+			FROM MemberMatchSubscription subscription
+			WHERE subscription.member.id = :memberId
+			""")
+	List<String> findMatchIdsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/resources/db/migration/V51__Create_member_match_subscription.sql
+++ b/src/main/resources/db/migration/V51__Create_member_match_subscription.sql
@@ -1,0 +1,16 @@
+-- 특정 경기 예약 알림. 팀 구독과 별개로, 유저가 개별 경기를 구독하면
+-- 그 경기의 세트 시작/종료/라이브 이벤트를 받는다(토글 없이 3종 전부).
+CREATE TABLE member_match_subscription (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id BIGINT NOT NULL,
+    match_id VARCHAR(50) NOT NULL,
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    CONSTRAINT uk_member_match_subscription
+        UNIQUE (member_id, match_id),
+    CONSTRAINT fk_member_match_subscription_member
+        FOREIGN KEY (member_id) REFERENCES member(id) ON DELETE CASCADE,
+    CONSTRAINT fk_member_match_subscription_match
+        FOREIGN KEY (match_id) REFERENCES league_match(id) ON DELETE CASCADE,
+    INDEX idx_member_match_subscription_member (member_id),
+    INDEX idx_member_match_subscription_match (match_id)
+);

--- a/src/test/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionServiceTest.java
@@ -1,0 +1,78 @@
+package com.toy.nar.app.mobile.subscription;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberMatchSubscription;
+import com.toy.nar.domain.member.repository.MemberMatchSubscriptionRepository;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MobileMatchSubscriptionServiceTest {
+
+	@Mock
+	private MemberMatchSubscriptionRepository subscriptionRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private LeagueMatchRepository leagueMatchRepository;
+
+	private MobileMatchSubscriptionService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new MobileMatchSubscriptionService(
+				subscriptionRepository, memberRepository, leagueMatchRepository);
+	}
+
+	@Test
+	void subscribeSavesNewSubscription() {
+		when(leagueMatchRepository.existsById("m1")).thenReturn(true);
+		when(subscriptionRepository.existsByMemberIdAndMatchId(7L, "m1")).thenReturn(false);
+		when(memberRepository.findById(7L)).thenReturn(
+				Optional.of(Member.builder().name("nar").tag("0001").build()));
+
+		service.subscribe(7L, "m1");
+
+		verify(subscriptionRepository).save(any(MemberMatchSubscription.class));
+	}
+
+	@Test
+	void subscribeIsIdempotentWhenAlreadySubscribed() {
+		when(leagueMatchRepository.existsById("m1")).thenReturn(true);
+		when(subscriptionRepository.existsByMemberIdAndMatchId(7L, "m1")).thenReturn(true);
+
+		service.subscribe(7L, "m1");
+
+		verify(subscriptionRepository, never()).save(any());
+	}
+
+	@Test
+	void subscribeRejectsUnknownMatch() {
+		when(leagueMatchRepository.existsById("nope")).thenReturn(false);
+
+		assertThatThrownBy(() -> service.subscribe(7L, "nope"))
+				.isInstanceOf(CustomException.class);
+		verify(subscriptionRepository, never()).save(any());
+	}
+
+	@Test
+	void unsubscribeDelegatesToRepository() {
+		service.unsubscribe(7L, "m1");
+
+		verify(subscriptionRepository).deleteByMemberIdAndMatchId(7L, "m1");
+	}
+}

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 6, Title: 프로 챔피언 티어리스트
-[2] Vote: 2, Title: ??? : 케틀 잡았다!(넥서스가 부숴지며)
-[3] Vote: 2, Title: 티원 조합 뭐여?
-[4] Vote: 1, Title: 대회 비원딜 계속 나오네
-[5] Vote: 1, Title: 지금상태로 티원은 우승 못함
+[1] Vote: 8, Title: 24년 대회가 제일 재미없던거같음
+[2] Vote: 6, Title: 대회에서 비원딜 쓰는 이유
+[3] Vote: 9, Title: 프로 챔피언 티어리스트
+[4] Vote: 5, Title: 대회 비원딜 계속 나오네
+[5] Vote: 3, Title: ??? : 케틀 잡았다!(넥서스가 부숴지며)
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 근데 정보통신망법 저거 실효성이 있을꺼 같음?
-[2] Vote: , Title: 오랜만에 칼바람 한판했는데 재밌네 ㅋㅋ
-[3] Vote: , Title: T1이 진 걸 떠나서 신선한 챔프 픽 보니 좋네.
-[4] Vote: , Title: 한화팬아닌데도 나는 딜라이트 씹호감임
-[5] Vote: , Title: 풀경기 볼만함?
+[1] Vote: , Title: 요즘 증바람 몰왕 전도중임
+[2] Vote: , Title: T1팬인데 경기력가지고 ㅈㄹ 하는거 이상하긴함
+[3] Vote: , Title: 아.......미국 반도체 또 떨어지농 ㅋㅋ
+[4] Vote: , Title: 뭔가 지투는 좀 그래
+[5] Vote: , Title: 증바람 잘 큰 탱커딜 보니까 벽느껴짐 ㅋㅋ


### PR DESCRIPTION
## 배경
팀 구독과 별개로, 유저가 관심 경기를 개별 구독해 알림받고 싶다는 요청. 리마인드(시작 15분 전)는 범위에서 뺐고, 기존 라이브 3종(세트 시작/종료/라이브 이벤트)만 경기 단위로 받는다.

## 변경
- `member_match_subscription` 테이블 (member_id, match_id) + `V51` 마이그레이션
- API (인증 필요):
  - `POST /api/mobile/me/match-subscriptions` {matchId} — 구독(멱등), 미존재 경기 404
  - `DELETE /api/mobile/me/match-subscriptions/{matchId}` — 해제
  - `GET /api/mobile/me/match-subscriptions` — 구독 중 matchId 목록 (앱 벨 상태용)
- `MemberDeviceRepository.findActiveDevicesBySubscribedMatchId` — 매치 구독자 기기 조회 (토글 없음)
- `TeamLiveEventPushService`: 기존 팀 fan-out 에 매치 구독자 fan-out 합류
  - dedup 키가 `(member, matchId, setNumber, eventType, eventOrder)` 라 팀+매치 양쪽 구독자여도 1회만 발송
  - 세트 시작/종료는 대진 중립 문구(`T1 vs HLE N세트 종료`)로 조립
  - LIVE_EVENT 는 acting 팀 비LCK 여도 매치 구독자에겐 발송 (국제전 상대팀 등)

## 스코프 밖
- 시작 전 리마인드: 제외 (스케줄러 불필요)
- 앱 UI(벨 버튼): 별도. 이 PR 은 백엔드만

## 검증
- `./gradlew build` 전체 통과, 서비스 단위 테스트 4건 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)