### PR TITLE
fix: EWC 경기 미노출 — API slug(ewc_lol) 리그명 보정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -58,6 +58,14 @@ public final class LeagueConstants {
     public static final String DEFAULT_STREAM_URL = "https://play.sooplive.co.kr/aflol";
 
     /**
+     * lolesports API 리그 slug → 내부 리그명. slug이 리그 코드와 다른 리그(EWC: ewc_lol)만 보정한다.
+     */
+    public static String fromApiSlug(String slug) {
+        String upper = slug == null ? "" : slug.trim().toUpperCase();
+        return "EWC_LOL".equals(upper) ? "EWC" : upper;
+    }
+
+    /**
      * 리그에 해당하는 라이브 스트림 URL 반환
      */
     public static String getLiveStreamUrl(String leagueName) {

--- a/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
@@ -189,12 +189,12 @@ public class WorldsService {
 
 			String liveStreamUrl = findBestLiveStreamUrl(event.path("streams"));
 			if ((liveStreamUrl == null || liveStreamUrl.isEmpty()) && "inProgress".equalsIgnoreCase(finalState)) {
-				String leagueSlug = event.path("league").path("slug").asText("").toUpperCase();
+				String leagueSlug = LeagueConstants.fromApiSlug(event.path("league").path("slug").asText(""));
 				liveStreamUrl = LeagueConstants.getLiveStreamUrl(leagueSlug);
 			}
 			return MatchResultDto.builder()
 					.matchId(eventId)
-					.leagueName(event.path("league").path("slug").asText("").toUpperCase())
+					.leagueName(LeagueConstants.fromApiSlug(event.path("league").path("slug").asText("")))
 					.matchTitle(stageName + " | " + teamA.path("code").asText() + " vs "
 							+ teamB.path("code").asText())
 					.matchDate(matchDate)
@@ -348,12 +348,12 @@ public class WorldsService {
 		String liveStreamUrl = findBestLiveStreamUrl(event.path("streams"));
 		// inProgress 상태인데 라이브 스트림 URL이 없으면 리그별 기본값 사용
 		if ((liveStreamUrl == null || liveStreamUrl.isEmpty()) && "inProgress".equalsIgnoreCase(finalState)) {
-			String leagueSlug = event.path("league").path("slug").asText("").toUpperCase();
+			String leagueSlug = LeagueConstants.fromApiSlug(event.path("league").path("slug").asText(""));
 			liveStreamUrl = LeagueConstants.getLiveStreamUrl(leagueSlug);
 		}
 		return MatchResultDto.builder()
 				.matchId(eventId)
-				.leagueName(event.path("league").path("slug").asText("").toUpperCase())
+				.leagueName(LeagueConstants.fromApiSlug(event.path("league").path("slug").asText("")))
 				.matchTitle(teamA.path("code").asText() + " vs " + teamB.path("code").asText())
 				.matchDate(matchDate)
 				.state(finalState)
@@ -435,12 +435,12 @@ public class WorldsService {
 		String liveStreamUrl = findBestLiveStreamUrl(event.path("streams"));
 		// inProgress 상태인데 라이브 스트림 URL이 없으면 리그별 기본값 사용
 		if ((liveStreamUrl == null || liveStreamUrl.isEmpty()) && "inProgress".equalsIgnoreCase(finalState)) {
-			String leagueSlug = event.path("league").path("slug").asText("").toUpperCase();
+			String leagueSlug = LeagueConstants.fromApiSlug(event.path("league").path("slug").asText(""));
 			liveStreamUrl = LeagueConstants.getLiveStreamUrl(leagueSlug);
 		}
 		return MatchResultDto.builder()
 				.matchId(eventId)
-				.leagueName(event.path("league").path("slug").asText("").toUpperCase())
+				.leagueName(LeagueConstants.fromApiSlug(event.path("league").path("slug").asText("")))
 				.matchTitle(stageName + " | " + teamA.path("code").asText() + " vs " + teamB.path("code").asText())
 				.matchDate(matchDate)
 				.state(finalState)

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueConstantsTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueConstantsTest.java
@@ -1,0 +1,20 @@
+package com.toy.nar.app.lolesports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LeagueConstantsTest {
+
+	@Test
+	void EWC_slug은_내부_리그명으로_보정된다() {
+		assertThat(LeagueConstants.fromApiSlug("ewc_lol")).isEqualTo("EWC");
+	}
+
+	@Test
+	void 일반_리그_slug은_대문자화만_한다() {
+		assertThat(LeagueConstants.fromApiSlug("lck")).isEqualTo("LCK");
+		assertThat(LeagueConstants.fromApiSlug("first_stand")).isEqualTo("FIRST_STAND");
+		assertThat(LeagueConstants.fromApiSlug(null)).isEmpty();
+	}
+}


### PR DESCRIPTION
## 문제
EWC 싱크는 성공하는데 캘린더/리스트에 안 뜸. `WorldsService`가 `event.league.slug`를 대문자화해 그대로 `leagueName`으로 저장 — 다른 리그는 slug=코드라 우연히 맞았지만 EWC만 slug이 `ewc_lol`이라 `EWC_LOL`로 저장돼 `leagueName = 'EWC'` 조회에서 전부 빠짐.

## 수정
- `LeagueConstants.fromApiSlug(slug)` 추가: `ewc_lol` → `EWC` 보정, 나머지는 대문자화
- `WorldsService` slug 읽는 6곳 전부 교체

## 기존 오염 데이터
이미 들어간 `EWC_LOL` 28행은 별도 마이그레이션 불필요 — `hasRealtimeRelevantChange`가 leagueName 변경을 업데이트 트리거로 보므로 배포 후 첫 싱크에서 자동 정정됨.

## 테스트
- `LeagueConstantsTest` 추가 (slug 보정 + 일반 slug 회귀)
- `lolesports.*` 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)