### PR TITLE
fix: EWC 라이브 미반영 — 스트림 URL 누락·슬러그 해석 실패 보정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -50,7 +50,9 @@ public final class LeagueConstants {
             "LCS", "https://www.twitch.tv/lcs",
             "WORLDS", "https://www.twitch.tv/riotgames",
             "MSI", "https://www.twitch.tv/riotgames",
-            "FIRST_STAND", "https://www.twitch.tv/riotgames");
+            "FIRST_STAND", "https://www.twitch.tv/riotgames",
+            // EWC 2026 한국어 중계는 치지직 독점. 아래는 검증된 영어 공식 Twitch 채널 — 치지직 EWC 채널 ID 확보 시 교체.
+            "EWC", "https://www.twitch.tv/ewclol2026");
 
     /**
      * 스트림 URL이 없는 리그의 기본 폴백 URL
@@ -95,6 +97,11 @@ public final class LeagueConstants {
             "chzzk", "치지직", "LPL 한국어 중계",
             "https://chzzk.naver.com/live/92b762ef6fac0cc8c68bc080868ad582");
 
+    /** EWC 2026 영어 공식 Twitch. 한국어는 치지직 독점이나 채널 ID 미확보 — 확보 시 치지직 링크를 앞에 추가. */
+    private static final StreamLink TWITCH_EWC = new StreamLink(
+            "twitch", "Twitch", "EWC 공식 · 영어",
+            "https://www.twitch.tv/ewclol2026");
+
     /**
      * 리그별 중계 채널 목록. 한국어 중계가 복수인 리그(LCK·국제전)는 치지직/SOOP 둘 다 내려주고,
      * 그 외 리그는 기존 단일 링크를 유지한다.
@@ -106,7 +113,8 @@ public final class LeagueConstants {
             "FIRST_STAND", List.of(CHZZK_LCK, SOOP_AFLOL),
             "LPL", List.of(CHZZK_LPL),
             "LEC", List.of(new StreamLink("twitch", "Twitch", "LEC 공식", "https://www.twitch.tv/lec")),
-            "LCS", List.of(new StreamLink("twitch", "Twitch", "LCS 공식", "https://www.twitch.tv/lcs")));
+            "LCS", List.of(new StreamLink("twitch", "Twitch", "LCS 공식", "https://www.twitch.tv/lcs")),
+            "EWC", List.of(TWITCH_EWC));
 
     /**
      * 리그의 중계 채널 목록 반환. 매핑이 없으면 SOOP 단일 링크로 폴백.

--- a/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
@@ -459,7 +459,8 @@ public class WorldsService {
 	}
 
 	private String normalizeLeagueSlug(String leagueSlug) {
-		return leagueSlug == null || leagueSlug.isBlank() ? "LCK" : leagueSlug.trim().toUpperCase();
+		// fromApiSlug 로 슬러그 변형(EWC: ewc_lol)까지 내부 리그명으로 보정 — 그래야 LEAGUE_IDS 해석이 실패하지 않는다.
+		return leagueSlug == null || leagueSlug.isBlank() ? "LCK" : LeagueConstants.fromApiSlug(leagueSlug);
 	}
 
 	private List<String> extractInProgressGameIds(JsonNode games) {

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueConstantsTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueConstantsTest.java
@@ -17,4 +17,11 @@ class LeagueConstantsTest {
 		assertThat(LeagueConstants.fromApiSlug("first_stand")).isEqualTo("FIRST_STAND");
 		assertThat(LeagueConstants.fromApiSlug(null)).isEmpty();
 	}
+
+	@Test
+	void EWC는_전용_라이브_스트림_URL을_가진다() {
+		// 폴백(LCK aflol)이 아닌 EWC 전용 URL이어야 라이브에 올바른 방송이 뜬다.
+		assertThat(LeagueConstants.getLiveStreamUrl("EWC")).isNotEqualTo(LeagueConstants.DEFAULT_STREAM_URL);
+		assertThat(LeagueConstants.getStreamLinks("EWC")).isNotEmpty();
+	}
 }


### PR DESCRIPTION
## 문제

EWC 경기가 일정 목록엔 뜨지만 라이브(진행중 배지·경기 스트림 URL)가 반영되지 않음.

## 원인 (2개)

1. **경기 URL 누락** — EWC가 `TARGET_LEAGUES`·`LEAGUE_IDS`엔 추가됐으나 `LIVE_STREAM_URLS`·`STREAM_LINKS` 맵엔 없어, `inProgress`여도 `getLiveStreamUrl("EWC")`가 폴백(LCK aflol)을 반환.
2. **슬러그 해석 실패** — `WorldsService.normalizeLeagueSlug`가 대문자화만 하고 `fromApiSlug`를 안 써, 리그명이 슬러그(`ewc_lol`)로 넘어오면 `LEAGUE_IDS` 해석 실패 → 라이브 폴러가 빈 결과 → state가 `inProgress`로 갱신 안 됨.

## 수정

- `LIVE_STREAM_URLS`·`STREAM_LINKS`에 EWC 항목 추가. EWC 2026 한국어 중계는 치지직 독점이나 채널 ID 미확보라, 검증된 영어 공식 Twitch(`twitch.tv/ewclol2026`)로 우선 연결 + 교체 주석.
- `normalizeLeagueSlug`를 `fromApiSlug`로 통일.

## 검증

- `./gradlew test --tests LeagueConstantsTest --tests WorldsServiceTest` → BUILD SUCCESSFUL
- LeagueConstantsTest에 EWC 전용 URL 케이스 추가.

## 후속 (별건)

치지직 EWC 채널 ID 확보 시 한국어 링크로 교체 예정. 배포 후 EWC 경기 라이브 반영 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)