### PR TITLE
fix: SET_END 오탐 — 디스커버리 폴백을 stale 확정 시에만 발사

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -187,10 +187,11 @@ public class LivePollingScheduler {
 			boolean stale = activeGame.lastSeenAtUtc() != null
 					&& java.time.Duration.between(activeGame.lastSeenAtUtc(), nowUtc).toMillis() > staleThresholdMs;
 
-			// [FCM #21] SET_END 감지(신규). 직전까지 활성이던 gameId 가 이번 사이클 피드의 라이브 세트에서
-			// 빠지면(=notDiscovered) 세트 종료로 본다. 플래그 게이트 + dedup 으로 1회만 발송된다.
-			// 플래그가 꺼져 있으면 어떤 부작용도 없다(기존 cleanup 동작과 바이트 동일).
-			if (notDiscovered && teamLiveEventPushService.isEnabled()
+			// [FCM #21] SET_END 폴백. 1차 판정은 프레임 gameState=finished(pollActiveGames)이고,
+			// 여기는 프레임 신호를 놓친 채 게임이 피드에서 사라진 경우의 안전망이다.
+			// stale(기본 3분) 확정 전에 쏘면 픽밴 중 디스커버리 플랩으로 오탐 발송되고,
+			// DB dedup 키가 소진돼 진짜 종료가 무음 스킵된다(2026-07-12 MSI 결승 실사례).
+			if (notDiscovered && stale && teamLiveEventPushService.isEnabled()
 					&& isNotifiableLeague(activeGame.leagueName())
 					&& setEndNotifiedGameIds.add(activeGame.gameId())) {
 				fireSetEndNotification(activeGame);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -193,6 +193,52 @@ class LivePollingSchedulerTest {
 				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
 	}
 
+	@Test
+	void discoveryFlapDoesNotFireSetEnd() {
+		// 픽밴 중 게임이 디스커버리에서 한두 사이클 빠지는 플랩(2026-07-12 MSI 결승 실사례):
+		// 즉시 SET_END 를 쏘면 오탐 발송 + DB dedup 키 소진으로 진짜 종료가 무음 스킵된다.
+		// stale(3분) 확정 전에는 발사하면 안 된다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		WorldsService worldsService = mock(WorldsService.class);
+		LivePollingScheduler scheduler = schedulerWith(
+				liveStateStore, pushService, worldsService, mock(LeagueMatchService.class));
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1")); // 방금 본 게임
+		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of())
+				.build());
+
+		scheduler.discoverLiveGames();
+
+		verify(pushService, never()).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
+	}
+
+	@Test
+	void staleUndiscoveredGameFiresSetEndFallback() {
+		// 프레임 finished 를 못 본 채 게임이 피드에서 사라져 stale(3분) 확정되면 폴백으로 1회 발사.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		WorldsService worldsService = mock(WorldsService.class);
+		LivePollingScheduler scheduler = schedulerWith(
+				liveStateStore, pushService, worldsService, mock(LeagueMatchService.class));
+		liveStateStore.getActiveGames().put("game-1", new ActiveLiveGame(
+				"game-1", "match-1", "LCK", "KT", "HLE",
+				LocalDateTime.now(ZoneOffset.UTC).minusMinutes(4), 0, 2, "100", "200"));
+		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of())
+				.build());
+
+		scheduler.discoverLiveGames();
+
+		verify(pushService, times(1)).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				eq("match-1"), eq(2), eq("100"), eq("200"), eq("KT"), eq("HLE"));
+	}
+
 	private ActiveLiveGame lckGame(String gameId) {
 		return new ActiveLiveGame(
 				gameId,


### PR DESCRIPTION
## 증상 (2026-07-12 MSI 결승 실사례)

game 607: 세트 시작 푸시 17:13 → **17:14 SET_END 오탐 발송** → 진짜 종료(18:05, frame finished 감지 정상)는 DB dedup 키 소진으로 **무음 스킵**. 유저는 엉뚱한 시점에 종료 알림을 받고 진짜 종료 알림은 못 받음.

## 원인

디스커버리 폴백이 `notDiscovered` 즉시 SET_END 발사. 픽밴 중 게임이 피드 liveGameIds에서 한두 사이클 빠지는 플랩에 그대로 오탐. 재발견 시 in-memory dedup(`setEndNotifiedGameIds`)은 해제되지만 **DB reserve 키(matchId, setNumber, SET_END, 0)는 영구 소진** → 진짜 종료 발송 불가.

## 수정

폴백 조건을 `notDiscovered && stale`(기본 3분)로 강화. 1차 판정은 #249의 frame gameState=finished라 실제 종료 감지 속도는 그대로(피드 기준 수십 초). 플랩은 stale에 도달하지 못해 무해.

테스트: 플랩 미발사 / stale 확정 발사 2건 추가.

## 남은 이슈 (별도)

- `resolveSetNumber` 오프바이원 (게임 606이 set=1로 계산) — set 번호 표시·dedup 키가 한 칸씩 밀림
- 방송 대비 몇 분 지연은 Riot 피드 자체 delay (수정 불가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)