### PR TITLE
fix: EWC 라이브 state가 다음 사이클에 unstarted로 되돌아가던 문제

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -109,19 +109,23 @@ public class LivePollingScheduler {
 			try {
 				MatchResponseWrapper response = worldsService.getWorldsMatches(null, league);
 				for (MatchResultDto match : response.getMatches()) {
+					// 업스트림(lolesports)이 EWC 등 일부 대회는 라이브 중에도 경기 state 를 unstarted 로 방치한다.
+					// 스케줄 state 로 못 잡으므로, 시작 시각이 지난 unstarted 경기는 매 사이클 livestats 피드를 직접 찔러
+					// 진행 중 게임을 찾는다. 피드가 라이브면 state 를 inProgress 로 올린다.
+					// 매 사이클 재판정해야 한다 — 이미 추적 중(activeMatchIds)이어도 여기서 다시 올리지 않으면
+					// 아래 syncRealtimeMatchStatus 가 Riot 원본 unstarted 로 DB 를 되돌린다.
+					List<String> feedLiveGameIds = List.of();
+					if ("unstarted".equalsIgnoreCase(match.getState())) {
+						feedLiveGameIds = liveGameIdsFromFeed(match);
+						if (!feedLiveGameIds.isEmpty()) {
+							match.setState("inProgress");
+						}
+					}
+
 					boolean activeOrRecentlyActive = "inProgress".equalsIgnoreCase(match.getState())
 							|| activeMatchIds.contains(match.getMatchId());
-
-					// 업스트림(lolesports)이 EWC 등 일부 대회는 라이브 중에도 경기 state 를 unstarted 로 방치한다.
-					// 스케줄 state 로 못 잡으므로, 시작 시각이 지난 unstarted 경기는 livestats 피드를 직접 찔러
-					// 진행 중 게임을 찾는다. 피드가 라이브면 state 를 inProgress 로 올려 이후 경로를 정상 진입시킨다.
-					List<String> feedLiveGameIds = List.of();
 					if (!activeOrRecentlyActive) {
-						feedLiveGameIds = liveGameIdsFromFeed(match);
-						if (feedLiveGameIds.isEmpty()) {
-							continue;
-						}
-						match.setState("inProgress");
+						continue;
 					}
 					scheduleCacheDirty |= leagueMatchService.syncRealtimeMatchStatus(match, league);
 

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -273,6 +273,43 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void alreadyTrackedUnstartedMatchStaysInProgressNotRevertedByRawState() {
+		// 회귀: 라이브로 추적 중(activeMatchIds)인 EWC 경기라도 Riot state 가 unstarted 인 한
+		// 매 사이클 피드로 재판정해 inProgress 로 유지해야 한다. 안 그러면 syncRealtimeMatchStatus 가
+		// 원본 unstarted 로 DB 를 되돌린다(=schedule 은 unstarted, live/games 만 라이브인 증상).
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStatsClient liveStatsClient = mock(LiveStatsClient.class);
+		LiveStateStore liveStateStore = new LiveStateStore();
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("EWC"));
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("EWC"));
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService, liveStatsClient, mock(LiveObjectEventRecorder.class), liveStateStore,
+				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
+				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		// 이미 추적 중인 상태로 시작
+		liveStateStore.getActiveGames().put("ewc-game-1", new ActiveLiveGame(
+				"ewc-game-1", "ewc-match-1", "EWC", "GEN", "KC",
+				LocalDateTime.now(ZoneOffset.UTC), 0, 1, "100", "200"));
+		MatchResultDto ewcUnstarted = MatchResultDto.builder()
+				.matchId("ewc-match-1").leagueName("EWC").state("unstarted")
+				.matchDate(Instant.now().toString()).gameIds(List.of("ewc-game-1")).build();
+		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(ewcUnstarted)).build());
+		when(liveStatsClient.getWindow(eq("ewc-game-1"), anyString())).thenReturn(windowWithGameState("in_game"));
+
+		scheduler.discoverLiveGames();
+
+		assertThat(ewcUnstarted.getState()).isEqualTo("inProgress");
+		verify(leagueMatchService).syncRealtimeMatchStatus(ewcUnstarted, "EWC");
+	}
+
+	@Test
 	void upstreamUnstartedWithFinishedFeedStaysUnstarted() {
 		// 피드 마지막 프레임이 finished(직전 세트 종료 잔상)면 라이브로 오판하면 안 된다.
 		WorldsService worldsService = mock(WorldsService.class);


### PR DESCRIPTION
## 문제

#263/#264 배포 후 `/api/live/games` 는 EWC 라이브 게임을 추적하는데(=감지·프레임 수집 정상), `/api/schedule` 의 matchStatus 는 계속 `unstarted`. 앱엔 여전히 "준비중".

## 원인

피드 재판정을 `if (!activeOrRecentlyActive)` 안에서만 수행. 첫 사이클엔 unstarted→inProgress 승격 후 게임이 activeGames 에 등록되지만, 다음 사이클부터는 `activeMatchIds` 에 잡혀 `activeOrRecentlyActive=true` → 피드 분기를 건너뜀 → `syncRealtimeMatchStatus` 에 Riot 원본 `unstarted` 가 그대로 전달되어 **DB 를 매 사이클 unstarted 로 되돌림**. LCK 등은 라이브 시 Riot 도 inProgress 라 이 재-sync 가 무해했으나, EWC 는 unstarted 라 revert 됨.

## 수정

`state==unstarted` 인 동안은 추적 여부와 무관하게 매 사이클 livestats 피드로 재판정 → 라이브면 inProgress 로 유지. `completed`(정상 종료)는 덮지 않음.

## 검증

- 신규 회귀 테스트 `alreadyTrackedUnstartedMatchStaysInProgressNotRevertedByRawState`: 이미 추적 중 + Riot unstarted + 피드 in_game → inProgress 유지·sync 확인. (구코드였으면 실패)
- `LivePollingSchedulerTest` 전체 통과.
- 배포 후 라이브 EWC 경기로 prod 최종 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)