### PR TITLE
feat: 경기 예약 구독에 알림 종류별 토글 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/subscription/MobileMatchSubscriptionController.java
+++ b/src/main/java/com/toy/nar/api/mobile/subscription/MobileMatchSubscriptionController.java
@@ -41,7 +41,10 @@ public class MobileMatchSubscriptionController {
 	public ResponseEntity<Void> subscribe(
 			@AuthenticationPrincipal Long memberId,
 			@Valid @RequestBody MatchSubscribeRequest request) {
-		subscriptionService.subscribe(memberId, request.matchId());
+		subscriptionService.subscribe(memberId, request.matchId(),
+				request.setStartEnabledOrDefault(),
+				request.setEndEnabledOrDefault(),
+				request.liveEventEnabledOrDefault());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/toy/nar/api/mobile/subscription/dto/MatchSubscribeRequest.java
+++ b/src/main/java/com/toy/nar/api/mobile/subscription/dto/MatchSubscribeRequest.java
@@ -7,5 +7,27 @@ import jakarta.validation.constraints.NotBlank;
 public record MatchSubscribeRequest(
 		@NotBlank
 		@Schema(description = "구독할 경기 ID", example = "113990000000000001")
-		String matchId) {
+		String matchId,
+
+		@Schema(description = "세트 시작 알림. 생략 시 true", example = "true")
+		Boolean setStartEnabled,
+
+		@Schema(description = "세트 종료 알림. 생략 시 true", example = "true")
+		Boolean setEndEnabled,
+
+		@Schema(description = "라이브 이벤트 알림. 생략 시 true", example = "true")
+		Boolean liveEventEnabled) {
+
+	// 구버전 앱(플래그 미전송) 호환: null 이면 기존처럼 3종 전부 ON.
+	public boolean setStartEnabledOrDefault() {
+		return setStartEnabled == null || setStartEnabled;
+	}
+
+	public boolean setEndEnabledOrDefault() {
+		return setEndEnabled == null || setEndEnabled;
+	}
+
+	public boolean liveEventEnabledOrDefault() {
+		return liveEventEnabled == null || liveEventEnabled;
+	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -117,7 +117,7 @@ public class TeamLiveEventPushService {
 			long eventOrder,
 			MobilePushMessage message) {
 		try {
-			List<MemberDevice> devices = deviceRepository.findActiveDevicesBySubscribedMatchId(matchId);
+			List<MemberDevice> devices = deviceRepository.findActiveDevicesBySubscribedMatchId(matchId, eventType);
 			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
 					.collect(Collectors.groupingBy(
 							device -> device.getMember().getId(),

--- a/src/main/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionService.java
+++ b/src/main/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionService.java
@@ -32,7 +32,8 @@ public class MobileMatchSubscriptionService {
 	}
 
 	@Transactional
-	public void subscribe(Long memberId, String matchId) {
+	public void subscribe(Long memberId, String matchId,
+			boolean setStartEnabled, boolean setEndEnabled, boolean liveEventEnabled) {
 		if (matchId == null || matchId.isBlank()) {
 			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
 		}
@@ -45,7 +46,8 @@ public class MobileMatchSubscriptionService {
 		}
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
-		subscriptionRepository.save(new MemberMatchSubscription(member, matchId));
+		subscriptionRepository.save(new MemberMatchSubscription(
+				member, matchId, setStartEnabled, setEndEnabled, liveEventEnabled));
 	}
 
 	@Transactional

--- a/src/main/java/com/toy/nar/domain/member/entity/MemberMatchSubscription.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/MemberMatchSubscription.java
@@ -20,7 +20,8 @@ import java.util.Objects;
 
 /**
  * 특정 경기 예약 알림 구독. 팀 구독과 별개로, 유저가 개별 경기를 구독하면
- * 해당 경기의 세트 시작/종료/라이브 이벤트를 받는다(토글 없이 3종 전부).
+ * 해당 경기의 세트 시작/종료/라이브 이벤트를 받는다. 팀 구독과 동일하게
+ * 종류별 토글(set_start/set_end/live_event)을 가진다.
  * match_id 는 league_match.id (외부 경기 식별자, VARCHAR).
  */
 @Entity
@@ -44,12 +45,26 @@ public class MemberMatchSubscription {
 	@Column(name = "match_id", nullable = false, length = 50)
 	private String matchId;
 
+	@Column(name = "set_start_enabled", nullable = false)
+	private boolean setStartEnabled = true;
+
+	@Column(name = "set_end_enabled", nullable = false)
+	private boolean setEndEnabled = true;
+
+	@Column(name = "live_event_enabled", nullable = false)
+	private boolean liveEventEnabled = true;
+
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
-	public MemberMatchSubscription(Member member, String matchId) {
+	public MemberMatchSubscription(
+			Member member, String matchId,
+			boolean setStartEnabled, boolean setEndEnabled, boolean liveEventEnabled) {
 		this.member = Objects.requireNonNull(member);
 		this.matchId = Objects.requireNonNull(matchId);
+		this.setStartEnabled = setStartEnabled;
+		this.setEndEnabled = setEndEnabled;
+		this.liveEventEnabled = liveEventEnabled;
 	}
 
 	@PrePersist

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
@@ -59,8 +59,8 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
 			@Param("eventType") String eventType);
 
 	/**
-	 * 특정 경기를 예약 구독한 회원들의 활성 기기 목록. 팀 구독과 달리 토글이 없어
-	 * 세트 시작/종료/라이브 이벤트를 구분하지 않고 구독 여부만 본다.
+	 * 특정 경기를 예약 구독하고 해당 이벤트 토글(SET_START/SET_END/LIVE_EVENT)이 켜진
+	 * 회원들의 활성 기기 목록. 팀 구독(findActiveDevicesBySubscribedTeamId)과 동일한 패턴이다.
 	 */
 	@EntityGraph(attributePaths = "member")
 	@Query("""
@@ -72,9 +72,16 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
 				  FROM MemberMatchSubscription subscription
 				  WHERE subscription.member = device.member
 				    AND subscription.matchId = :matchId
+				    AND (
+				        (:eventType = 'SET_START' AND subscription.setStartEnabled = true)
+				        OR (:eventType = 'SET_END' AND subscription.setEndEnabled = true)
+				        OR (:eventType = 'LIVE_EVENT' AND subscription.liveEventEnabled = true)
+				    )
 			  )
 			""")
-	List<MemberDevice> findActiveDevicesBySubscribedMatchId(@Param("matchId") String matchId);
+	List<MemberDevice> findActiveDevicesBySubscribedMatchId(
+			@Param("matchId") String matchId,
+			@Param("eventType") String eventType);
 
 	@Modifying(clearAutomatically = true)
 	@Transactional

--- a/src/main/resources/db/migration/V53__Add_toggle_to_member_match_subscription.sql
+++ b/src/main/resources/db/migration/V53__Add_toggle_to_member_match_subscription.sql
@@ -1,0 +1,6 @@
+-- 경기 예약 구독에 알림 종류별 토글 추가(팀 구독과 동일 패턴).
+-- 기존 구독자는 3종 전부 받던 동작을 유지하도록 DEFAULT TRUE 로 백필된다.
+ALTER TABLE member_match_subscription
+    ADD COLUMN set_start_enabled  BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN set_end_enabled    BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN live_event_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/test/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionServiceTest.java
@@ -45,7 +45,7 @@ class MobileMatchSubscriptionServiceTest {
 		when(memberRepository.findById(7L)).thenReturn(
 				Optional.of(Member.builder().name("nar").tag("0001").build()));
 
-		service.subscribe(7L, "m1");
+		service.subscribe(7L, "m1", true, true, true);
 
 		verify(subscriptionRepository).save(any(MemberMatchSubscription.class));
 	}
@@ -55,7 +55,7 @@ class MobileMatchSubscriptionServiceTest {
 		when(leagueMatchRepository.existsById("m1")).thenReturn(true);
 		when(subscriptionRepository.existsByMemberIdAndMatchId(7L, "m1")).thenReturn(true);
 
-		service.subscribe(7L, "m1");
+		service.subscribe(7L, "m1", true, true, true);
 
 		verify(subscriptionRepository, never()).save(any());
 	}
@@ -64,7 +64,7 @@ class MobileMatchSubscriptionServiceTest {
 	void subscribeRejectsUnknownMatch() {
 		when(leagueMatchRepository.existsById("nope")).thenReturn(false);
 
-		assertThatThrownBy(() -> service.subscribe(7L, "nope"))
+		assertThatThrownBy(() -> service.subscribe(7L, "nope", true, true, true))
 				.isInstanceOf(CustomException.class);
 		verify(subscriptionRepository, never()).save(any());
 	}


### PR DESCRIPTION
## 문제
경기 예약 구독(`/api/mobile/me/match-subscriptions`)은 구독만 하면 세트 시작/종료/라이브 이벤트 **3종 전부**를 필터 없이 발송했다. 모바일 '경기 알림 설정' 시트의 토글 3개는 서버로 전송되지 않는 장식이었다.

원인: `MemberDeviceRepository.findActiveDevicesBySubscribedMatchId` 가 `matchId` 일치만 확인하고 eventType 필터가 없었음. (팀 구독 쿼리는 플래그 필터가 이미 있음)

## 변경
팀 구독과 동일한 패턴으로 경기 구독에 종류별 토글을 추가.

- **V53 마이그레이션**: `member_match_subscription` 에 `set_start_enabled` / `set_end_enabled` / `live_event_enabled BOOLEAN DEFAULT TRUE`. 기존 구독자는 현행(3종 전부) 유지.
- **엔티티**: `MemberMatchSubscription` 플래그 3필드 + 생성자
- **쿼리**: `findActiveDevicesBySubscribedMatchId(matchId, eventType)` 에 팀 구독과 동일한 `(:eventType = 'SET_START' AND setStartEnabled = true) OR ...` 필터
- **발송**: `TeamLiveEventPushService.fanOutToMatchSubscribers` 가 eventType 전달
- **API**: `POST` body 에 플래그 3개 수용. 생략 시 `true` → 구버전 앱 호환.

## 호환성
- 구버전 앱(플래그 미전송) → DTO 기본값 true → 현행 동작
- 신버전 앱 + 구버전 백엔드 → 백엔드가 unknown 필드 무시 → 현행 동작
- 필터링은 **양쪽 배포 후** 실제 적용

## 테스트
- `./gradlew compileJava` ✅
- ⚠️ 유닛테스트 미실행 (로컬 MySQL/ES 의존). 라이브 발송 end-to-end 미검증 — `live.notification.fcm.enabled` flag 뒤라 실경기 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)