### PR TITLE
fix: 라이브 킬 알림 진영 스왑 시 팀명·선수 어긋남 수정 (HLE→BLG 표기 버그)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -343,11 +343,40 @@ public class LiveObjectEventRecorder {
 		}
 	}
 
+	/**
+	 * 진영(Blue/Red)의 표시용 팀명. 세트마다 진영이 스왑되므로 매치 기준 blue/redTeamName 을 그대로 쓰면
+	 * 팀명과 선수가 어긋난다(#: HLE Gumayusi 가 BILIBILI GAMING 으로 표기). window 의 진영별
+	 * esportsTeamId 를 매치 메타데이터의 id↔팀명 쌍과 대조해 실제 팀명을 찾고, 대조가 불가능할 때만
+	 * 매치 기준으로 폴백한다.
+	 */
 	private String teamNameOf(ActiveLiveGame activeGame, String teamSide) {
+		String fromWindow = windowSideTeamName(activeGame, teamSide);
+		if (fromWindow != null) {
+			return fromWindow;
+		}
 		if ("Blue".equalsIgnoreCase(teamSide)) {
 			return activeGame.blueTeamName();
 		}
 		if ("Red".equalsIgnoreCase(teamSide)) {
+			return activeGame.redTeamName();
+		}
+		return null;
+	}
+
+	/** window 진영별 esportsTeamId 를 매치 메타데이터와 대조해 팀명을 찾는다. 못 찾으면 null. */
+	private String windowSideTeamName(ActiveLiveGame activeGame, String teamSide) {
+		SideTeamIds sideIds = sideTeamIdsByGame.get(activeGame.gameId());
+		if (sideIds == null) {
+			return null;
+		}
+		String sideTeamId = "Blue".equalsIgnoreCase(teamSide) ? sideIds.blue() : sideIds.red();
+		if (sideTeamId == null || sideTeamId.isBlank()) {
+			return null;
+		}
+		if (sideTeamId.equals(activeGame.blueEsportsTeamId())) {
+			return activeGame.blueTeamName();
+		}
+		if (sideTeamId.equals(activeGame.redEsportsTeamId())) {
 			return activeGame.redTeamName();
 		}
 		return null;
@@ -451,7 +480,7 @@ public class LiveObjectEventRecorder {
 	/* ---------- 푸시 문구 빌더 (경기 흐름을 알 수 있게 상대 카운트를 함께 보여준다) ---------- */
 
 	private String opponentNameOf(ActiveLiveGame activeGame, String teamSide) {
-		return "Blue".equalsIgnoreCase(teamSide) ? activeGame.redTeamName() : activeGame.blueTeamName();
+		return teamNameOf(activeGame, "Blue".equalsIgnoreCase(teamSide) ? "Red" : "Blue");
 	}
 
 	private String setSuffix(ActiveLiveGame activeGame) {

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
@@ -7,6 +7,7 @@ import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
 import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
 import com.toy.nar.app.mobile.push.TeamLiveEventPushService;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,6 +16,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,6 +45,71 @@ class LiveObjectEventRecorderTest {
 
 	private String invokeWithTeam(String team, String player) {
 		return (String) ReflectionTestUtils.invokeMethod(recorder, "withTeam", team, player);
+	}
+
+	@Test
+	void killPushShowsWindowSideTeamsWhenSidesSwapBetweenSets() throws Exception {
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		LiveObjectEventRecorder swapRecorder = new LiveObjectEventRecorder(
+				objectEventRepository, mock(NotificationService.class), pushService);
+		ReflectionTestUtils.setField(swapRecorder, "notificationLeagues", "LCK");
+		when(objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(any(), any(), any(), any()))
+				.thenReturn(false);
+		when(objectEventRepository.save(any(LiveGameObjectEvent.class))).thenAnswer(invocation -> {
+			LiveGameObjectEvent saved = invocation.getArgument(0);
+			ReflectionTestUtils.setField(saved, "id", 42L);
+			return saved;
+		});
+
+		// 매치 기준 Blue=HLE, Red=BLG. 이번 세트는 진영이 스왑되어 window 기준 Blue=BLG, Red=HLE.
+		ActiveLiveGame game = new ActiveLiveGame("game-2", "match-2", "LCK",
+				"Hanwha Life Esports", "BILIBILI GAMING",
+				LocalDateTime.now(ZoneOffset.UTC), 0,
+				4, "team-hle", "team-blg");
+		JsonNode window = objectMapper.readTree("""
+				{
+				  "gameMetadata": {
+				    "blueTeamMetadata": {
+				      "esportsTeamId": "team-blg",
+				      "participantMetadata": [
+				        { "participantId": 1, "summonerName": "ON", "championId": "Alistar" }
+				      ]
+				    },
+				    "redTeamMetadata": {
+				      "esportsTeamId": "team-hle",
+				      "participantMetadata": [
+				        { "participantId": 6, "summonerName": "Zeus", "championId": "Rumble" }
+				      ]
+				    }
+				  },
+				  "frames": [
+				    {
+				      "rfc460Timestamp": "2026-07-09T11:20:00.000Z",
+				      "blueTeam": { "totalKills": 0, "dragons": [],
+				        "participants": [ { "participantId": 1, "kills": 0, "deaths": 0 } ] },
+				      "redTeam": { "totalKills": 1, "dragons": [],
+				        "participants": [ { "participantId": 6, "kills": 1, "deaths": 0 } ] }
+				    },
+				    {
+				      "rfc460Timestamp": "2026-07-09T11:20:10.000Z",
+				      "blueTeam": { "totalKills": 1, "dragons": [],
+				        "participants": [ { "participantId": 1, "kills": 1, "deaths": 0 } ] },
+				      "redTeam": { "totalKills": 1, "dragons": [],
+				        "participants": [ { "participantId": 6, "kills": 1, "deaths": 1 } ] }
+				    }
+				  ]
+				}
+				""");
+
+		swapRecorder.record(game, window);
+
+		// 킬러 ON 은 window 기준 Blue=BLG 소속. 팀명도 BLG 여야 한다(매치 기준 Blue=HLE 아님).
+		ArgumentCaptor<String> title = ArgumentCaptor.forClass(String.class);
+		verify(pushService).notifyLiveEvent(
+				eq("match-2"), eq(4), anyLong(), eq("team-blg"), title.capture(), any());
+		assertThat(title.getValue())
+				.isEqualTo("BILIBILI GAMING ON님이 Hanwha Life Esports Zeus님을 처치했습니다");
 	}
 
 	@Test


### PR DESCRIPTION
## 증상
라이브 킬 푸시에서 팀명과 선수가 서로 반대로 표기됨.
> "**BILIBILI GAMING** HLE Gumayusi님이 **Hanwha Life Esports** BLG ON님을 처치했습니다"

## 원인
세트마다 블루/레드 진영이 스왑되는데, 문구를 만드는 세 소스가 어긋나 있었다.

| 정보 | 소스 | 진영 스왑 반영 |
|---|---|---|
| 팀 표시명 (`teamNameOf`) | 매치 기준 `blue/redTeamName` | ❌ |
| 선수명·킬 감지 | 라이브 window `blue/redTeamMetadata` | ✅ |
| 푸시 라우팅 (`sideTeamIdsByGame`) | window `esportsTeamId` | ✅ (FCM #21에서 수정됨) |

FCM #21이 라우팅은 window 기준으로 고쳤지만 표시 문구는 매치 기준이 남아 있어, 진영이 스왑된 세트(예: 4세트)에서 window Blue=BLG인데 팀명은 매치 Blue=HLE 를 출력 → 어긋남.

## 수정
`teamNameOf` 가 window 의 진영별 `esportsTeamId` 를 매치 메타데이터의 id↔팀명 쌍(`blueEsportsTeamId↔blueTeamName`)과 대조해 실제 팀명을 반환. 대조 불가(esportsTeamId 미보유 — 백필 경로 등) 시에만 기존 매치 기준으로 폴백. `opponentNameOf` 는 반대 진영으로 위임.

디스코드 킬 알림, 오브젝트 이벤트(포탑/드래곤/바론) 문구도 같은 경로를 쓰므로 함께 고쳐진다.

## 검증
- 실패 재현 테스트 추가: `killPushShowsWindowSideTeamsWhenSidesSwapBetweenSets` — 진영 스왑 세트에서 "BILIBILI GAMING ON님이 Hanwha Life Esports Zeus님을 처치했습니다" 검증 (수정 전 fail 확인 → 수정 후 pass)
- 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)