### PR TITLE
feat: 백오피스 목록 검색(q 파라미터) 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -27,23 +28,28 @@ public class BackofficeController {
     private final TeamRepository teamRepository;
 
     @GetMapping("/members")
-    public Page<MemberRow> members(Pageable pageable) {
-        return memberRepository.findAll(pageable)
+    public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
+        return memberRepository.searchForBackoffice(blankToNull(q), pageable)
                 .map(m -> new MemberRow(m.getId(), m.getNickname(), m.getEmail(),
                         m.getFavoriteLeagueName(), m.getCreatedAt()));
     }
 
     @GetMapping("/players")
-    public Page<PlayerRow> players(Pageable pageable) {
-        return playerRepository.findAll(pageable)
+    public Page<PlayerRow> players(@RequestParam(required = false) String q, Pageable pageable) {
+        return playerRepository.searchForBackoffice(blankToNull(q), pageable)
                 .map(p -> new PlayerRow(p.getId(), p.getName(), p.getRealName(),
                         p.getRole(), p.getAge()));
     }
 
     @GetMapping("/teams")
-    public Page<TeamRow> teams(Pageable pageable) {
-        return teamRepository.findAll(pageable)
+    public Page<TeamRow> teams(@RequestParam(required = false) String q, Pageable pageable) {
+        return teamRepository.searchForBackoffice(blankToNull(q), pageable)
                 .map(t -> new TeamRow(t.getId(), t.getName(), t.getCode()));
+    }
+
+    // 빈 문자열/공백은 null 로 정규화 → 검색 쿼리의 ":q IS NULL" 분기가 전체 조회로 동작.
+    private static String blankToNull(String q) {
+        return (q == null || q.isBlank()) ? null : q.trim();
     }
 
     @GetMapping("/cron-jobs")

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -1,5 +1,6 @@
 package com.toy.nar.api.admin;
 
+import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
@@ -26,6 +27,7 @@ public class BackofficeController {
     private final MemberRepository memberRepository;
     private final PlayerRepository playerRepository;
     private final TeamRepository teamRepository;
+    private final LeagueRepository leagueRepository;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
@@ -35,16 +37,26 @@ public class BackofficeController {
     }
 
     @GetMapping("/players")
-    public Page<PlayerRow> players(@RequestParam(required = false) String q, Pageable pageable) {
-        return playerRepository.searchForBackoffice(blankToNull(q), pageable)
+    public Page<PlayerRow> players(@RequestParam(required = false) String q,
+                                   @RequestParam(required = false) String league,
+                                   Pageable pageable) {
+        return playerRepository.searchForBackoffice(blankToNull(q), blankToNull(league), pageable)
                 .map(p -> new PlayerRow(p.getId(), p.getName(), p.getRealName(),
                         p.getRole(), p.getAge()));
     }
 
     @GetMapping("/teams")
-    public Page<TeamRow> teams(@RequestParam(required = false) String q, Pageable pageable) {
-        return teamRepository.searchForBackoffice(blankToNull(q), pageable)
+    public Page<TeamRow> teams(@RequestParam(required = false) String q,
+                               @RequestParam(required = false) String league,
+                               Pageable pageable) {
+        return teamRepository.searchForBackoffice(blankToNull(q), blankToNull(league), pageable)
                 .map(t -> new TeamRow(t.getId(), t.getName(), t.getCode()));
+    }
+
+    // 리그 필터 옵션. 실제 데이터에 존재하는 리그명(전 시즌) distinct.
+    @GetMapping("/leagues")
+    public List<String> leagues() {
+        return leagueRepository.findAllDistinctLeagueNames();
     }
 
     // 빈 문자열/공백은 null 로 정규화 → 검색 쿼리의 ":q IS NULL" 분기가 전체 조회로 동작.

--- a/src/main/java/com/toy/nar/domain/game/repository/LeagueRepository.java
+++ b/src/main/java/com/toy/nar/domain/game/repository/LeagueRepository.java
@@ -34,6 +34,10 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 	@Query("SELECT DISTINCT l.leagueName FROM League l WHERE l.seasonYear = 2025")
 	List<String> findDistinctLeagueNames();
 
+	// 백오피스 리그 필터 옵션: 전 시즌 통틀어 실제 존재하는 리그명만.
+	@Query("SELECT DISTINCT l.leagueName FROM League l ORDER BY l.leagueName")
+	List<String> findAllDistinctLeagueNames();
+
 	@Query("SELECT DISTINCT l.leagueName FROM League l WHERE l.seasonYear = :year ORDER BY l.leagueName")
 	List<String> findDistinctLeagueNamesByYear(@Param("year") int year);
 

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
@@ -1,7 +1,11 @@
 package com.toy.nar.domain.member.repository;
 
 import com.toy.nar.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +14,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     // 이메일 자동 연동용. 혹시 중복 이메일이 있어도 가장 오래된 계정으로 안전하게 연결한다.
     Optional<Member> findFirstByEmailOrderByIdAsc(String email);
+
+    // 백오피스 검색: 닉네임(name)·이메일 부분일치. q 가 null 이면 전체.
+    @Query("""
+            SELECT m FROM Member m
+            WHERE :q IS NULL
+               OR LOWER(m.name) LIKE LOWER(CONCAT('%', :q, '%'))
+               OR LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%'))
+            """)
+    Page<Member> searchForBackoffice(@Param("q") String q, Pageable pageable);
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -14,6 +14,15 @@ import java.util.Set;
 public interface PlayerRepository extends JpaRepository<Player, Long> {
 	Optional<Player> findByName(String name);
 
+	// 백오피스 검색: 선수명·실명 부분일치. q 가 null 이면 전체.
+	@Query("""
+			SELECT p FROM Player p
+			WHERE :q IS NULL
+			   OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
+			   OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%'))
+			""")
+	Page<Player> searchForBackoffice(@Param("q") String q, Pageable pageable);
+
 	Optional<Player> findByPlayerOriginId(String playerOriginId);
 
 	List<Player> findAllByNameInIgnoreCase(Set<String> names);

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -14,14 +14,18 @@ import java.util.Set;
 public interface PlayerRepository extends JpaRepository<Player, Long> {
 	Optional<Player> findByName(String name);
 
-	// 백오피스 검색: 선수명·실명 부분일치. q 가 null 이면 전체.
+	// 백오피스 검색: 선수명·실명 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
+	// 리그는 출전 기록(GameParticipant→Game→League) 기준 EXISTS 로 판정(전 시즌 통합).
 	@Query("""
 			SELECT p FROM Player p
-			WHERE :q IS NULL
-			   OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
-			   OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%'))
+			WHERE (:q IS NULL
+			       OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND (:league IS NULL
+			       OR EXISTS (SELECT 1 FROM GameParticipant gp
+			                  WHERE gp.player = p AND gp.game.league.leagueName = :league))
 			""")
-	Page<Player> searchForBackoffice(@Param("q") String q, Pageable pageable);
+	Page<Player> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
 
 	Optional<Player> findByPlayerOriginId(String playerOriginId);
 

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -51,12 +51,16 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	@Query("SELECT t FROM Team t WHERE LOWER(t.name) = LOWER(:name)")
 	Optional<Team> findByNameIgnoreCase(@Param("name") String name);
 
-	// 백오피스 검색: 팀명·코드 부분일치. q 가 null 이면 전체.
+	// 백오피스 검색: 팀명·코드 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
+	// 리그는 LeagueTeam 조인 대신 EXISTS 로 걸러 페이징/카운트를 단순하게 유지(전 시즌 통합).
 	@Query("""
 			SELECT t FROM Team t
-			WHERE :q IS NULL
-			   OR LOWER(t.name) LIKE LOWER(CONCAT('%', :q, '%'))
-			   OR LOWER(t.code) LIKE LOWER(CONCAT('%', :q, '%'))
+			WHERE (:q IS NULL
+			       OR LOWER(t.name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(t.code) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND (:league IS NULL
+			       OR EXISTS (SELECT 1 FROM LeagueTeam lt
+			                  WHERE lt.team = t AND lt.league.leagueName = :league))
 			""")
-	Page<Team> searchForBackoffice(@Param("q") String q, Pageable pageable);
+	Page<Team> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -1,5 +1,7 @@
 package com.toy.nar.domain.participant.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -48,4 +50,13 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
 	@Query("SELECT t FROM Team t WHERE LOWER(t.name) = LOWER(:name)")
 	Optional<Team> findByNameIgnoreCase(@Param("name") String name);
+
+	// 백오피스 검색: 팀명·코드 부분일치. q 가 null 이면 전체.
+	@Query("""
+			SELECT t FROM Team t
+			WHERE :q IS NULL
+			   OR LOWER(t.name) LIKE LOWER(CONCAT('%', :q, '%'))
+			   OR LOWER(t.code) LIKE LOWER(CONCAT('%', :q, '%'))
+			""")
+	Page<Team> searchForBackoffice(@Param("q") String q, Pageable pageable);
 }

--- a/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +14,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import com.toy.nar.domain.game.entity.League;
+import com.toy.nar.domain.game.entity.LeagueTeam;
 import com.toy.nar.domain.participant.entity.Team;
 
 // 백오피스 검색 쿼리(searchForBackoffice) 검증. H2 격리 실행(마이그레이션은 MySQL 전용이라 엔티티 기반 스키마 사용).
@@ -23,6 +28,9 @@ class TeamRepositorySearchTest {
 	@Autowired
 	private TeamRepository teamRepository;
 
+	@PersistenceContext
+	private EntityManager em;
+
 	@Test
 	@DisplayName("q가 null이면 전체, 값이 있으면 팀명·코드 부분일치(대소문자 무시)로 검색한다")
 	void searchForBackoffice_matchesNameOrCode() {
@@ -31,21 +39,53 @@ class TeamRepositorySearchTest {
 		teamRepository.save(Team.builder().name("T1").code("T1").build());
 
 		// null → 전체
-		assertThat(teamRepository.searchForBackoffice(null, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(teamRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
 				.isEqualTo(3);
 
 		// 팀명 부분일치(소문자 입력도 매칭)
-		List<String> byName = teamRepository.searchForBackoffice("gen", PageRequest.of(0, 10))
+		List<String> byName = teamRepository.searchForBackoffice("gen", null, PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(byName).containsExactly("Gen.G");
 
 		// 코드 부분일치
-		List<String> byCode = teamRepository.searchForBackoffice("dk", PageRequest.of(0, 10))
+		List<String> byCode = teamRepository.searchForBackoffice("dk", null, PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(byCode).containsExactly("Dplus KIA");
 
 		// 매칭 없음
-		Page<Team> none = teamRepository.searchForBackoffice("zzz", PageRequest.of(0, 10));
+		Page<Team> none = teamRepository.searchForBackoffice("zzz", null, PageRequest.of(0, 10));
 		assertThat(none.getTotalElements()).isZero();
+	}
+
+	@Test
+	@DisplayName("league을 주면 해당 리그(LeagueTeam)에 속한 팀만, q와 함께도 동작한다")
+	void searchForBackoffice_filtersByLeague() {
+		Team genG = teamRepository.save(Team.builder().name("Gen.G").code("GEN").build());
+		Team t1 = teamRepository.save(Team.builder().name("T1").code("T1").build());
+		Team weibo = teamRepository.save(Team.builder().name("Weibo Gaming").code("WBG").build());
+
+		League lck = em.merge(League.builder().leagueName("LCK").seasonYear(2025)
+				.seasonSplit("Spring").isPlayoffs(false).build());
+		League lpl = em.merge(League.builder().leagueName("LPL").seasonYear(2025)
+				.seasonSplit("Spring").isPlayoffs(false).build());
+		em.persist(LeagueTeam.builder().league(lck).team(genG).build());
+		em.persist(LeagueTeam.builder().league(lck).team(t1).build());
+		em.persist(LeagueTeam.builder().league(lpl).team(weibo).build());
+		em.flush();
+		em.clear();
+
+		// LCK 소속 팀만
+		List<String> lckTeams = teamRepository.searchForBackoffice(null, "LCK", PageRequest.of(0, 10))
+				.map(Team::getName).getContent();
+		assertThat(lckTeams).containsExactlyInAnyOrder("Gen.G", "T1");
+
+		// LCK + q 결합
+		List<String> lckGen = teamRepository.searchForBackoffice("gen", "LCK", PageRequest.of(0, 10))
+				.map(Team::getName).getContent();
+		assertThat(lckGen).containsExactly("Gen.G");
+
+		// 소속 팀 없는 리그
+		assertThat(teamRepository.searchForBackoffice(null, "LEC", PageRequest.of(0, 10)).getTotalElements())
+				.isZero();
 	}
 }

--- a/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
@@ -1,0 +1,51 @@
+package com.toy.nar.domain.participant.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import com.toy.nar.domain.participant.entity.Team;
+
+// 백오피스 검색 쿼리(searchForBackoffice) 검증. H2 격리 실행(마이그레이션은 MySQL 전용이라 엔티티 기반 스키마 사용).
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class TeamRepositorySearchTest {
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Test
+	@DisplayName("q가 null이면 전체, 값이 있으면 팀명·코드 부분일치(대소문자 무시)로 검색한다")
+	void searchForBackoffice_matchesNameOrCode() {
+		teamRepository.save(Team.builder().name("Gen.G").code("GEN").build());
+		teamRepository.save(Team.builder().name("Dplus KIA").code("DK").build());
+		teamRepository.save(Team.builder().name("T1").code("T1").build());
+
+		// null → 전체
+		assertThat(teamRepository.searchForBackoffice(null, PageRequest.of(0, 10)).getTotalElements())
+				.isEqualTo(3);
+
+		// 팀명 부분일치(소문자 입력도 매칭)
+		List<String> byName = teamRepository.searchForBackoffice("gen", PageRequest.of(0, 10))
+				.map(Team::getName).getContent();
+		assertThat(byName).containsExactly("Gen.G");
+
+		// 코드 부분일치
+		List<String> byCode = teamRepository.searchForBackoffice("dk", PageRequest.of(0, 10))
+				.map(Team::getName).getContent();
+		assertThat(byCode).containsExactly("Dplus KIA");
+
+		// 매칭 없음
+		Page<Team> none = teamRepository.searchForBackoffice("zzz", PageRequest.of(0, 10));
+		assertThat(none.getTotalElements()).isZero();
+	}
+}


### PR DESCRIPTION
## 개요

백오피스 목록 API(members/players/teams)에 검색을 추가한다. 서버 페이징이라 클라이언트 필터로는 로드된 페이지만 걸러져 무의미하므로 서버 사이드로 구현했다. FE 검색창(warding-backoffice-fe PR #1)과 짝이다.

## 변경

`GET /api/admin/{members,players,teams}`에 선택 `q` 파라미터 추가.

| 리소스 | 검색 대상 |
|--------|-----------|
| members | 닉네임(name)·이메일 |
| players | 선수명·실명 |
| teams | 팀명·코드 |

- 부분일치, 대소문자 무시(`LIKE LOWER(...)`)
- `q`가 비었으면 전체 조회(`:q IS NULL` 분기)
- 기존 페이징/정렬과 함께 동작

## 검증

- `compileJava` 통과
- `TeamRepositorySearchTest`(H2 @DataJpaTest): null=전체, 팀명/코드 부분일치, 미매칭 케이스 검증. 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)