### PR TITLE
fix: EWC 라이브 프로브 startingTime=null 피드 거부 보정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -231,7 +231,8 @@ public class LivePollingScheduler {
 				continue;
 			}
 			try {
-				JsonNode window = liveStatsClient.getWindow(gameId, null);
+				// startingTime 은 반드시 유효한 값이어야 한다 — null 이면 빈 쿼리파라미터로 나가 피드가 거부한다.
+				JsonNode window = liveStatsClient.getWindow(gameId, computeStartingTime(gameId));
 				if (hasFrames(window) && !isFrameFinished(window)) {
 					live.add(gameId);
 				}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -263,7 +263,7 @@ class LivePollingSchedulerTest {
 				.matchDate(Instant.now().toString()).gameIds(List.of("ewc-game-1")).build();
 		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
 				.matches(List.of(ewcUnstarted)).build());
-		when(liveStatsClient.getWindow("ewc-game-1", null)).thenReturn(windowWithGameState("in_game"));
+		when(liveStatsClient.getWindow(eq("ewc-game-1"), anyString())).thenReturn(windowWithGameState("in_game"));
 
 		scheduler.discoverLiveGames();
 
@@ -295,7 +295,7 @@ class LivePollingSchedulerTest {
 				.matchDate(Instant.now().toString()).gameIds(List.of("ewc-game-1")).build();
 		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
 				.matches(List.of(ewcUnstarted)).build());
-		when(liveStatsClient.getWindow("ewc-game-1", null)).thenReturn(windowWithGameState("finished"));
+		when(liveStatsClient.getWindow(eq("ewc-game-1"), anyString())).thenReturn(windowWithGameState("finished"));
 
 		scheduler.discoverLiveGames();
 


### PR DESCRIPTION
## 문제

#263 배포 후에도 EWC 경기가 라이브인데 여전히 "준비중". 실데이터로 확인: 해당 게임 livestats 피드는 HTTP 200 `in_game`(라이브)인데 우리 API는 unstarted 유지.

## 원인

#263 이 추가한 라이브 프로브가 `getWindow(gameId, null)` 로 호출. `LiveStatsClient` 는 `startingTime` 쿼리파라미터를 항상 붙이는데, null 이면 값 없는 `?startingTime` 로 나가 피드가 거부 → 프로브가 매번 빈 응답 → flip 안 됨. `pollActiveGames` 는 `computeStartingTime` 으로 유효값을 넘겨 정상 동작했음.

유닛테스트는 `getWindow` 를 mock 해 이 경로(실제 WebClient의 null 파라미터 처리)를 타지 않아 초록이었음.

## 수정

프로브도 `computeStartingTime(gameId)` 로 유효한 타임스탬프를 계산해 넘김. 테스트 stub 을 `anyString()` 매처로 조정.

## 검증

- `LivePollingSchedulerTest` 통과.
- 배포 후 prod 에서 라이브 EWC 경기 inProgress 반영 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)