### PR TITLE
feat: 리그별 라이브 수집·알림·동기화 토글을 DB(league_config)로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,6 @@ jobs:
               -e YOUTUBE_API_KEY="${{ secrets.YOUTUBE_API_KEY }}" \
               -e LOL_ESPORTS_KEY="${{ secrets.LOL_ESPORTS_KEY }}" \
               -e LOL_SYNC_CRON="0 0/30 * * * *" \
-              -e LOL_ACTIVE_LEAGUES="${{ secrets.LOL_ACTIVE_LEAGUES }}" \
               -e LOL_LIVE_ENABLED="true" \
               -e LOL_TEAM_METADATA_CRON="0 15 4 * * *" \
               -e DISCORD_PLAYER_WEBHOOK_URL="${{ secrets.DISCORD_PLAYER_WEBHOOK_URL }}" \
@@ -170,7 +169,6 @@ jobs:
               -e CLOUDINARY_API_SECRET="${{ secrets.CLOUDINARY_API_SECRET }}" \
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
-              -e LOLESPORTS_LIVE_NOTIFICATION_LEAGUES="LCK,MSI" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               "${APP_IMAGE}"

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -1,5 +1,7 @@
 package com.toy.nar.api.admin;
 
+import com.toy.nar.app.lolesports.LeagueConfigService;
+import com.toy.nar.app.lolesports.repository.LeagueConfig;
 import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -8,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,8 +21,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * 백오피스 조회 전용 API. {@code /api/admin/**} 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
- * 응답은 Spring {@link Page} 형식({@code content}, {@code totalElements}) 그대로 — FE 데이터프로바이더가 흡수한다.
+ * 백오피스 API. {@code /api/admin/**} 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
+ * 조회 응답은 Spring {@link Page} 형식({@code content}, {@code totalElements}) 그대로 — FE 데이터프로바이더가 흡수한다.
+ * 쓰기는 리그 설정 토글(PUT /league-configs/{leagueName})만 존재.
  */
 @RestController
 @RequestMapping("/api/admin")
@@ -28,6 +34,7 @@ public class BackofficeController {
     private final PlayerRepository playerRepository;
     private final TeamRepository teamRepository;
     private final LeagueRepository leagueRepository;
+    private final LeagueConfigService leagueConfigService;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
@@ -69,6 +76,18 @@ public class BackofficeController {
         return CRON_CATALOG;
     }
 
+    @GetMapping("/league-configs")
+    public List<LeagueConfigRow> leagueConfigs() {
+        return leagueConfigService.findAll().stream().map(LeagueConfigRow::from).toList();
+    }
+
+    @PutMapping("/league-configs/{leagueName}")
+    public LeagueConfigRow updateLeagueConfig(@PathVariable String leagueName,
+                                              @RequestBody LeagueConfigUpdateRequest request) {
+        return LeagueConfigRow.from(leagueConfigService.update(
+                leagueName, request.liveEnabled(), request.notificationEnabled(), request.syncEnabled()));
+    }
+
     public record MemberRow(Long id, String name, String email,
                             String favoriteLeagueName, LocalDateTime createdAt) {}
 
@@ -76,6 +95,17 @@ public class BackofficeController {
                             String role, Integer age) {}
 
     public record TeamRow(Long id, String name, String code) {}
+
+    public record LeagueConfigRow(String leagueName, boolean liveEnabled,
+                                  boolean notificationEnabled, boolean syncEnabled) {
+        static LeagueConfigRow from(LeagueConfig config) {
+            return new LeagueConfigRow(config.getLeagueName(), config.isLiveEnabled(),
+                    config.isNotificationEnabled(), config.isSyncEnabled());
+        }
+    }
+
+    public record LeagueConfigUpdateRequest(boolean liveEnabled, boolean notificationEnabled,
+                                            boolean syncEnabled) {}
 
     /**
      * @param type        CRON(달력 기준) | INTERVAL(간격 기준)

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConfigService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConfigService.java
@@ -1,0 +1,82 @@
+package com.toy.nar.app.lolesports;
+
+import com.toy.nar.app.lolesports.repository.LeagueConfig;
+import com.toy.nar.app.lolesports.repository.LeagueConfigRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * 리그별 라이브 수집/디스코드 알림/경기 동기화 토글 조회·변경.
+ * 스케줄러(라이브 discovery 60s, 경기 동기화 6h)가 사이클마다 조회한다 — 9행이라 캐시 없이 DB 직조회.
+ */
+@Service
+@RequiredArgsConstructor
+public class LeagueConfigService {
+
+	private final LeagueConfigRepository leagueConfigRepository;
+
+	/** 종전 prod env(LOLESPORTS_LIVE_NOTIFICATION_LEAGUES=LCK,MSI) 동작을 보존하는 알림 시드 기본값. */
+	private static final java.util.Set<String> DEFAULT_NOTIFICATION_LEAGUES = java.util.Set.of("LCK", "MSI");
+
+	/**
+	 * 기동 시 TARGET_LEAGUES 기준 insert-if-missing 시드.
+	 * 기본값은 종전 동작 보존: 수집·동기화 전체 on, 디스코드 알림은 LCK·MSI 만 on.
+	 */
+	@PostConstruct
+	void seedMissing() {
+		for (String league : LeagueConstants.TARGET_LEAGUES) {
+			if (!leagueConfigRepository.existsById(league)) {
+				leagueConfigRepository.save(LeagueConfig.builder()
+						.leagueName(league)
+						.liveEnabled(true)
+						.notificationEnabled(DEFAULT_NOTIFICATION_LEAGUES.contains(league))
+						.syncEnabled(true)
+						.build());
+			}
+		}
+	}
+
+	public List<String> liveLeagues() {
+		return enabledLeagues(LeagueConfig::isLiveEnabled);
+	}
+
+	public List<String> syncLeagues() {
+		return enabledLeagues(LeagueConfig::isSyncEnabled);
+	}
+
+	public boolean isNotificationEnabled(String leagueName) {
+		if (leagueName == null || leagueName.isBlank()) {
+			return false;
+		}
+		return leagueConfigRepository.findById(leagueName.trim().toUpperCase())
+				.map(LeagueConfig::isNotificationEnabled)
+				.orElse(false);
+	}
+
+	public List<LeagueConfig> findAll() {
+		return leagueConfigRepository.findAll().stream()
+				.sorted(Comparator.comparing(LeagueConfig::getLeagueName))
+				.toList();
+	}
+
+	@Transactional
+	public LeagueConfig update(String leagueName, boolean liveEnabled, boolean notificationEnabled, boolean syncEnabled) {
+		LeagueConfig config = leagueConfigRepository.findById(leagueName.trim().toUpperCase())
+				.orElseThrow(() -> new IllegalArgumentException("알 수 없는 리그: " + leagueName));
+		config.update(liveEnabled, notificationEnabled, syncEnabled);
+		return config;
+	}
+
+	private List<String> enabledLeagues(java.util.function.Predicate<LeagueConfig> enabled) {
+		return leagueConfigRepository.findAll().stream()
+				.filter(enabled)
+				.map(LeagueConfig::getLeagueName)
+				.sorted()
+				.toList();
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/MatchSyncScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/MatchSyncScheduler.java
@@ -4,11 +4,9 @@ import com.toy.nar.app.monitor.SchedulerAlertService;
 import com.toy.nar.app.schedule.CacheEvictionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -19,8 +17,7 @@ public class MatchSyncScheduler {
 	private final LeagueMatchService leagueMatchService;
 	private final SchedulerAlertService schedulerAlertService;
 	private final CacheEvictionService cacheEvictionService;
-	@Value("${lolesports.sync.active-leagues:}")
-	private String configuredActiveLeagues;
+	private final LeagueConfigService leagueConfigService;
 
 	// 기본 6시간 주기 (기존 30분 -> 비용 절감)
 	@Scheduled(cron = "${lolesports.sync.cron:0 0 */6 * * *}")
@@ -79,16 +76,8 @@ public class MatchSyncScheduler {
 		}
 	}
 
+	// 백오피스 리그 설정(sync_enabled)이 대상 결정. 구 env(LOL_ACTIVE_LEAGUES)는 폐기.
 	private List<String> resolveTargetLeagues() {
-		if (configuredActiveLeagues == null || configuredActiveLeagues.isBlank()) {
-			return LeagueConstants.TARGET_LEAGUES;
-		}
-		List<String> leagues = Arrays.stream(configuredActiveLeagues.split(","))
-				.map(String::trim)
-				.filter(value -> !value.isBlank())
-				.map(String::toUpperCase)
-				.distinct()
-				.toList();
-		return leagues.isEmpty() ? LeagueConstants.TARGET_LEAGUES : leagues;
+		return leagueConfigService.syncLeagues();
 	}
 }

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveGameMetadataService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveGameMetadataService.java
@@ -2,7 +2,7 @@ package com.toy.nar.app.lolesports.live;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.toy.nar.app.lolesports.LeagueConstants;
+import com.toy.nar.app.lolesports.LeagueConfigService;
 import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
 import com.toy.nar.app.lolesports.WorldsService;
@@ -26,6 +26,7 @@ public class LiveGameMetadataService {
 
 	private final WorldsService worldsService;
 	private final LeagueMatchGameRepository leagueMatchGameRepository;
+	private final LeagueConfigService leagueConfigService;
 	private final Cache<String, Optional<ActiveLiveGame>> metadataByGameId = Caffeine.newBuilder()
 			.expireAfterWrite(60, TimeUnit.SECONDS)
 			.maximumSize(1_000)
@@ -74,7 +75,7 @@ public class LiveGameMetadataService {
 	}
 
 	private Optional<ActiveLiveGame> loadFromSchedule(String gameId) {
-		for (String league : LeagueConstants.TARGET_LEAGUES) {
+		for (String league : leagueConfigService.liveLeagues()) {
 			try {
 				MatchResponseWrapper response = worldsService.getWorldsMatches(null, league);
 				Optional<ActiveLiveGame> match = response.getMatches().stream()

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -44,6 +44,7 @@ public class LivePollingScheduler {
 	private final LiveFrameProcessor liveFrameProcessor;
 	private final LiveGameMetadataService liveGameMetadataService;
 	private final LeagueMatchService leagueMatchService;
+	private final com.toy.nar.app.lolesports.LeagueConfigService leagueConfigService;
 	private final CacheEvictionService cacheEvictionService;
 	private final NotificationService notificationService;
 	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
@@ -72,10 +73,6 @@ public class LivePollingScheduler {
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.enabled:false}")
 	private boolean liveNotificationEnabled;
 
-	// 디스코드 알림을 보낼 리그(쉼표 구분). 기본 LCK 만. 그 외 리그는 데이터 수집만 하고 알림은 보내지 않는다.
-	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.leagues:LCK}")
-	private String notificationLeagues;
-
 	@Scheduled(fixedDelayString = "${lolesports.live.discovery-interval-ms:60000}")
 	public void discoverLiveGames() {
 		Map<String, ActiveLiveGame> activeGames = liveStateStore.getActiveGames();
@@ -96,6 +93,10 @@ public class LivePollingScheduler {
 		}
 		leaguesToPoll.addAll(
 				leagueMatchService.findLeaguesWithMatchesBetween(nowUtc.minusDays(1), nowUtc.plusDays(1)));
+
+		// 백오피스 리그 설정(live_enabled=false)이면 진행 중 게임 포함 수집 자체를 중단한다.
+		Set<String> liveEnabledLeagues = new HashSet<>(leagueConfigService.liveLeagues());
+		leaguesToPoll.removeIf(league -> !liveEnabledLeagues.contains(league.toUpperCase()));
 
 		for (String league : leaguesToPoll) {
 			try {
@@ -317,17 +318,9 @@ public class LivePollingScheduler {
 		return LocalDateTime.ofInstant(Instant.ofEpochSecond(flooredSeconds), ZoneOffset.UTC).format(START_TIME_FORMATTER);
 	}
 
-	/** 알림 대상 리그인지 (notificationLeagues 설정, 기본 LCK). 그 외 리그는 디스코드 알림 안 보냄. */
+	/** 알림 대상 리그인지 (백오피스 리그 설정 notification_enabled). 그 외 리그는 데이터 수집만 하고 알림은 보내지 않는다. */
 	private boolean isNotifiableLeague(String league) {
-		if (league == null || league.isBlank()) {
-			return false;
-		}
-		for (String allowed : notificationLeagues.split(",")) {
-			if (allowed.trim().equalsIgnoreCase(league.trim())) {
-				return true;
-			}
-		}
-		return false;
+		return leagueConfigService.isNotificationEnabled(league);
 	}
 
 	private Instant nextWindowStart(Instant latestFrameTimestamp) {

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueConfig.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueConfig.java
@@ -1,0 +1,36 @@
+package com.toy.nar.app.lolesports.repository;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 리그별 라이브 수집/디스코드 알림/경기 동기화 토글. 백오피스에서 관리한다.
+ * 키는 {@code LeagueConstants.TARGET_LEAGUES} 의 대문자 리그명.
+ */
+@Entity
+@Table(name = "league_config")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class LeagueConfig {
+
+	@Id
+	private String leagueName;
+
+	private boolean liveEnabled;
+	private boolean notificationEnabled;
+	private boolean syncEnabled;
+
+	public void update(boolean liveEnabled, boolean notificationEnabled, boolean syncEnabled) {
+		this.liveEnabled = liveEnabled;
+		this.notificationEnabled = notificationEnabled;
+		this.syncEnabled = syncEnabled;
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueConfigRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueConfigRepository.java
@@ -1,0 +1,6 @@
+package com.toy.nar.app.lolesports.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LeagueConfigRepository extends JpaRepository<LeagueConfig, String> {
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -127,7 +127,7 @@ lolesports:
   sync:
     cron: ${LOL_SYNC_CRON:0 0/30 * * * *}
     team-metadata-cron: ${LOL_TEAM_METADATA_CRON:0 15 4 * * *}
-    active-leagues: ${LOL_ACTIVE_LEAGUES:LCK,LPL,LEC,LCS,LCP,CBLOL,MSI,WORLDS,FIRST_STAND}
+    # active-leagues(env LOL_ACTIVE_LEAGUES) 폐기 — 동기화 대상은 league_config 테이블(백오피스 리그 설정)이 결정.
   live:
     enabled: ${LOL_LIVE_ENABLED:false}
     # 디스커버리 대상 리그를 active+오늘경기 리그로 좁혔으므로(보통 0~2개) 10초로 단축.

--- a/src/main/resources/db/migration/V52__Create_league_config.sql
+++ b/src/main/resources/db/migration/V52__Create_league_config.sql
@@ -1,0 +1,8 @@
+-- 리그별 라이브 수집/디스코드 알림/경기 동기화 토글. 백오피스(/league-configs)에서 관리.
+-- 행 시드는 앱 기동 시 LeagueConfigService 가 TARGET_LEAGUES 기준 insert-if-missing 으로 수행.
+CREATE TABLE league_config (
+    league_name          VARCHAR(30) NOT NULL PRIMARY KEY,
+    live_enabled         BOOLEAN     NOT NULL DEFAULT TRUE,
+    notification_enabled BOOLEAN     NOT NULL DEFAULT FALSE,
+    sync_enabled         BOOLEAN     NOT NULL DEFAULT TRUE
+);

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueConfigServiceTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueConfigServiceTest.java
@@ -1,0 +1,77 @@
+package com.toy.nar.app.lolesports;
+
+import com.toy.nar.app.lolesports.repository.LeagueConfig;
+import com.toy.nar.app.lolesports.repository.LeagueConfigRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 마이그레이션이 MySQL 전용이라 H2 에선 flyway 를 끄고 엔티티 기준으로 스키마를 만든다.
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop",
+})
+class LeagueConfigServiceTest {
+
+	@Autowired
+	private LeagueConfigRepository leagueConfigRepository;
+
+	private LeagueConfigService leagueConfigService;
+
+	@BeforeEach
+	void setUp() {
+		leagueConfigService = new LeagueConfigService(leagueConfigRepository);
+		leagueConfigService.seedMissing();
+	}
+
+	@Test
+	@DisplayName("시드: TARGET_LEAGUES 전체 생성, 알림은 LCK·MSI만 on (종전 prod env 동작 보존)")
+	void seedDefaults() {
+		List<LeagueConfig> all = leagueConfigService.findAll();
+		assertThat(all).hasSameSizeAs(LeagueConstants.TARGET_LEAGUES);
+		assertThat(all).allMatch(LeagueConfig::isLiveEnabled);
+		assertThat(all).allMatch(LeagueConfig::isSyncEnabled);
+		assertThat(all.stream().filter(LeagueConfig::isNotificationEnabled).map(LeagueConfig::getLeagueName))
+				.containsExactlyInAnyOrder("LCK", "MSI");
+	}
+
+	@Test
+	@DisplayName("시드: 이미 있는 행은 덮어쓰지 않는다 (운영자 변경 보존)")
+	void seedKeepsExistingRows() {
+		leagueConfigService.update("LCK", false, false, false);
+		leagueConfigService.seedMissing();
+		assertThat(leagueConfigService.liveLeagues()).doesNotContain("LCK");
+	}
+
+	@Test
+	@DisplayName("update: 토글이 liveLeagues/syncLeagues/isNotificationEnabled 에 반영")
+	void updateReflectsInQueries() {
+		leagueConfigService.update("LPL", false, true, false);
+
+		assertThat(leagueConfigService.liveLeagues()).doesNotContain("LPL");
+		assertThat(leagueConfigService.syncLeagues()).doesNotContain("LPL");
+		assertThat(leagueConfigService.isNotificationEnabled("LPL")).isTrue();
+		// 대소문자·공백 무관
+		assertThat(leagueConfigService.isNotificationEnabled(" lpl ")).isTrue();
+	}
+
+	@Test
+	@DisplayName("update: 알 수 없는 리그면 IllegalArgumentException")
+	void updateUnknownLeague() {
+		org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+				() -> leagueConfigService.update("NOPE", true, true, true));
+	}
+
+	@Test
+	@DisplayName("isNotificationEnabled: null/빈 리그명은 false")
+	void notificationNullSafe() {
+		assertThat(leagueConfigService.isNotificationEnabled(null)).isFalse();
+		assertThat(leagueConfigService.isNotificationEnabled(" ")).isFalse();
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveGameMetadataServiceTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveGameMetadataServiceTest.java
@@ -1,5 +1,6 @@
 package com.toy.nar.app.lolesports.live;
 
+import com.toy.nar.app.lolesports.LeagueConfigService;
 import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
 import com.toy.nar.app.lolesports.WorldsService;
@@ -21,7 +22,9 @@ class LiveGameMetadataServiceTest {
 	void resolvesMetadataFromScheduleAndCachesByGameId() {
 		WorldsService worldsService = mock(WorldsService.class);
 		LeagueMatchGameRepository leagueMatchGameRepository = mock(LeagueMatchGameRepository.class);
-		LiveGameMetadataService service = new LiveGameMetadataService(worldsService, leagueMatchGameRepository);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("LCK"));
+		LiveGameMetadataService service = new LiveGameMetadataService(worldsService, leagueMatchGameRepository, leagueConfigService);
 		when(leagueMatchGameRepository.findWithMatchByGameId("game-1")).thenReturn(Optional.empty());
 		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(MatchResponseWrapper.builder()
 				.matches(List.of(MatchResultDto.builder()

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -1,5 +1,6 @@
 package com.toy.nar.app.lolesports.live;
 
+import com.toy.nar.app.lolesports.LeagueConfigService;
 import com.toy.nar.app.lolesports.LeagueMatchService;
 import com.toy.nar.app.lolesports.MatchResponseWrapper;
 import com.toy.nar.app.lolesports.MatchResultDto;
@@ -45,6 +46,7 @@ class LivePollingSchedulerTest {
 				liveFrameProcessor,
 				liveGameMetadataService,
 				leagueMatchService,
+				mock(LeagueConfigService.class),
 				cacheEvictionService,
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class));
@@ -75,6 +77,8 @@ class LivePollingSchedulerTest {
 		LiveGameMetadataService liveGameMetadataService = mock(LiveGameMetadataService.class);
 		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
 		CacheEvictionService cacheEvictionService = mock(CacheEvictionService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("LCK"));
 		LivePollingScheduler scheduler = new LivePollingScheduler(
 				worldsService,
 				liveStatsClient,
@@ -83,6 +87,7 @@ class LivePollingSchedulerTest {
 				liveFrameProcessor,
 				liveGameMetadataService,
 				leagueMatchService,
+				leagueConfigService,
 				cacheEvictionService,
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class));
@@ -225,6 +230,9 @@ class LivePollingSchedulerTest {
 			TeamLiveEventPushService pushService,
 			WorldsService worldsService,
 			LeagueMatchService leagueMatchService) {
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("LCK"));
+		when(leagueConfigService.isNotificationEnabled("LCK")).thenReturn(true);
 		LivePollingScheduler scheduler = new LivePollingScheduler(
 				worldsService,
 				mock(LiveStatsClient.class),
@@ -233,12 +241,12 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class),
 				liveGameMetadataServiceMock(),
 				leagueMatchService,
+				leagueConfigService,
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				pushService);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 6);
-		ReflectionTestUtils.setField(scheduler, "notificationLeagues", "LCK");
 		return scheduler;
 	}
 
@@ -256,6 +264,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class),
 				mock(LiveGameMetadataService.class),
 				mock(LeagueMatchService.class),
+				mock(LeagueConfigService.class),
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class));


### PR DESCRIPTION
## 요약
백오피스 리그 설정 화면(warding-backoffice-fe#3)의 백엔드. 리그별 **라이브 수집 / 디스코드 알림 / 경기 동기화**를 env·상수 대신 DB로 관리.

- `league_config` 테이블(V52) + 기동 시 `TARGET_LEAGUES` insert-if-missing 시드
  - 기본값: 수집·동기화 전부 on, **알림은 LCK·MSI만 on** — 종전 prod env 동작 그대로
- `GET/PUT /api/admin/league-configs` (ROLE_ADMIN)
- `LivePollingScheduler`: 디스커버리 대상에서 `live_enabled=false` 리그 제외, 알림 게이트 env → DB
- `MatchSyncScheduler`: 동기화 대상 env(`LOL_ACTIVE_LEAGUES`) → DB
- `LiveGameMetadataService`: 메타데이터 조회 리그도 `live_enabled` 기준
- deploy.yml에서 폐기 env 2개 제거 (`LOL_ACTIVE_LEAGUES`, `LOLESPORTS_LIVE_NOTIFICATION_LEAGUES`)

## ⚠️ 배포 시 확인
- secret `LOL_ACTIVE_LEAGUES`가 9개 전체가 아니라 일부였다면, 배포 직후 동기화 대상이 전체로 늘어남 → 백오피스에서 조정
- 이미 운영 중 DB엔 기동 시드가 행만 추가(insert-if-missing) — 운영자 변경 덮어쓰지 않음

## 검증
- 전체 테스트 그린 (`./gradlew test`) — `LeagueConfigServiceTest` 신규(시드 기본값·멱등, update 반영, 대소문자 무관)
- 로컬 e2e: 백오피스 `/league-configs`에서 9개 리그 토글 조회·변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)