### PR TITLE
fix: EWC 라이브 미감지 — 업스트림 unstarted 방치를 livestats 피드로 재판정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -111,15 +111,27 @@ public class LivePollingScheduler {
 				for (MatchResultDto match : response.getMatches()) {
 					boolean activeOrRecentlyActive = "inProgress".equalsIgnoreCase(match.getState())
 							|| activeMatchIds.contains(match.getMatchId());
+
+					// 업스트림(lolesports)이 EWC 등 일부 대회는 라이브 중에도 경기 state 를 unstarted 로 방치한다.
+					// 스케줄 state 로 못 잡으므로, 시작 시각이 지난 unstarted 경기는 livestats 피드를 직접 찔러
+					// 진행 중 게임을 찾는다. 피드가 라이브면 state 를 inProgress 로 올려 이후 경로를 정상 진입시킨다.
+					List<String> feedLiveGameIds = List.of();
 					if (!activeOrRecentlyActive) {
-						continue;
+						feedLiveGameIds = liveGameIdsFromFeed(match);
+						if (feedLiveGameIds.isEmpty()) {
+							continue;
+						}
+						match.setState("inProgress");
 					}
 					scheduleCacheDirty |= leagueMatchService.syncRealtimeMatchStatus(match, league);
 
-					if (match.getLiveGameIds() == null) {
+					List<String> liveGameIds = !feedLiveGameIds.isEmpty()
+							? feedLiveGameIds
+							: match.getLiveGameIds();
+					if (liveGameIds == null) {
 						continue;
 					}
-					for (String gameId : match.getLiveGameIds()) {
+					for (String gameId : liveGameIds) {
 						if (gameId == null || gameId.isBlank()) {
 							continue;
 						}
@@ -193,6 +205,56 @@ public class LivePollingScheduler {
 			frameFinishedGameIds.remove(gameId);
 			startNotifiedGameIds.remove(gameId);
 		});
+	}
+
+	/** livestats 피드로 라이브를 직접 판정할 시작 시각 창(분). 방송/피드 오차를 흡수한다. */
+	private static final long FEED_PROBE_LEAD_MINUTES = 5L;
+	private static final long FEED_PROBE_TRAIL_HOURS = 6L;
+
+	/**
+	 * 업스트림 state 가 unstarted 인 경기를 livestats 피드로 재판정한다.
+	 * 시작 시각 창 안(−5분 ~ +6시간)의 경기에 한해 게임 id 를 순회하며 window 를 찔러,
+	 * 최근 프레임이 있고 finished 가 아닌(=in_game) 게임 id 목록을 돌려준다.
+	 * 창 밖이거나 게임 id 가 없거나 피드가 비면 빈 목록 — 기존 inProgress 경로에는 영향 없다.
+	 */
+	private List<String> liveGameIdsFromFeed(MatchResultDto match) {
+		if (!"unstarted".equalsIgnoreCase(match.getState()) || !withinFeedProbeWindow(match.getMatchDate())) {
+			return List.of();
+		}
+		List<String> gameIds = match.getGameIds();
+		if (gameIds == null || gameIds.isEmpty()) {
+			return List.of();
+		}
+		List<String> live = new ArrayList<>();
+		for (String gameId : gameIds) {
+			if (gameId == null || gameId.isBlank()) {
+				continue;
+			}
+			try {
+				JsonNode window = liveStatsClient.getWindow(gameId, null);
+				if (hasFrames(window) && !isFrameFinished(window)) {
+					live.add(gameId);
+				}
+			} catch (Exception e) {
+				log.debug("livestats 라이브 프로브 실패 gameId={}: {}", gameId, e.getMessage());
+			}
+		}
+		return live;
+	}
+
+	/** matchDate(ISO instant)가 지금 기준 시작 시각 창 안인지. 파싱 실패 시 false. */
+	private boolean withinFeedProbeWindow(String matchDate) {
+		if (matchDate == null || matchDate.isBlank()) {
+			return false;
+		}
+		try {
+			Instant start = Instant.parse(matchDate);
+			Instant now = Instant.now();
+			return !now.isBefore(start.minus(Duration.ofMinutes(FEED_PROBE_LEAD_MINUTES)))
+					&& !now.isAfter(start.plus(Duration.ofHours(FEED_PROBE_TRAIL_HOURS)));
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	/** window 응답에 프레임이 하나라도 있는지. 픽밴/로딩 중엔 프레임이 없다. */

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -240,6 +240,72 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void upstreamUnstartedButLiveFeedFlipsMatchToInProgress() {
+		// EWC 등 업스트림이 라이브 중에도 unstarted 로 방치하는 대회: 시작 시각이 지난 unstarted 경기의
+		// livestats 피드가 in_game 이면 state 를 inProgress 로 올리고 라이브로 추적해야 한다.
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStatsClient liveStatsClient = mock(LiveStatsClient.class);
+		LiveStateStore liveStateStore = new LiveStateStore();
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("EWC"));
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("EWC"));
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService, liveStatsClient, mock(LiveObjectEventRecorder.class), liveStateStore,
+				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
+				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		MatchResultDto ewcUnstarted = MatchResultDto.builder()
+				.matchId("ewc-match-1").leagueName("EWC").state("unstarted")
+				.matchDate(Instant.now().toString()).gameIds(List.of("ewc-game-1")).build();
+		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(ewcUnstarted)).build());
+		when(liveStatsClient.getWindow("ewc-game-1", null)).thenReturn(windowWithGameState("in_game"));
+
+		scheduler.discoverLiveGames();
+
+		assertThat(ewcUnstarted.getState()).isEqualTo("inProgress");
+		verify(leagueMatchService).syncRealtimeMatchStatus(ewcUnstarted, "EWC");
+		assertThat(liveStateStore.getActiveGames()).containsKey("ewc-game-1");
+	}
+
+	@Test
+	void upstreamUnstartedWithFinishedFeedStaysUnstarted() {
+		// 피드 마지막 프레임이 finished(직전 세트 종료 잔상)면 라이브로 오판하면 안 된다.
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStatsClient liveStatsClient = mock(LiveStatsClient.class);
+		LiveStateStore liveStateStore = new LiveStateStore();
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("EWC"));
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("EWC"));
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService, liveStatsClient, mock(LiveObjectEventRecorder.class), liveStateStore,
+				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
+				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		MatchResultDto ewcUnstarted = MatchResultDto.builder()
+				.matchId("ewc-match-1").leagueName("EWC").state("unstarted")
+				.matchDate(Instant.now().toString()).gameIds(List.of("ewc-game-1")).build();
+		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(ewcUnstarted)).build());
+		when(liveStatsClient.getWindow("ewc-game-1", null)).thenReturn(windowWithGameState("finished"));
+
+		scheduler.discoverLiveGames();
+
+		assertThat(ewcUnstarted.getState()).isEqualTo("unstarted");
+		verify(leagueMatchService, never()).syncRealtimeMatchStatus(
+				org.mockito.ArgumentMatchers.any(), anyString());
+		assertThat(liveStateStore.getActiveGames()).doesNotContainKey("ewc-game-1");
+	}
+
+	@Test
 	void setStartFiresOnFirstFrameNotOnDiscovery() {
 		// 디스커버리 등장 = 픽밴 시작(업스트림이 픽밴 때 inProgress 로 뒤집음)이므로
 		// 그 시점에 쏘면 "이전 세트 종료 몇 분 뒤" 오탐. 첫 프레임 도착 때 1회만 쏴야 한다.


### PR DESCRIPTION
## 문제

EWC 경기가 실제 라이브 중인데 앱엔 "준비중"(unstarted)으로 노출. (#262 의 스트림 URL·슬러그 수정 이후에도 잔존)

## 근본 원인 (실데이터 확인)

lolesports 스케줄/이벤트 API가 EWC 경기 state 를 라이브 중에도 `unstarted` 로 방치. LCK·Worlds 는 라이브 시 `inProgress` 로 뒤집히는 것과 다름.

- `getSchedule`(EWC): GEN vs KC → `state: unstarted`, 유일한 `inProgress` 는 팀 없는 `type: show`
- `getEventDetails`: `event.state: null`, game1 `unstarted`
- **`livestats/v1/window/{gameId}`: HTTP 200, `gameState: in_game`, 최신 타임스탬프** → 실제로는 라이브

라이브 폴러의 디스커버리 게이트가 `state == inProgress` 를 요구해 EWC 는 진입 자체가 안 됨 → livestats 를 보러 가지도 못함.

## 수정

시작 시각 창(−5분~+6시간) 안의 `unstarted` 경기에 한해 게임 id 의 livestats window 를 직접 프로브. 최근 프레임이 있고 `finished` 가 아니면(=in_game) 라이브로 판정 → match state 를 `inProgress` 로 올려 DB 동기화 + 기존 라이브 추적 경로 진입.

- 오탐 가드: 프레임 없음(픽밴/미시작)·마지막 프레임 finished(직전 세트 잔상)는 제외.
- 비용: unstarted+시작창 경기에만, 게임 id 순회. inProgress 로 뒤집히는 리그는 이 분기 안 탐.
- 알림: EWC 는 league_config 알림 off 라 이 경로가 푸시 유발 안 함.

## 검증

- `LivePollingSchedulerTest` 신규 2케이스: in_game → inProgress flip + active 등록 / finished → unstarted 유지·미등록.
- `./gradlew test --tests "com.toy.nar.app.lolesports.*"` BUILD SUCCESSFUL.

## 후속

치지직 EWC 채널 ID 확보 시 스트림 URL 한국어로 교체(#262 후속).

🤖 Generated with [Claude Code](https://claude.com/claude-code)