### PR TITLE
fix: 경기 종료 직후 state 인식 — unstarted 롤백(구멍 A) + completed 방치(구멍 B)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -129,8 +129,15 @@ public class LivePollingScheduler {
 						}
 					}
 
+					// 업스트림 completed flip 이 stale 창(3분)을 넘겨 도착하면 추적이 이미 끝나
+					// activeMatchIds 로는 못 잡는다(EWC 상습 — 그러면 30분 cron 까지 inProgress 방치).
+					// 최근 경기(시작 −5분 ~ +6시간) completed 는 추적 여부와 무관하게 sync 한다.
+					// upsert 가 무변경 skip 이라 이미 completed 인 매치는 write 가 발생하지 않는다.
+					boolean recentlyCompleted = "completed".equalsIgnoreCase(match.getState())
+							&& withinFeedProbeWindow(match.getMatchDate());
 					boolean activeOrRecentlyActive = "inProgress".equalsIgnoreCase(match.getState())
-							|| activeMatchIds.contains(match.getMatchId());
+							|| activeMatchIds.contains(match.getMatchId())
+							|| recentlyCompleted;
 					if (!activeOrRecentlyActive) {
 						continue;
 					}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -116,9 +116,16 @@ public class LivePollingScheduler {
 					// 아래 syncRealtimeMatchStatus 가 Riot 원본 unstarted 로 DB 를 되돌린다.
 					List<String> feedLiveGameIds = List.of();
 					if ("unstarted".equalsIgnoreCase(match.getState())) {
-						feedLiveGameIds = liveGameIdsFromFeed(match);
+						FeedProbe probe = probeFeed(match);
+						feedLiveGameIds = probe.liveGameIds();
 						if (!feedLiveGameIds.isEmpty()) {
 							match.setState("inProgress");
+						} else if (probe.sawFinished()) {
+							// 세트 사이/경기 종료 직후: 피드는 finished 잔상인데 업스트림 state 는 여전히 unstarted.
+							// 여기서 sync 하면 matchId 가 activeMatchIds 에 남아 있는 동안(stale 3분 창)
+							// Riot 원본 unstarted 가 DB 의 inProgress 를 되돌린다. 이 사이클은 건너뛰고
+							// 업스트림 completed flip(또는 30분 cron)에 맡긴다.
+							continue;
 						}
 					}
 
@@ -215,21 +222,28 @@ public class LivePollingScheduler {
 	private static final long FEED_PROBE_LEAD_MINUTES = 5L;
 	private static final long FEED_PROBE_TRAIL_HOURS = 6L;
 
+	/** unstarted 재판정 프로브 결과: 라이브 게임 id 목록 + finished 잔상 관측 여부. */
+	private record FeedProbe(List<String> liveGameIds, boolean sawFinished) {
+		static final FeedProbe EMPTY = new FeedProbe(List.of(), false);
+	}
+
 	/**
 	 * 업스트림 state 가 unstarted 인 경기를 livestats 피드로 재판정한다.
 	 * 시작 시각 창 안(−5분 ~ +6시간)의 경기에 한해 게임 id 를 순회하며 window 를 찔러,
-	 * 최근 프레임이 있고 finished 가 아닌(=in_game) 게임 id 목록을 돌려준다.
-	 * 창 밖이거나 게임 id 가 없거나 피드가 비면 빈 목록 — 기존 inProgress 경로에는 영향 없다.
+	 * 최근 프레임이 있고 finished 가 아닌(=in_game) 게임 id 목록과 finished 관측 여부를 돌려준다.
+	 * finished 관측은 "시작 전"이 아니라 "세트 사이/종료 직후" 신호라 unstarted sync 차단에 쓴다.
+	 * 창 밖이거나 게임 id 가 없거나 피드가 비면 EMPTY — 기존 inProgress 경로에는 영향 없다.
 	 */
-	private List<String> liveGameIdsFromFeed(MatchResultDto match) {
+	private FeedProbe probeFeed(MatchResultDto match) {
 		if (!"unstarted".equalsIgnoreCase(match.getState()) || !withinFeedProbeWindow(match.getMatchDate())) {
-			return List.of();
+			return FeedProbe.EMPTY;
 		}
 		List<String> gameIds = match.getGameIds();
 		if (gameIds == null || gameIds.isEmpty()) {
-			return List.of();
+			return FeedProbe.EMPTY;
 		}
 		List<String> live = new ArrayList<>();
+		boolean sawFinished = false;
 		for (String gameId : gameIds) {
 			if (gameId == null || gameId.isBlank()) {
 				continue;
@@ -237,14 +251,19 @@ public class LivePollingScheduler {
 			try {
 				// startingTime 은 반드시 유효한 값이어야 한다 — null 이면 빈 쿼리파라미터로 나가 피드가 거부한다.
 				JsonNode window = liveStatsClient.getWindow(gameId, computeStartingTime(gameId));
-				if (hasFrames(window) && !isFrameFinished(window)) {
+				if (!hasFrames(window)) {
+					continue;
+				}
+				if (isFrameFinished(window)) {
+					sawFinished = true;
+				} else {
 					live.add(gameId);
 				}
 			} catch (Exception e) {
 				log.debug("livestats 라이브 프로브 실패 gameId={}: {}", gameId, e.getMessage());
 			}
 		}
-		return live;
+		return new FeedProbe(live, sawFinished);
 	}
 
 	/** matchDate(ISO instant)가 지금 기준 시작 시각 창 안인지. 파싱 실패 시 false. */

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -382,6 +382,66 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void recentCompletedMatchSyncsEvenAfterTrackingEnded() {
+		// 구멍 B: 업스트림 completed flip 이 stale 3분 창을 넘겨 도착하면(EWC 는 상습),
+		// 게임이 이미 store 에서 제거돼 activeMatchIds 가 비어 completed sync 가 스킵됐다
+		// → DB 가 30분 cron 까지 inProgress 로 방치. 최근 경기의 completed 는
+		// 추적 여부와 무관하게 sync 해야 한다. (upsert 가 무변경이면 skip 하므로 중복 write 없음)
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStateStore liveStateStore = new LiveStateStore(); // 추적 종료 상태(비어 있음)
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("EWC"));
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("EWC"));
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService, mock(LiveStatsClient.class), mock(LiveObjectEventRecorder.class), liveStateStore,
+				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
+				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		MatchResultDto completed = MatchResultDto.builder()
+				.matchId("ewc-match-1").leagueName("EWC").state("completed")
+				.matchDate(Instant.now().minusSeconds(3600).toString()).build();
+		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(completed)).build());
+
+		scheduler.discoverLiveGames();
+
+		verify(leagueMatchService).syncRealtimeMatchStatus(completed, "EWC");
+	}
+
+	@Test
+	void staleCompletedMatchIsNotSynced() {
+		// 과거(창 밖) completed 매치까지 매 사이클 sync 하면 페이지 전체가 대상이 된다 — 창 밖은 스킵 유지.
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStateStore liveStateStore = new LiveStateStore();
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("EWC"));
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("EWC"));
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService, mock(LiveStatsClient.class), mock(LiveObjectEventRecorder.class), liveStateStore,
+				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
+				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		MatchResultDto oldCompleted = MatchResultDto.builder()
+				.matchId("ewc-match-old").leagueName("EWC").state("completed")
+				.matchDate(Instant.now().minusSeconds(60 * 60 * 24 * 2).toString()).build();
+		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(oldCompleted)).build());
+
+		scheduler.discoverLiveGames();
+
+		verify(leagueMatchService, never()).syncRealtimeMatchStatus(
+				org.mockito.ArgumentMatchers.any(), anyString());
+	}
+
+	@Test
 	void setStartFiresOnFirstFrameNotOnDiscovery() {
 		// 디스커버리 등장 = 픽밴 시작(업스트림이 픽밴 때 inProgress 로 뒤집음)이므로
 		// 그 시점에 쏘면 "이전 세트 종료 몇 분 뒤" 오탐. 첫 프레임 도착 때 1회만 쏴야 한다.

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -343,6 +343,45 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void trackedMatchWithFinishedFeedDoesNotRevertToUnstarted() {
+		// 경기 종료 직후: 프로브가 finished 잔상을 보면 inProgress 승격이 끊기는데,
+		// matchId 는 아직 activeMatchIds(stale 3분 창)에 있어 Riot 원본 unstarted 가
+		// syncRealtimeMatchStatus 로 그대로 들어가 DB 를 inProgress → unstarted 로 되돌렸다.
+		// finished 를 봤으면 이 사이클 sync 를 건너뛰어 DB state 를 유지해야 한다.
+		WorldsService worldsService = mock(WorldsService.class);
+		LiveStatsClient liveStatsClient = mock(LiveStatsClient.class);
+		LiveStateStore liveStateStore = new LiveStateStore();
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("EWC"));
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("EWC"));
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				worldsService, liveStatsClient, mock(LiveObjectEventRecorder.class), liveStateStore,
+				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
+				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
+				mock(TeamLiveEventPushService.class));
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		// 마지막 세트를 라이브로 추적하던 중이었음
+		liveStateStore.getActiveGames().put("ewc-game-1", new ActiveLiveGame(
+				"ewc-game-1", "ewc-match-1", "EWC", "GEN", "KC",
+				LocalDateTime.now(ZoneOffset.UTC), 0, 3, "100", "200"));
+		MatchResultDto ewcUnstarted = MatchResultDto.builder()
+				.matchId("ewc-match-1").leagueName("EWC").state("unstarted")
+				.matchDate(Instant.now().toString()).gameIds(List.of("ewc-game-1")).build();
+		when(worldsService.getWorldsMatches(null, "EWC")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(ewcUnstarted)).build());
+		when(liveStatsClient.getWindow(eq("ewc-game-1"), anyString())).thenReturn(windowWithGameState("finished"));
+
+		scheduler.discoverLiveGames();
+
+		assertThat(ewcUnstarted.getState()).isEqualTo("unstarted");
+		verify(leagueMatchService, never()).syncRealtimeMatchStatus(
+				org.mockito.ArgumentMatchers.any(), anyString());
+	}
+
+	@Test
 	void setStartFiresOnFirstFrameNotOnDiscovery() {
 		// 디스커버리 등장 = 픽밴 시작(업스트림이 픽밴 때 inProgress 로 뒤집음)이므로
 		// 그 시점에 쏘면 "이전 세트 종료 몇 분 뒤" 오탐. 첫 프레임 도착 때 1회만 쏴야 한다.


### PR DESCRIPTION
## 문제

EWC 경기 종료 후 스케줄 state 가 제때 `completed` 로 안 바뀜. 2026-07-17 8강 T1 vs HLE / GEN vs JDG 실사례 — 종료 후 25분+ `inProgress` 고정.

## 원인 두 개

### 구멍 A — 종료 직후 unstarted 롤백 (1st 커밋)

`discoverLiveGames` 의 unstarted 재판정 프로브가 마지막 세트 finished 를 보면 inProgress 승격이 끊기는데, matchId 는 stale 3분 창 동안 `activeMatchIds` 에 남아 Riot 원본 `unstarted` 가 `syncRealtimeMatchStatus` 로 그대로 들어가 DB 를 되돌렸다. #265 는 라이브 중 롤백만 막았고 종료 직후 구간은 재발.

**수정**: 프로브가 finished 잔상을 관측하면(= "시작 전" 아니라 "세트 사이/종료 직후" 신호) 그 사이클 sync 를 건너뛰어 DB state 유지. `liveGameIdsFromFeed` → `probeFeed` (라이브 게임 목록 + `sawFinished`).

### 구멍 B — 추적 종료 뒤 도착한 completed 는 30분 cron 까지 방치 (2nd 커밋)

completed 매치는 `state==inProgress || activeMatchIds` 일 때만 sync 되는데, 업스트림 completed flip 이 stale 창(3분)을 넘겨 도착하면(EWC 상습) 추적이 이미 끝나 sync 대상에서 빠짐 → 30분 cron 대기.

실측: 2026-07-17 13:03 UTC 시점 upstream `getEventDetails` 는 T1 vs HLE 를 2:0 completed 로 판정 가능(게임1·2 completed, 게임3 unneeded — `getWorldsMatches` 보정1이 completed 로 변환)인데, 추적 종료 상태라 디스커버리가 스킵해 DB 는 inProgress 고정.

**수정**: 최근 경기(시작 −5분 ~ +6시간)의 completed 는 추적 여부와 무관하게 sync. upsert 가 무변경 skip 이라 이미 completed 인 매치는 write 없음.

## 여전히 남는 지연 (코드로 해결 불가)

GEN vs JDG 는 upstream `getEventDetails` 자체가 종료 26분 뒤에도 게임2를 `inProgress` 로 방치 — 받아쓸 completed 가 없음. 프레임 finished 로 세트 종료는 알아도 승자를 몰라 매치 종료를 로컬 단정할 수 없다. 이 구간은 업스트림 데이터 지연.

## 테스트

- `trackedMatchWithFinishedFeedDoesNotRevertToUnstarted` (구멍 A) — 수정 전 red 확인
- `recentCompletedMatchSyncsEvenAfterTrackingEnded` (구멍 B) — 수정 전 red 확인
- `staleCompletedMatchIsNotSynced` — 창 밖 과거 completed 는 스킵 유지
- 전체 테스트 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)