### PR TITLE
feat: 구독 관리 정렬 개선 — 선수 포지션순·구독 팀 최상단 (#235)

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationService.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationService.java
@@ -60,6 +60,8 @@ public class MobileTeamNotificationService {
 							? defaultResponse(member, team)
 							: toResponse(member, subscription);
 				})
+				// 구독 중인 팀을 최상단에 올리고, 그 안에서는 리그 화면 순서(catalog) 유지(안정 정렬).
+				.sorted(Comparator.comparing((TeamNotificationSubscriptionResponse response) -> !response.subscribed()))
 				.toList();
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/subscription/MobilePlayerSubscriptionService.java
+++ b/src/main/java/com/toy/nar/app/mobile/subscription/MobilePlayerSubscriptionService.java
@@ -6,6 +6,7 @@ import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.entity.MemberFavoritePlayer;
 import com.toy.nar.domain.member.repository.MemberFavoritePlayerRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.participant.PlayerRoleOrder;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +58,9 @@ public class MobilePlayerSubscriptionService {
 				.map(subscription -> playerOptions.get(subscription.getPlayer().getId()))
 				.filter(option -> option != null)
 				.map(option -> PlayerSubscriptionResponse.from(option, true))
-				.sorted((left, right) -> left.playerName().compareToIgnoreCase(right.playerName()))
+				.sorted(Comparator
+						.comparingInt((PlayerSubscriptionResponse response) -> PlayerRoleOrder.of(response.role()))
+						.thenComparing(PlayerSubscriptionResponse::playerName, String.CASE_INSENSITIVE_ORDER))
 				.toList();
 	}
 

--- a/src/main/java/com/toy/nar/domain/participant/PlayerRoleOrder.java
+++ b/src/main/java/com/toy/nar/domain/participant/PlayerRoleOrder.java
@@ -1,0 +1,22 @@
+package com.toy.nar.domain.participant;
+
+import java.util.List;
+import java.util.Locale;
+
+/** 선수 포지션 정렬 순서(탑→정글→미드→바텀→서포터). role 값은 players.role(Top/Jungle/Mid/ADC/Support). */
+public final class PlayerRoleOrder {
+
+	private static final List<String> ORDER = List.of("TOP", "JUNGLE", "MID", "ADC", "SUPPORT");
+
+	private PlayerRoleOrder() {
+	}
+
+	/** 정렬 인덱스. 알 수 없거나 null 인 포지션은 맨 뒤로. */
+	public static int of(String role) {
+		if (role == null) {
+			return ORDER.size();
+		}
+		int index = ORDER.indexOf(role.toUpperCase(Locale.ROOT));
+		return index < 0 ? ORDER.size() : index;
+	}
+}

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -95,7 +95,14 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 					WHERE ranked.rn = 1
 					  AND (:teamId IS NULL OR ranked.teamId = :teamId)
 					  AND (:query IS NULL OR LOWER(ranked.playerName) LIKE LOWER(CONCAT('%', :query, '%')))
-					ORDER BY ranked.playerName
+					ORDER BY CASE UPPER(ranked.role)
+					             WHEN 'TOP' THEN 1
+					             WHEN 'JUNGLE' THEN 2
+					             WHEN 'MID' THEN 3
+					             WHEN 'ADC' THEN 4
+					             WHEN 'SUPPORT' THEN 5
+					             ELSE 6 END,
+					         ranked.playerName
 					""",
 			countQuery = """
 					SELECT COUNT(*)

--- a/src/test/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationServiceTest.java
@@ -61,7 +61,7 @@ class MobileTeamNotificationServiceTest {
 	}
 
 	@Test
-	void returnsAvailableTeamsInCatalogOrderWithSubscriptionState() {
+	void returnsAvailableTeamsWithSubscribedFirstThenCatalogOrder() {
 		Team t1 = team(1L, "T1", "T1");
 		Team gen = team(2L, "Gen.G", "GEN");
 		Member member = member(7L, t1);
@@ -73,14 +73,15 @@ class MobileTeamNotificationServiceTest {
 
 		var response = service.getAvailableTeams(7L);
 
+		// 구독 중인 GEN 이 카탈로그상 T1 보다 뒤여도 최상단에 노출된다.
 		assertThat(response).extracting(item -> item.teamCode())
-				.containsExactly("T1", "GEN");
-		assertThat(response.get(0).subscribed()).isFalse();
-		assertThat(response.get(0).setStartEnabled()).isTrue();
-		assertThat(response.get(0).setEndEnabled()).isTrue();
-		assertThat(response.get(0).liveEventEnabled()).isFalse();
-		assertThat(response.get(1).subscribed()).isTrue();
-		assertThat(response.get(1).liveEventEnabled()).isTrue();
+				.containsExactly("GEN", "T1");
+		assertThat(response.get(0).subscribed()).isTrue();
+		assertThat(response.get(0).liveEventEnabled()).isTrue();
+		assertThat(response.get(1).subscribed()).isFalse();
+		assertThat(response.get(1).setStartEnabled()).isTrue();
+		assertThat(response.get(1).setEndEnabled()).isTrue();
+		assertThat(response.get(1).liveEventEnabled()).isFalse();
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
@@ -148,16 +148,17 @@ class PlayerRepositoryLckPlayerOptionsTest {
 	}
 
 	@Test
-	@DisplayName("페이지네이션: size=2, page0 은 이름순 2건 + 전체 4건/2페이지")
+	@DisplayName("페이지네이션: size=2, page0 은 포지션순 2건 + 전체 4건/2페이지")
 	void paginates() {
 		Page<LckPlayerOption> page0 = playerRepository.findLckPlayerOptions(
 				LCK, YEAR, null, null, PageRequest.of(0, 2));
 
 		assertThat(page0.getTotalElements()).isEqualTo(4);
 		assertThat(page0.getTotalPages()).isEqualTo(2);
-		// 이름순: Faker, GenStar, Mover, Twin
+		// 포지션순(탑→정글→미드→바텀→서폿), 동일 포지션 내 이름순:
+		// Mover(Top), Faker(Mid), GenStar(Mid), Twin(Support)
 		assertThat(page0.getContent()).extracting(LckPlayerOption::getPlayerName)
-				.containsExactly("Faker", "GenStar");
+				.containsExactly("Mover", "Faker");
 	}
 
 	// ── 시딩 헬퍼 (네이티브 SQL) ─────────────────────────────────


### PR DESCRIPTION
## 개요
구독 관리 화면 정렬을 롤 팬에게 직관적인 순서로 변경. (#235)

## 변경
### 선수 — 포지션순
기존 ABC순 → 포지션순(탑 → 정글 → 미드 → 바텀 → 서포터). 포지션 미상은 맨 뒤.
- `PlayerRoleOrder` 헬퍼 신규 (role 값: `Top/Jungle/Mid/ADC/Support`)
- 구독 목록: 포지션순 + 동일 포지션 내 이름순
- 추천 목록(페이징): DB 정렬이 필요해 native `ORDER BY CASE` 로 포지션순

### 팀 — 구독 팀 최상단
리그 화면 순서(T1 → 한화 → 젠지 …, `LckTeamCatalog`)는 유지하되 이미 구독 중인 팀을 최상단에 우선 노출. 안정 정렬이라 그룹 내 카탈로그 순서 보존.

## 검증
- `./gradlew compileJava` 통과
- DB 실쿼리로 CASE 순서 확인: Top(1) → Jungle(2) → Mid(3) → ADC(4=바텀) → Support(5) → NULL(6)

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)