### PR TITLE
feat: 회원 탈퇴 API 추가 (DELETE /api/auth/me)

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -27,6 +27,7 @@ import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.entity.RefreshToken;
 import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.member.repository.MemberSocialRepository;
 import com.toy.nar.domain.member.repository.RefreshTokenRepository;
 import com.toy.nar.domain.participant.LckTeamCatalog;
 import com.toy.nar.domain.participant.entity.Player;
@@ -100,6 +101,7 @@ public class AuthController {
     private final AppleUserClient appleUserClient;
     private final SocialLoginService socialLoginService;
     private final MemberRepository memberRepository;
+    private final MemberSocialRepository memberSocialRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TeamRepository teamRepository;
     private final PlayerRepository playerRepository;
@@ -331,6 +333,29 @@ public class AuthController {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
         return ResponseEntity.ok(MemberResponse.from(member));
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자의 계정과 모든 관련 데이터(소셜 연동, 기기, 구독, 알림, 평점)를 삭제합니다. "
+                    + "소셜 연동만 앱에서 지우고 나머지는 DB FK ON DELETE CASCADE로 함께 삭제된다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+    @DeleteMapping("/me")
+    @Transactional
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal Long memberId) {
+        if (memberId == null) {
+            throw new ResponseStatusException(UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
+        memberSocialRepository.deleteByMemberId(memberId);
+        memberRepository.delete(member);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberSocialRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberSocialRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface MemberSocialRepository extends JpaRepository<MemberSocial, Long> {
     Optional<MemberSocial> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -11,6 +11,7 @@ import com.toy.nar.app.mobile.device.MobileDeviceService;
 import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.member.repository.MemberSocialRepository;
 import com.toy.nar.domain.member.repository.RefreshTokenRepository;
 import com.toy.nar.domain.participant.LckTeamCatalog;
 import com.toy.nar.domain.participant.entity.Player;
@@ -52,6 +53,7 @@ class AuthControllerOnboardingNotificationTest {
 				mock(com.toy.nar.app.auth.AppleUserClient.class),
 				socialLoginService,
 				memberRepository,
+				mock(MemberSocialRepository.class),
 				refreshTokenRepository,
 				teamRepository,
 				playerRepository,
@@ -170,6 +172,29 @@ class AuthControllerOnboardingNotificationTest {
 		verify(context.playerRepository).findOnboardingPlayers("LCK", 2026, 1L);
 	}
 
+	@Test
+	void withdrawDeletesSocialLinksAndMember() {
+		TestContext context = context();
+		Member member = member(7L);
+		when(context.memberRepository.findById(7L)).thenReturn(Optional.of(member));
+
+		var response = context.controller.withdraw(7L);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(204);
+		verify(context.memberSocialRepository).deleteByMemberId(7L);
+		verify(context.memberRepository).delete(member);
+	}
+
+	@Test
+	void withdrawRejectsUnknownMember() {
+		TestContext context = context();
+		when(context.memberRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> context.controller.withdraw(99L))
+				.isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+				.hasMessageContaining("회원을 찾을 수 없습니다");
+	}
+
 	private TestContext context() {
 		JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
 		KakaoUserClient kakaoUserClient = mock(KakaoUserClient.class);
@@ -182,6 +207,7 @@ class AuthControllerOnboardingNotificationTest {
 		MobileTeamNotificationService notificationService = mock(MobileTeamNotificationService.class);
 		com.toy.nar.app.auth.profile.ProfileService profileService =
 				mock(com.toy.nar.app.auth.profile.ProfileService.class);
+		MemberSocialRepository memberSocialRepository = mock(MemberSocialRepository.class);
 		AuthController controller = new AuthController(
 				jwtTokenProvider,
 				kakaoUserClient,
@@ -190,6 +216,7 @@ class AuthControllerOnboardingNotificationTest {
 				mock(com.toy.nar.app.auth.AppleUserClient.class),
 				socialLoginService,
 				memberRepository,
+				memberSocialRepository,
 				refreshTokenRepository,
 				teamRepository,
 				playerRepository,
@@ -198,6 +225,7 @@ class AuthControllerOnboardingNotificationTest {
 				profileService,
 				mock(CloudinarySignatureService.class));
 		return new TestContext(
+				memberSocialRepository,
 				controller,
 				memberRepository,
 				teamRepository,
@@ -224,6 +252,7 @@ class AuthControllerOnboardingNotificationTest {
 	}
 
 	private record TestContext(
+			MemberSocialRepository memberSocialRepository,
 			AuthController controller,
 			MemberRepository memberRepository,
 			TeamRepository teamRepository,


### PR DESCRIPTION
## 개요

App Store 심사 가이드라인 5.1.1(v) 대응 — 계정 생성을 지원하는 앱은 계정 삭제 기능이 필수. 앱 마이페이지의 회원탈퇴 버튼(현재 TODO)이 붙을 백엔드 API.

## 스펙

```
DELETE /api/auth/me  (bearerAuth)
204: 탈퇴 완료
401: 미로그인 / 404: 회원 없음
```

## 구현

- `member_social`만 앱에서 명시 삭제 (V33 테이블만 FK에 ON DELETE CASCADE가 없음)
- 나머지 연관 테이블은 전부 기존 FK `ON DELETE CASCADE`로 DB에서 함께 삭제: refresh_token, member_device, member_favorite_player, member_team_notification_subscription, member_match_subscription, member_notification, member_team_event_push_delivery, player_solo_rank_push_delivery, live_player_rating
- 마이그레이션 불필요

## 참고

- Cloudinary 프로필 이미지는 삭제하지 않음 (orphan 허용, 필요 시 후속)
- Apple 토큰 revoke(REST API)는 미구현 — authorization code 교환 플로우가 없어 revoke용 토큰이 없음. 심사 지적 시 후속 대응

## 테스트

- `withdrawDeletesSocialLinksAndMember`, `withdrawRejectsUnknownMember`
- `./gradlew test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)