### PR TITLE
fix: 세트 종료 감지를 프레임 gameState=finished 1차 판정으로 개선

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -58,6 +58,14 @@ public class LivePollingScheduler {
 	 */
 	private final java.util.Set<String> setEndNotifiedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
+	/**
+	 * livestats 프레임 gameState=finished 로 종료를 확정한 gameId.
+	 * 업스트림 eventDetails 는 종료된 세트를 분 단위(최악: 다음 세트 끝까지) inProgress 로 방치하므로,
+	 * 프레임 신호가 1차 종료 판정이고 notDiscovered 는 fallback 이다.
+	 * 여기 있는 gameId 는 디스커버리에 다시 나타나도 SET_END dedup 을 해제하지 않는다(재발송 방지).
+	 */
+	private final java.util.Set<String> frameFinishedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.max-consecutive-failures:6}")
 	private int maxConsecutiveFailures;
 
@@ -130,7 +138,11 @@ public class LivePollingScheduler {
 								redExternalId);
 						activeGames.put(gameId, next);
 						// 피드에 다시 나타났으면 SET_END 오탐(일시 누락)이었으므로 재발송 가능하게 해제.
-						setEndNotifiedGameIds.remove(gameId);
+						// 단 프레임 finished 로 확정된 게임은 예외 — eventDetails 가 종료를 늦게 반영해
+						// inProgress 로 계속 보이는 것뿐이므로 dedup 을 유지한다.
+						if (!frameFinishedGameIds.contains(gameId)) {
+							setEndNotifiedGameIds.remove(gameId);
+						}
 						liveGameMetadataService.remember(next);
 
 						if (liveNotificationEnabled && current == null && isNotifiableLeague(resolvedLeagueName)) {
@@ -192,7 +204,20 @@ public class LivePollingScheduler {
 			liveStateStore.removeGame(gameId);
 			liveObjectEventRecorder.evict(gameId);
 			setEndNotifiedGameIds.remove(gameId);
+			frameFinishedGameIds.remove(gameId);
 		});
+	}
+
+	/** window 응답의 마지막 프레임이 gameState=finished 인지. 프레임이 없으면 false. */
+	private boolean isFrameFinished(JsonNode windowResponse) {
+		if (windowResponse == null) {
+			return false;
+		}
+		JsonNode frames = windowResponse.path("frames");
+		if (!frames.isArray() || frames.isEmpty()) {
+			return false;
+		}
+		return "finished".equalsIgnoreCase(frames.get(frames.size() - 1).path("gameState").asText());
 	}
 
 	/** gameId 의 매치 내 1-based 세트 번호. match.gameIds 의 순서가 세트 순서다. 못 찾으면 null. */
