### PR TITLE
feat: 무중단 배포 — docker blue/green + nginx upstream 스위치

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,16 +111,29 @@ jobs:
             df -h
             docker system df || true
 
-            # 1. 메인 Spring Boot 앱 배포
+            # 1. 메인 Spring Boot 앱 blue/green 배포
+            # nginx upstream(/etc/nginx/conf.d/nar-upstream.conf)이 가리키는 포트의 반대편에
+            # 새 컨테이너를 띄우고, 헬스체크 통과 후 upstream을 교체한다.
+            # 헬스체크 실패 시 구 컨테이너가 그대로 남아 롤백이 필요 없다.
+            UPSTREAM_CONF="/etc/nginx/conf.d/nar-upstream.conf"
+            ACTIVE_PORT=$(grep -oE '127\.0\.0\.1:[0-9]+' "${UPSTREAM_CONF}" | cut -d: -f2)
+
+            if [ "${ACTIVE_PORT}" = "8080" ]; then
+              NEW_PORT=8083; NEW_NAME=nar-gg-green; OLD_NAME=nar-gg-blue
+            else
+              NEW_PORT=8080; NEW_NAME=nar-gg-blue; OLD_NAME=nar-gg-green
+            fi
+            echo "Active port: ${ACTIVE_PORT} -> deploying ${NEW_NAME} on ${NEW_PORT}"
+
+            # 이전 배포 실패 잔재 정리
+            docker rm -f "${NEW_NAME}" 2>/dev/null || true
+
             echo "Pulling app image: ${APP_IMAGE}"
             docker pull "${APP_IMAGE}"
 
-            echo "Restarting app container..."
-            docker stop nar-gg-container || true
-            docker rm nar-gg-container || true
-            docker run -d --name nar-gg-container -p 8080:8080 \
+            docker run -d --name "${NEW_NAME}" -p 127.0.0.1:${NEW_PORT}:8080 \
               -m 768m \
-              -e JAVA_OPTS="-Xmx512m" \
+              --log-opt max-size=10m --log-opt max-file=5 \
               -e SPRING_PROFILES_ACTIVE="prod" \
               -e DISCORD_WEBHOOK_URL="${{ secrets.DISCORD_WEBHOOK_URL }}" \
               -e DB_URL="${{ secrets.DB_URL }}" \
@@ -157,21 +170,36 @@ jobs:
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               "${APP_IMAGE}"
 
-            echo "Verifying deployed application..."
-            for i in $(seq 1 30); do
-              if curl -fsS http://localhost:8080/v3/api-docs | grep -q '"leagues"'; then
+            # micro+swap 환경은 기동이 느릴 수 있어 상한 120초(60회 x 2초)
+            echo "Verifying new container on port ${NEW_PORT}..."
+            for i in $(seq 1 60); do
+              if curl -fsS "http://localhost:${NEW_PORT}/v3/api-docs" | grep -q '"leagues"'; then
                 echo "Deployment verification succeeded."
                 break
               fi
 
-              if [ "$i" -eq 30 ]; then
-                echo "Deployment verification failed: 'leagues' field not found in OpenAPI spec."
-                docker logs --tail 200 nar-gg-container || true
+              if [ "$i" -eq 60 ]; then
+                echo "Verification failed. Old container keeps serving traffic (no downtime)."
+                docker logs --tail 200 "${NEW_NAME}" || true
+                docker rm -f "${NEW_NAME}" || true
                 exit 1
               fi
 
               sleep 2
             done
+
+            echo "Switching nginx upstream to ${NEW_PORT}..."
+            printf 'upstream nar_backend {\n    server 127.0.0.1:%s;\n}\n' "${NEW_PORT}" \
+              | sudo tee "${UPSTREAM_CONF}" > /dev/null
+            sudo nginx -t && sudo nginx -s reload
+
+            # Spring graceful shutdown 유예 30초보다 길게 대기 (SIGKILL 방지)
+            echo "Stopping old container..."
+            docker stop -t 35 "${OLD_NAME}" 2>/dev/null || true
+            docker rm "${OLD_NAME}" 2>/dev/null || true
+            # 구 배포 방식(nar-gg-container) 잔재 정리 — 최초 전환 이후엔 no-op
+            docker stop -t 35 nar-gg-container 2>/dev/null || true
+            docker rm nar-gg-container 2>/dev/null || true
 
             # 2. Dozzle 배포
             echo "Deploying Dozzle..."


### PR DESCRIPTION
## 배경

기존 배포는 `docker stop → rm → run` 순서라 **배포마다 30초~2분 다운타임**이 있고, 새 컨테이너 검증 실패 시 구 컨테이너가 이미 삭제된 상태라 **서비스가 죽은 채로 남는다**.

사전 검토 문서: 무중단배포 서버 증설 검토 (2026-07) / NAR 무중단배포 적용 전 점검 (2026-07)

## 변경 내용

### 배포 흐름 (deploy.yml)

```
nginx upstream이 가리키는 포트 확인 (blue 8080 / green 8083)
  → 반대편 포트에 새 컨테이너 기동
  → 헬스체크 (/v3/api-docs, 최대 120초)
  → 통과: nginx upstream 교체 + reload (커넥션 유지) → 구 컨테이너 graceful 종료
  → 실패: 새 컨테이너만 제거, 구 컨테이너 계속 서빙 (다운타임 0, 롤백 불필요)
```

### 점검 문서의 함정 반영

| 함정 | 대응 |
|---|---|
| graceful shutdown 30초 vs docker stop 10초 | `docker stop -t 35` |
| 헬스체크 60초 상한 (micro+swap 기동 지연) | 120초로 확대 |
| JAVA_OPTS 죽은 설정 (exec-form이 안 읽음) | env 제거 (실효 힙 192M 유지) |
| 배포 시 로그 소실 | 로테이션 추가 (10m × 5) |
| 8081 포트 sqlite-web 점유 | green은 8083 사용 |
| 스케줄러 중복 (오버랩 1~2분) | 감수 + 경기 시간대 배포 회피. 문제 시 ShedLock |

### 부수 개선

- 앱 컨테이너 바인딩 `0.0.0.0:8080` → `127.0.0.1` (nginx 경유만 허용)

## 서버 사전 세팅 (완료)

- `/etc/nginx/conf.d/nar-upstream.conf` 생성 (현재 8080 유지 — 무영향 확인)
- `sites-enabled/api.nar.kr`의 proxy_pass 3곳 → `nar_backend` upstream (백업: `/etc/nginx/api.nar.kr.bak`)
- `vm.swappiness=10` 적용 + 영속화 (swap 2GB는 기존 설정)

## 검증

- YAML 파싱 OK, 인라인 스크립트 `bash -n` OK
- nginx 교체 후 `https://api.nar.kr` 경유 백엔드 응답 정상 확인
- 실제 무중단 여부는 머지 후 첫 배포에서 오버랩 구간 curl 폴링으로 확인 예정

## 이후 단계 (별도)

- 배포 안정화 후 awslogs 전환 + 보존기간 30일
- 최초 blue/green 전환 배포는 경기 없는 시간대에 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)