### PR TITLE
feat: EWC(Esports World Cup) 리그 추가

### DIFF
--- a/src/main/java/com/toy/nar/app/kakao/KakaoScheduleSkillService.java
+++ b/src/main/java/com/toy/nar/app/kakao/KakaoScheduleSkillService.java
@@ -329,6 +329,10 @@ public class KakaoScheduleSkillService {
 		aliases.put("엘씨에스", "LCS");
 		aliases.put("lcp", "LCP");
 		aliases.put("cblol", "CBLOL");
+		aliases.put("ewc", "EWC");
+		aliases.put("esports world cup", "EWC");
+		aliases.put("이스포츠 월드컵", "EWC");
+		aliases.put("이스포츠월드컵", "EWC");
 		return aliases;
 	}
 

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -17,13 +17,13 @@ public final class LeagueConstants {
      * 동기화 및 API 대상 리그 목록
      */
     public static final List<String> TARGET_LEAGUES = List.of(
-            "LCK", "LPL", "LEC", "LCS", "LCP", "CBLOL", "MSI", "WORLDS", "FIRST_STAND");
+            "LCK", "LPL", "LEC", "LCS", "LCP", "CBLOL", "MSI", "WORLDS", "FIRST_STAND", "EWC");
 
     /**
      * 일정 조회 시 허용되는 리그 목록 (TARGET_LEAGUES + 추가 리그)
      */
     public static final Set<String> ALLOWED_LEAGUES = Set.of(
-            "LCK", "LPL", "LCP", "LEC", "LCS", "CBLOL", "MSI", "WORLDS", "FIRST_STAND");
+            "LCK", "LPL", "LCP", "LEC", "LCS", "CBLOL", "MSI", "WORLDS", "FIRST_STAND", "EWC");
 
     /**
      * lolesports API의 리그 ID 매핑
@@ -37,7 +37,8 @@ public final class LeagueConstants {
             Map.entry("CBLOL", "98767991332355509"),
             Map.entry("FIRST_STAND", "113464388705111224"),
             Map.entry("WORLDS", "98767975604431411"),
-            Map.entry("MSI", "98767991325878492"));
+            Map.entry("MSI", "98767991325878492"),
+            Map.entry("EWC", "116838530616006090"));
 
     /**
      * 리그별 기본 라이브 스트림 URL


### PR DESCRIPTION
## 요약
- `TARGET_LEAGUES` / `ALLOWED_LEAGUES` / `LEAGUE_IDS`에 EWC 추가 (lolesports API id `116838530616006090`, slug `ewc_lol`)
- 카카오 스킬 리그 별칭 추가: ewc / esports world cup / 이스포츠 월드컵 / 이스포츠월드컵

## 동작
- `league_config` 행은 앱 기동 시 `LeagueConfigService`가 자동 시드 → 백오피스에서 라이브/알림/싱크 토글 가능
- 30분 주기 싱크가 EWC 경기 자동 수집 → 모바일 경기리스트·캘린더 노출 (앱 리그 필터는 서버 응답 기반이라 플러터 수정 불필요 확인함)
- 중계 링크는 SOOP 폴백 (치지직 EWC 중계권 미확인 — 확인되면 `STREAM_LINKS` 추가)

## 테스트
- `lolesports.* / kakao.* / schedule.* / mobile.*` 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)