### PR TITLE
feat: 앱 로그 CloudWatch 전환 — awslogs 드라이버

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,9 +131,14 @@ jobs:
             echo "Pulling app image: ${APP_IMAGE}"
             docker pull "${APP_IMAGE}"
 
+            # awslogs: CloudWatch /nar/app 로 전송 (보존 30일). docker 20.10+ dual logging
+            # 캐시 덕에 docker logs·Dozzle 도 그대로 동작한다. EC2 롤: NAR-CloudWatch-Role
             docker run -d --name "${NEW_NAME}" -p 127.0.0.1:${NEW_PORT}:8080 \
               -m 768m \
-              --log-opt max-size=10m --log-opt max-file=5 \
+              --log-driver=awslogs \
+              --log-opt awslogs-region=ap-northeast-2 \
+              --log-opt awslogs-group=/nar/app \
+              --log-opt awslogs-create-group=true \
               -e SPRING_PROFILES_ACTIVE="prod" \
               -e DISCORD_WEBHOOK_URL="${{ secrets.DISCORD_WEBHOOK_URL }}" \
               -e DB_URL="${{ secrets.DB_URL }}" \


### PR DESCRIPTION
## 변경

배포마다 `docker rm`으로 이전 컨테이너 로그가 소실되던 문제 해결. 앱 컨테이너 로그를 CloudWatch `/nar/app`으로 전송.

- `--log-driver=awslogs` + `awslogs-create-group=true`
- json-file 로테이션 옵션 제거 (awslogs와 배타)

## 사전 검증 (서버에서 완료)

- 인스턴스 롤 `NAR-CloudWatch-Role`로 테스트 컨테이너 인제스트 성공 → `/nar/app` 그룹 생성 확인
- 보존 30일 설정 완료 — 무료 티어(저장 5GB) 유지 조건
- docker 28.3.2 dual logging 캐시 → `docker logs`·Dozzle **그대로 동작** (기존 우려 해소)
- 부수: VPC Flow Logs 유물 `nargg-log-group`(776MB, 보존 무제한) → 보존 7일로 축소. Flow Logs 자체 끄기는 콘솔 권한 필요(nar-user·인스턴스 롤 둘 다 ec2:DeleteFlowLogs 없음)

## 볼륨

현재 로그 월 수백 MB 수준 — 수집 5GB/월 무료 한도 내 넉넉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)