### PR TITLE
fix: 라이브 킬 알림 팀명·선수명 중복 (T1 T1 Doran)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -501,6 +501,27 @@ public class LiveObjectEventRecorder {
 		return counts + setSuffix(activeGame);
 	}
 
+	/**
+	 * 팀명과 선수명을 합치되 중복을 막는다. Riot summonerName 은 보통 팀 태그를 포함해
+	 * ("T1 Doran") 팀명을 그대로 덧붙이면 "T1 T1 Doran" 이 된다. 선수명이 이미 팀명(태그)으로
+	 * 시작하면 선수명만 쓴다.
+	 */
+	private String withTeam(String teamName, String playerName) {
+		String player = playerName == null ? "" : playerName.trim();
+		String team = teamName == null ? "" : teamName.trim();
+		if (player.isEmpty()) {
+			return team;
+		}
+		if (team.isEmpty()) {
+			return player;
+		}
+		if (player.equalsIgnoreCase(team)
+				|| player.regionMatches(true, 0, team + " ", 0, team.length() + 1)) {
+			return player;
+		}
+		return team + " " + player;
+	}
+
 	private String killEventTitle(ActiveLiveGame activeGame, String killerSide, boolean firstBlood,
 			String killerName, String victimName, int teamKillsAfter) {
 		String acting = teamNameOf(activeGame, killerSide);
@@ -508,11 +529,11 @@ public class LiveObjectEventRecorder {
 			return acting + " " + teamKillsAfter + "킬 달성";
 		}
 		if (firstBlood) {
-			return acting + " " + killerName + " 선취점 달성";
+			return withTeam(acting, killerName) + " 선취점 달성";
 		}
 		String opponent = opponentNameOf(activeGame, killerSide);
-		String victim = victimName == null ? opponent : opponent + " " + victimName;
-		return acting + " " + killerName + "님이 " + victim + "님을 처치했습니다";
+		String victim = victimName == null ? opponent : withTeam(opponent, victimName);
+		return withTeam(acting, killerName) + "님이 " + victim + "님을 처치했습니다";
 	}
 
 	private String killEventBody(ActiveLiveGame activeGame, String killerSide, boolean firstBlood,
@@ -520,7 +541,7 @@ public class LiveObjectEventRecorder {
 		String acting = teamNameOf(activeGame, killerSide);
 		String opponent = opponentNameOf(activeGame, killerSide);
 		if (firstBlood && killerName != null && victimName != null) {
-			return acting + " " + killerName + "님이 " + opponent + " " + victimName + "님을 처치했습니다"
+			return withTeam(acting, killerName) + "님이 " + withTeam(opponent, victimName) + "님을 처치했습니다"
 					+ setSuffix(activeGame);
 		}
 		return acting + " " + teamKillsAfter + " Kill vs " + opponentKills + " Kill " + opponent

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
@@ -7,6 +7,9 @@ import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
 import com.toy.nar.app.mobile.push.TeamLiveEventPushService;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -23,6 +26,23 @@ class LiveObjectEventRecorderTest {
 	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(
 			objectEventRepository, mock(NotificationService.class), mock(TeamLiveEventPushService.class));
 	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void withTeamAvoidsDuplicatingTeamTagAlreadyInPlayerName() {
+		// summonerName 이 팀 태그를 포함하면("T1 Doran") 팀명을 다시 붙이지 않는다.
+		assertThat(invokeWithTeam("T1", "T1 Doran")).isEqualTo("T1 Doran");
+		assertThat(invokeWithTeam("T1", "t1 doran")).isEqualTo("t1 doran"); // 대소문자 무시
+		// 태그가 없거나 다르면 팀명을 붙인다.
+		assertThat(invokeWithTeam("HLE", "Zeka")).isEqualTo("HLE Zeka");
+		// 선수명이 팀명과 완전히 같으면 팀명만.
+		assertThat(invokeWithTeam("T1", "T1")).isEqualTo("T1");
+		// 선수명이 비면 팀명만.
+		assertThat(invokeWithTeam("T1", null)).isEqualTo("T1");
+	}
+
+	private String invokeWithTeam(String team, String player) {
+		return (String) ReflectionTestUtils.invokeMethod(recorder, "withTeam", team, player);
+	}
 
 	@Test
 	void replayingSameWindowDoesNotSaveDuplicateObjectEvents() throws Exception {

--- a/test_result.log
+++ b/test_result.log
@@ -1,15 +1,15 @@
 [OP.GG Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: 8, Title: 24년 대회가 제일 재미없던거같음
-[2] Vote: 6, Title: 대회에서 비원딜 쓰는 이유
-[3] Vote: 9, Title: 프로 챔피언 티어리스트
-[4] Vote: 5, Title: 대회 비원딜 계속 나오네
-[5] Vote: 3, Title: ??? : 케틀 잡았다!(넥서스가 부숴지며)
+[1] Vote: 50, Title: 타팀팬이라 말하긴 좀 그렇지만
+[2] Vote: 37, Title: 싱글벙글 G2 트위터 근황
+[3] Vote: 22, Title: 15 5 7 클레드가 T1 넥서스 파괴!!!!
+[4] Vote: 21, Title: LCK의 3부리그화, G2의 강세...?
+[5] Vote: 18, Title: "역시 형이야! 구하러 왔구나!"
 --------------------------------------------------
 [Inven Popular Sort Test]
 Fetched 40 posts.
-[1] Vote: , Title: 요즘 증바람 몰왕 전도중임
-[2] Vote: , Title: T1팬인데 경기력가지고 ㅈㄹ 하는거 이상하긴함
-[3] Vote: , Title: 아.......미국 반도체 또 떨어지농 ㅋㅋ
-[4] Vote: , Title: 뭔가 지투는 좀 그래
-[5] Vote: , Title: 증바람 잘 큰 탱커딜 보니까 벽느껴짐 ㅋㅋ
+[1] Vote: , Title: 이폼으로 홈그때 재계약뜨면
+[2] Vote: , Title: 근데 갈리오 w플 부활시키면 개사기됨?
+[3] Vote: , Title: 캡스는 중국이나 한국인이면 월즈 한번은 들었을듯
+[4] Vote: , Title: 돌려보니 오늘 감코도 잘못했네 ㅇㅇ
+[5] Vote: 추천 1, Title: 티원 초가삼간 다 탔지만 희소식도 하나 있다


### PR DESCRIPTION
## 증상
킬 알림 문구가 "T1 T1 Doran" 처럼 팀명이 두 번 나왔다.

## 원인
Riot `summonerName` 은 보통 팀 태그를 포함한다("T1 Doran", "HLE Zeka"). 문구 조립이 `팀명 + " " + summonerName` 이라, 팀 태그가 팀명과 같으면(T1) "T1 T1 Doran" 이 됐다.

## 수정
`withTeam(teamName, playerName)` 헬퍼 추가.
- 선수명이 팀명으로 시작하면(대소문자 무시) 선수명만 사용 → "T1 Doran"
- 태그가 없거나 다르면 기존대로 접두 → "HLE Zeka"
- 킬/선취점 문구의 killer/victim 조립에 적용

선수 솔로랭 알림은 `player.getName()`(팀 미포함)이라 영향 없음.

## 검증
- `./gradlew build` 통과, `withTeam` 분기 단위 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)