@@ -243,6 +268,19 @@ public class LivePollingScheduler {
 				String startingTime = computeStartingTime(activeGame.gameId());
 				JsonNode window = liveStatsClient.getWindow(activeGame.gameId(), startingTime);
 				JsonNode details = liveStatsClient.getDetails(activeGame.gameId(), startingTime);
+
+				// 세트 종료 1차 판정: 프레임 gameState=finished (실제 종료 후 수 초 내 반영).
+				// finished 프레임은 timestamp 가 멈춰 aggregator 의 stale 필터에 걸리므로 여기 raw 응답에서 본다.
+				if (isFrameFinished(window)
+						&& frameFinishedGameIds.add(activeGame.gameId())
+						&& teamLiveEventPushService.isEnabled()
+						&& isNotifiableLeague(activeGame.leagueName())
+						&& setEndNotifiedGameIds.add(activeGame.gameId())) {
+					log.info("[live-notify] set-end(frame) gameId={} matchId={} set={}",
+							activeGame.gameId(), activeGame.matchId(), activeGame.setNumber());
+					fireSetEndNotification(activeGame);
+				}
+
 				liveFrameProcessor.process(activeGame, window, details);
 			} catch (Exception e) {
 				ActiveLiveGame failed = activeGame.increaseFailures();

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -16,8 +16,12 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -106,6 +110,140 @@ class LivePollingSchedulerTest {
 
 		verify(leagueMatchService).syncRealtimeMatchStatus(completed, "LCK");
 		verify(cacheEvictionService).evictScheduleCaches();
+	}
+
+	@Test
+	void firesSetEndImmediatelyWhenFrameGameStateFinished() {
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();
+		scheduler.pollActiveGames();
+
+		verify(pushService, times(1)).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				eq("match-1"),
+				eq(2),
+				eq("100"),
+				eq("200"),
+				eq("KT"),
+				eq("HLE"));
+	}
+
+	@Test
+	void doesNotFireSetEndWhileFrameGameStateInGameOrPaused() {
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("in_game"))
+				.thenReturn(windowWithGameState("paused"));
+
+		scheduler.pollActiveGames();
+		scheduler.pollActiveGames();
+
+		verify(pushService, never()).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
+	}
+
+	@Test
+	void rediscoveryDoesNotRefireFrameDetectedSetEnd() {
+		// 업스트림 eventDetails 가 종료된 세트를 inProgress 로 방치하는 케이스:
+		// 프레임 finished 로 SET_END 발사 후, 디스커버리가 같은 gameId 를 다시 봐도
+		// dedup 이 풀려서 재발사되면 안 된다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		WorldsService worldsService = mock(WorldsService.class);
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService, worldsService, leagueMatchService);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+		MatchResultDto stillInProgress = MatchResultDto.builder()
+				.matchId("match-1")
+				.leagueName("LCK")
+				.state("inProgress")
+				.liveGameIds(List.of("game-1"))
+				.gameIds(List.of("game-0", "game-1"))
+				.build();
+		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(stillInProgress))
+				.build());
+
+		scheduler.pollActiveGames();
+		scheduler.discoverLiveGames();
+		scheduler.pollActiveGames();
+
+		verify(pushService, times(1)).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
+	}
+
+	private ActiveLiveGame lckGame(String gameId) {
+		return new ActiveLiveGame(
+				gameId,
+				"match-1",
+				"LCK",
+				"KT",
+				"HLE",
+				LocalDateTime.now(ZoneOffset.UTC),
+				0,
+				2,
+				"100",
+				"200");
+	}
+
+	private com.fasterxml.jackson.databind.JsonNode windowWithGameState(String gameState) {
+		try {
+			return new com.fasterxml.jackson.databind.ObjectMapper().readTree(
+					"{\"frames\":[{\"rfc460Timestamp\":\"2026-07-11T10:00:00Z\",\"gameState\":\"in_game\"},"
+							+ "{\"rfc460Timestamp\":\"2026-07-11T10:00:10Z\",\"gameState\":\"" + gameState + "\"}]}");
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private LiveStatsClient liveStatsClient(LivePollingScheduler scheduler) {
+		return (LiveStatsClient) ReflectionTestUtils.getField(scheduler, "liveStatsClient");
+	}
+
+	private LivePollingScheduler schedulerWith(LiveStateStore liveStateStore, TeamLiveEventPushService pushService) {
+		return schedulerWith(liveStateStore, pushService, mock(WorldsService.class), mock(LeagueMatchService.class));
+	}
+
+	private LivePollingScheduler schedulerWith(
+			LiveStateStore liveStateStore,
+			TeamLiveEventPushService pushService,
+			WorldsService worldsService,
+			LeagueMatchService leagueMatchService) {
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService,
+				mock(LiveStatsClient.class),
+				mock(LiveObjectEventRecorder.class),
+				liveStateStore,
+				mock(LiveFrameProcessor.class),
+				liveGameMetadataServiceMock(),
+				leagueMatchService,
+				mock(CacheEvictionService.class),
+				mock(NotificationService.class),
+				pushService);
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 6);
+		ReflectionTestUtils.setField(scheduler, "notificationLeagues", "LCK");
+		return scheduler;
+	}
+
+	private LiveGameMetadataService liveGameMetadataServiceMock() {
+		return mock(LiveGameMetadataService.class);
 	}
 
 	@Test


### PR DESCRIPTION
## 문제

1세트가 실제로 끝났는데 SET_END 알림이 2세트 종료 시점까지 안 나감 (그 후 1·2세트 동시 발사).

## 원인

SET_END 판정이 유일하게 `getEventDetails` 의 `games[].state` 가 `inProgress` 목록에서 빠지는 것(디스커버리 60초 틱, notDiscovered)에 의존. 이 API 는 게임 state 갱신이 느려서 종료된 세트를 분 단위(최악: 다음 세트 끝까지) `inProgress` 로 방치함. 한편 5초마다 폴링하는 livestats window 프레임에는 `gameState=finished` 가 실제 종료 후 수 초 내 실리는데 코드 어디서도 안 읽고 있었음.

## 수정

- `pollActiveGames` 에서 window 마지막 프레임 `gameState=finished` 감지 → 즉시 SET_END 발사. 감지 지연 60초+업스트림 지연 → 5~10초.
- finished 프레임은 timestamp 가 멈춰 aggregator 의 stale/duplicate 필터에 걸리므로 aggregator 진입 전 raw 응답에서 판정.
- 프레임으로 종료 확정된 gameId 는 디스커버리가 (업스트림 지연으로) 다시 inProgress 로 보여도 dedup 을 해제하지 않음 → 재발사 방지.
- 기존 notDiscovered 경로는 fallback 으로 유지 (피드가 프레임 없이 끊기는 케이스).

## 테스트

- `firesSetEndImmediatelyWhenFrameGameStateFinished` — finished 프레임 → 1회 발사, 재폴링에도 dedup
- `doesNotFireSetEndWhileFrameGameStateInGameOrPaused` — in_game/paused 는 미발사
- `rediscoveryDoesNotRefireFrameDetectedSetEnd` — 발사 후 디스커버리 재발견에도 재발사 없음 (이번 실사례 재현)
- 전체 스위트 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)