### PR TITLE
fix: MSI 라이브 킬 알림 누락 — 레코더 리그 게이트를 league_config로 통일

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -35,16 +35,13 @@ public class LiveObjectEventRecorder {
 	private final LiveGameObjectEventRepository objectEventRepository;
 	private final NotificationService notificationService;
 	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
+	private final com.toy.nar.app.lolesports.LeagueConfigService leagueConfigService;
 	private final Map<String, ObservedObjectState> lastObservedByGame = new ConcurrentHashMap<>();
 	// [FCM #21] 세트마다 진영이 스왑되므로, 피드 window 의 진영별 esportsTeamId 를 게임별로 기억한다(Blue/Red → esportsTeamId).
 	private final Map<String, SideTeamIds> sideTeamIdsByGame = new ConcurrentHashMap<>();
 
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.events-enabled:false}")
 	private boolean eventNotificationEnabled;
-
-	// 디스코드 알림을 보낼 리그(쉼표 구분). 기본 LCK 만. 그 외 리그는 이벤트를 DB에 기록만 하고 알림은 안 보낸다.
-	@org.springframework.beans.factory.annotation.Value("${lolesports.live.notification.leagues:LCK}")
-	private String notificationLeagues;
 
 	public void evict(String gameId) {
 		if (gameId == null || gameId.isBlank()) {
@@ -570,17 +567,9 @@ public class LiveObjectEventRecorder {
 		return value == null || value.isBlank() ? null : value;
 	}
 
-	/** 알림 대상 리그인지 (notificationLeagues 설정, 기본 LCK). 그 외 리그는 디스코드 알림 안 보냄. */
+	/** 알림 대상 리그인지 (백오피스 리그 설정 notification_enabled). 폴러(LivePollingScheduler)와 같은 기준. */
 	private boolean isNotifiableLeague(String league) {
-		if (league == null || league.isBlank()) {
-			return false;
-		}
-		for (String allowed : notificationLeagues.split(",")) {
-			if (allowed.trim().equalsIgnoreCase(league.trim())) {
-				return true;
-			}
-		}
-		return false;
+		return leagueConfigService.isNotificationEnabled(league);
 	}
 
 	private LocalDateTime parseFrameTimestamp(String raw) {

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorderTest.java
@@ -26,8 +26,11 @@ import static org.mockito.Mockito.when;
 class LiveObjectEventRecorderTest {
 
 	private final LiveGameObjectEventRepository objectEventRepository = mock(LiveGameObjectEventRepository.class);
+	private final com.toy.nar.app.lolesports.LeagueConfigService leagueConfigService =
+			mock(com.toy.nar.app.lolesports.LeagueConfigService.class);
 	private final LiveObjectEventRecorder recorder = new LiveObjectEventRecorder(
-			objectEventRepository, mock(NotificationService.class), mock(TeamLiveEventPushService.class));
+			objectEventRepository, mock(NotificationService.class), mock(TeamLiveEventPushService.class),
+			leagueConfigService);
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Test
@@ -35,8 +38,8 @@ class LiveObjectEventRecorderTest {
 		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
 		when(pushService.isEnabled()).thenReturn(true);
 		LiveObjectEventRecorder swapRecorder = new LiveObjectEventRecorder(
-				objectEventRepository, mock(NotificationService.class), pushService);
-		ReflectionTestUtils.setField(swapRecorder, "notificationLeagues", "LCK");
+				objectEventRepository, mock(NotificationService.class), pushService, leagueConfigService);
+		when(leagueConfigService.isNotificationEnabled("LCK")).thenReturn(true);
 		when(objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(any(), any(), any(), any()))
 				.thenReturn(false);
 		when(objectEventRepository.save(any(LiveGameObjectEvent.class))).thenAnswer(invocation -> {


### PR DESCRIPTION
## 증상

MSI 결승(HLE vs BLG) 중 킬·오브젝트 FCM 푸시 전멸. LIVE_EVENT 7/11 356건 → 7/12 **0건**. SET_START/SET_END는 정상 발송(17:11 세트종료, 17:13 세트시작 확인).

## 원인

#254가 리그 알림 토글을 league_config(DB)로 전환하면서 **폴러(LivePollingScheduler)만 전환**하고 `LiveObjectEventRecorder`는 누락. 레코더는 여전히 env `lolesports.live.notification.leagues`(기본 **LCK**)를 읽는데, #254가 deploy.yml에서 `LOLESPORTS_LIVE_NOTIFICATION_LEAGUES=LCK,MSI`를 삭제 → 기본값 LCK로 떨어져 MSI 이벤트 푸시가 게이트에서 무음 스킵.

배제한 것: league_config MSI=1 확인, FCM isReady 정상(SET_END 발송 성공으로 입증), 피드 esportsTeamId 정상, 구독자 존재. 레코더 게이트만 false.

## 수정

레코더 `isNotifiableLeague` → 폴러와 동일한 `LeagueConfigService.isNotificationEnabled`. env 필드 삭제. 테스트 갱신.

## 부가 발견 (별도 이슈 권장)

`resolveSetNumber` 오프바이원 — 게임 606(실제 세트2)이 set=1로 계산돼 세트2 SET_START가 세트1 dedup 키와 충돌·스킵. 이후 세트 번호가 하나씩 밀림.

🤖 Generated with [Claude Code](https://claude.com/claude-code)