### PR TITLE
feat: 백오피스 쓰기 API — LCK 선수 팀이동/이미지 수정, 회원·선수·팀 삭제

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -2,28 +2,38 @@ package com.toy.nar.api.admin;
 
 import com.toy.nar.app.lolesports.LeagueConfigService;
 import com.toy.nar.app.lolesports.repository.LeagueConfig;
+import com.toy.nar.app.member.service.MemberDeleteService;
+import com.toy.nar.app.participant.service.PlayerAdminService;
 import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * 백오피스 API. {@code /api/admin/**} 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
  * 조회 응답은 Spring {@link Page} 형식({@code content}, {@code totalElements}) 그대로 — FE 데이터프로바이더가 흡수한다.
- * 쓰기는 리그 설정 토글(PUT /league-configs/{leagueName})만 존재.
+ * 쓰기: 리그 설정 토글, LCK 선수 수정(PUT /players/{id}), 회원/선수/팀 삭제(DELETE).
  */
 @RestController
 @RequestMapping("/api/admin")
@@ -35,6 +45,8 @@ public class BackofficeController {
     private final TeamRepository teamRepository;
     private final LeagueRepository leagueRepository;
     private final LeagueConfigService leagueConfigService;
+    private final PlayerAdminService playerAdminService;
+    private final MemberDeleteService memberDeleteService;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
@@ -48,8 +60,7 @@ public class BackofficeController {
                                    @RequestParam(required = false) String league,
                                    Pageable pageable) {
         return playerRepository.searchForBackoffice(blankToNull(q), blankToNull(league), pageable)
-                .map(p -> new PlayerRow(p.getId(), p.getName(), p.getRealName(),
-                        p.getRole(), p.getAge()));
+                .map(PlayerRow::from);
     }
 
     @GetMapping("/teams")
@@ -88,11 +99,70 @@ public class BackofficeController {
                 leagueName, request.liveEnabled(), request.notificationEnabled(), request.syncEnabled()));
     }
 
+    // LCK 선수 한정 수정(이미지 = 수동 잠금 동반, 소속팀 변경). 서버에서 LCK 출전 이력 검증.
+    @PutMapping("/players/{id}")
+    public PlayerRow updatePlayer(@PathVariable Long id, @RequestBody PlayerUpdateRequest request) {
+        return PlayerRow.from(playerAdminService.update(
+                id, request.imageUrl(), request.unlockImage(), request.currentTeamId()));
+    }
+
+    @DeleteMapping("/members/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteMember(@PathVariable Long id) {
+        memberDeleteService.delete(id);
+    }
+
+    // 선수/팀은 경기 기록(game_participants) FK가 걸리면 삭제 불가 → DataIntegrityViolation → 409.
+    @DeleteMapping("/players/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePlayer(@PathVariable Long id) {
+        if (!playerRepository.existsById(id)) {
+            throw new NoSuchElementException("선수를 찾을 수 없습니다: " + id);
+        }
+        playerRepository.deleteById(id);
+    }
+
+    @DeleteMapping("/teams/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTeam(@PathVariable Long id) {
+        if (!teamRepository.existsById(id)) {
+            throw new NoSuchElementException("팀을 찾을 수 없습니다: " + id);
+        }
+        teamRepository.deleteById(id);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> onConflict() {
+        return Map.of("message", "경기 기록 등 연관 데이터가 있어 삭제할 수 없습니다");
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> onNotFound(NoSuchElementException e) {
+        return Map.of("message", e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> onBadRequest(IllegalStateException e) {
+        return Map.of("message", e.getMessage());
+    }
+
     public record MemberRow(Long id, String name, String email,
                             String favoriteLeagueName, LocalDateTime createdAt) {}
 
-    public record PlayerRow(Long id, String name, String realName,
-                            String role, Integer age) {}
+    public record PlayerRow(Long id, String name, String realName, String role, Integer age,
+                            String imageUrl, Long currentTeamId, String currentTeamName, boolean imageLocked) {
+        static PlayerRow from(Player p) {
+            var team = p.getCurrentTeam();
+            return new PlayerRow(p.getId(), p.getName(), p.getRealName(), p.getRole(), p.getAge(),
+                    p.getImageUrl(), team != null ? team.getId() : null,
+                    team != null ? team.getName() : null, p.isImageLocked());
+        }
+    }
+
+    public record PlayerUpdateRequest(String imageUrl, Boolean unlockImage, Long currentTeamId) {}
 
     public record TeamRow(Long id, String name, String code) {}
 

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -99,11 +99,12 @@ public class BackofficeController {
                 leagueName, request.liveEnabled(), request.notificationEnabled(), request.syncEnabled()));
     }
 
-    // LCK 선수 한정 수정(이미지 = 수동 잠금 동반, 소속팀 변경). 서버에서 LCK 출전 이력 검증.
+    // LCK 선수 한정 수정(이미지 = 수동 잠금 동반, 소속팀 변경, 솔랭 계정 수동 잠금). 서버에서 LCK 출전 이력 검증.
     @PutMapping("/players/{id}")
     public PlayerRow updatePlayer(@PathVariable Long id, @RequestBody PlayerUpdateRequest request) {
         return PlayerRow.from(playerAdminService.update(
-                id, request.imageUrl(), request.unlockImage(), request.currentTeamId()));
+                id, request.imageUrl(), request.unlockImage(), request.currentTeamId(),
+                request.unlockGameAccounts(), request.gameAccounts()));
     }
 
     @DeleteMapping("/members/{id}")
@@ -149,20 +150,31 @@ public class BackofficeController {
         return Map.of("message", e.getMessage());
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> onInvalidArgument(IllegalArgumentException e) {
+        return Map.of("message", e.getMessage());
+    }
+
     public record MemberRow(Long id, String name, String email,
                             String favoriteLeagueName, LocalDateTime createdAt) {}
 
     public record PlayerRow(Long id, String name, String realName, String role, Integer age,
-                            String imageUrl, Long currentTeamId, String currentTeamName, boolean imageLocked) {
+                            String imageUrl, Long currentTeamId, String currentTeamName, boolean imageLocked,
+                            String gameAccounts, boolean gameAccountsLocked) {
         static PlayerRow from(Player p) {
             var team = p.getCurrentTeam();
             return new PlayerRow(p.getId(), p.getName(), p.getRealName(), p.getRole(), p.getAge(),
                     p.getImageUrl(), team != null ? team.getId() : null,
-                    team != null ? team.getName() : null, p.isImageLocked());
+                    team != null ? team.getName() : null, p.isImageLocked(),
+                    p.getGameAccounts(), p.isGameAccountsLocked());
         }
     }
 
-    public record PlayerUpdateRequest(String imageUrl, Boolean unlockImage, Long currentTeamId) {}
+    public record GameAccountEntry(String region, String riotId, String tier) {}
+
+    public record PlayerUpdateRequest(String imageUrl, Boolean unlockImage, Long currentTeamId,
+                                      Boolean unlockGameAccounts, List<GameAccountEntry> gameAccounts) {}
 
     public record TeamRow(Long id, String name, String code) {}
 

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -4,6 +4,7 @@ import com.toy.nar.app.lolesports.LeagueConfigService;
 import com.toy.nar.app.lolesports.repository.LeagueConfig;
 import com.toy.nar.app.member.service.MemberDeleteService;
 import com.toy.nar.app.participant.service.PlayerAdminService;
+import com.toy.nar.app.riot.RiotApiException;
 import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.entity.Player;
@@ -14,6 +15,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -154,6 +156,17 @@ public class BackofficeController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Map<String, String> onInvalidArgument(IllegalArgumentException e) {
         return Map.of("message", e.getMessage());
+    }
+
+    // Riot 실검증 실패: 계정 없음(404)은 어드민 입력 오류(400), 그 외(키 미설정/장애)는 502.
+    @ExceptionHandler(RiotApiException.class)
+    public ResponseEntity<Map<String, String>> onRiotApiError(RiotApiException e) {
+        if (e.getStatusCode() == 404) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("message", "존재하지 않는 Riot ID입니다. 이름#태그를 확인해 주세요"));
+        }
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(Map.of("message", "Riot API 오류로 저장하지 못했습니다. 잠시 후 다시 시도해 주세요"));
     }
 
     public record MemberRow(Long id, String name, String email,

--- a/src/main/java/com/toy/nar/app/member/service/MemberDeleteService.java
+++ b/src/main/java/com/toy/nar/app/member/service/MemberDeleteService.java
@@ -1,0 +1,49 @@
+package com.toy.nar.app.member.service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.toy.nar.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 백오피스 회원 삭제. member_id FK로 참조하는 자식 테이블을 먼저 지우고 회원을 지운다.
+ * ponytail: 자식 테이블 목록 하드코딩. member 참조 엔티티가 늘면 여기에도 추가해야 한다
+ * (누락 시 FK 위반 → 컨트롤러에서 409로 표면화되므로 조용히 깨지진 않는다).
+ */
+@Service
+@RequiredArgsConstructor
+public class MemberDeleteService {
+
+	// 삭제 순서 무관(모두 member_id 직접 참조, 상호 FK 없음).
+	private static final List<String> MEMBER_CHILD_TABLES = List.of(
+			"refresh_token",
+			"member_social",
+			"member_device",
+			"member_favorite_player",
+			"member_notification",
+			"member_match_subscription",
+			"member_team_notification_subscription",
+			"player_solo_rank_push_delivery",
+			"member_team_event_push_delivery",
+			"live_player_rating");
+
+	private final JdbcTemplate jdbcTemplate;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void delete(Long memberId) {
+		if (!memberRepository.existsById(memberId)) {
+			throw new NoSuchElementException("회원을 찾을 수 없습니다: " + memberId);
+		}
+		for (String table : MEMBER_CHILD_TABLES) {
+			jdbcTemplate.update("DELETE FROM " + table + " WHERE member_id = ?", memberId);
+		}
+		memberRepository.deleteById(memberId);
+	}
+}

--- a/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
+++ b/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toy.nar.api.admin.BackofficeController;
+import com.toy.nar.app.riot.PlayerRiotAccountSyncService;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -28,6 +29,7 @@ public class PlayerAdminService {
 	private final PlayerRepository playerRepository;
 	private final TeamRepository teamRepository;
 	private final ObjectMapper objectMapper;
+	private final PlayerRiotAccountSyncService playerRiotAccountSyncService;
 
 	@Transactional
 	public Player update(Long playerId, String imageUrl, Boolean unlockImage, Long currentTeamId,
@@ -46,6 +48,8 @@ public class PlayerAdminService {
 			player.unlockGameAccounts();
 		} else if (gameAccounts != null) {
 			player.overrideGameAccounts(serializeGameAccounts(gameAccounts));
+			// Riot 실존 검증 + puuid 즉시 반영. 실패 시 예외 전파 → 트랜잭션 롤백(계정 저장 안 됨).
+			playerRiotAccountSyncService.syncPlayerAccountNow(player);
 		}
 		if (currentTeamId != null) {
 			Team team = teamRepository.findById(currentTeamId)

--- a/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
+++ b/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
@@ -27,7 +27,7 @@ public class PlayerAdminService {
 
 	@Transactional
 	public Player update(Long playerId, String imageUrl, Boolean unlockImage, Long currentTeamId) {
-		Player player = playerRepository.findById(playerId)
+		Player player = playerRepository.findWithCurrentTeamById(playerId)
 				.orElseThrow(() -> new NoSuchElementException("선수를 찾을 수 없습니다: " + playerId));
 		if (!playerRepository.hasLeagueParticipation(playerId, EDITABLE_LEAGUE)) {
 			throw new IllegalStateException("LCK 출전 이력이 있는 선수만 수정할 수 있습니다");

--- a/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
+++ b/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
@@ -1,10 +1,13 @@
 package com.toy.nar.app.participant.service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.api.admin.BackofficeController;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -24,9 +27,11 @@ public class PlayerAdminService {
 
 	private final PlayerRepository playerRepository;
 	private final TeamRepository teamRepository;
+	private final ObjectMapper objectMapper;
 
 	@Transactional
-	public Player update(Long playerId, String imageUrl, Boolean unlockImage, Long currentTeamId) {
+	public Player update(Long playerId, String imageUrl, Boolean unlockImage, Long currentTeamId,
+			Boolean unlockGameAccounts, List<BackofficeController.GameAccountEntry> gameAccounts) {
 		Player player = playerRepository.findWithCurrentTeamById(playerId)
 				.orElseThrow(() -> new NoSuchElementException("선수를 찾을 수 없습니다: " + playerId));
 		if (!playerRepository.hasLeagueParticipation(playerId, EDITABLE_LEAGUE)) {
@@ -37,11 +42,33 @@ public class PlayerAdminService {
 		} else if (imageUrl != null && !imageUrl.isBlank()) {
 			player.overrideImage(imageUrl.trim());
 		}
+		if (Boolean.TRUE.equals(unlockGameAccounts)) {
+			player.unlockGameAccounts();
+		} else if (gameAccounts != null) {
+			player.overrideGameAccounts(serializeGameAccounts(gameAccounts));
+		}
 		if (currentTeamId != null) {
 			Team team = teamRepository.findById(currentTeamId)
 					.orElseThrow(() -> new NoSuchElementException("팀을 찾을 수 없습니다: " + currentTeamId));
 			player.changeCurrentTeam(team);
 		}
 		return player;
+	}
+
+	// 크론 파서(RiotIdParser)가 읽는 형식 유지: [{"region","riotId","tier"}], riotId는 반드시 gameName#tagLine.
+	private String serializeGameAccounts(List<BackofficeController.GameAccountEntry> accounts) {
+		for (var acc : accounts) {
+			if (acc.region() == null || acc.region().isBlank()) {
+				throw new IllegalArgumentException("region은 비울 수 없습니다");
+			}
+			if (acc.riotId() == null || !acc.riotId().matches("^.+#.+$")) {
+				throw new IllegalArgumentException("riotId는 '이름#태그' 형식이어야 합니다: " + acc.riotId());
+			}
+		}
+		try {
+			return objectMapper.writeValueAsString(accounts);
+		} catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+			throw new IllegalArgumentException("계정 정보 직렬화 실패", e);
+		}
 	}
 }

--- a/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
+++ b/src/main/java/com/toy/nar/app/participant/service/PlayerAdminService.java
@@ -1,0 +1,47 @@
+package com.toy.nar.app.participant.service;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.PlayerRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 백오피스 선수 수정. LCK 출전 이력이 있는 선수만 허용(서버 강제 — UI 필터만 믿지 않는다).
+ * 이미지 수정은 overrideImage로 잠금까지 걸어 자동 동기화 덮어쓰기를 차단한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PlayerAdminService {
+
+	private static final String EDITABLE_LEAGUE = "LCK";
+
+	private final PlayerRepository playerRepository;
+	private final TeamRepository teamRepository;
+
+	@Transactional
+	public Player update(Long playerId, String imageUrl, Boolean unlockImage, Long currentTeamId) {
+		Player player = playerRepository.findById(playerId)
+				.orElseThrow(() -> new NoSuchElementException("선수를 찾을 수 없습니다: " + playerId));
+		if (!playerRepository.hasLeagueParticipation(playerId, EDITABLE_LEAGUE)) {
+			throw new IllegalStateException("LCK 출전 이력이 있는 선수만 수정할 수 있습니다");
+		}
+		if (Boolean.TRUE.equals(unlockImage)) {
+			player.unlockImage();
+		} else if (imageUrl != null && !imageUrl.isBlank()) {
+			player.overrideImage(imageUrl.trim());
+		}
+		if (currentTeamId != null) {
+			Team team = teamRepository.findById(currentTeamId)
+					.orElseThrow(() -> new NoSuchElementException("팀을 찾을 수 없습니다: " + currentTeamId));
+			player.changeCurrentTeam(team);
+		}
+		return player;
+	}
+}

--- a/src/main/java/com/toy/nar/app/riot/PlayerRiotAccountSyncService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerRiotAccountSyncService.java
@@ -110,6 +110,13 @@ public class PlayerRiotAccountSyncService {
 		});
 	}
 
+	// 백오피스 수동 수정 직후 단일 선수 즉시 동기화(실존 검증 겸용).
+	// KR 주계정이 없으면 검증할 게 없어 조용히 통과. 존재하지 않는 Riot ID면 RiotApiException(404) 전파.
+	public void syncPlayerAccountNow(Player player) {
+		riotApiClient.assertConfigured();
+		extractPrimaryKrAccount(player).ifPresent(candidate -> syncSinglePlayerAccount(player, candidate));
+	}
+
 	private Optional<PrimaryAccountCandidate> extractPrimaryKrAccount(Player player) {
 		if (player.getGameAccounts() == null || player.getGameAccounts().isBlank()) {
 			return Optional.empty();

--- a/src/main/java/com/toy/nar/domain/participant/entity/Player.java
+++ b/src/main/java/com/toy/nar/domain/participant/entity/Player.java
@@ -2,9 +2,12 @@ package com.toy.nar.domain.participant.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,7 +23,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "id")
-@ToString
+@ToString(exclude = "currentTeam")
 public class Player {
 
 	@Id
@@ -52,6 +55,15 @@ public class Player {
 	@Column(name = "game_accounts", columnDefinition = "JSON")
 	private String gameAccounts;
 
+	// 백오피스에서 수동 관리하는 현재 소속팀. 경기 기록(GameParticipant)과 무관 — sync가 건드리지 않는다.
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "current_team_id")
+	private Team currentTeam;
+
+	// true면 자동 동기화가 imageUrl을 덮어쓰지 못한다(setImageUrl no-op).
+	@Column(name = "image_locked", nullable = false, columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
+	private boolean imageLocked;
+
 	@Builder
 	public Player(String name, String imageUrl) {
 		this.name = Objects.requireNonNull(name, "Player name must not be null");
@@ -62,8 +74,26 @@ public class Player {
 		this.name = name;
 	}
 
+	// 자동 동기화 경로. 수동 잠금 상태면 무시 — 모든 sync 호출부(PlayerService, PlayerImageMigrationService)가 이 한 곳으로 보호된다.
 	public void setImageUrl(String imageUrl) {
+		if (imageLocked) {
+			return;
+		}
 		this.imageUrl = imageUrl;
+	}
+
+	// 백오피스 수동 수정: 이미지 교체 + sync 잠금.
+	public void overrideImage(String imageUrl) {
+		this.imageUrl = imageUrl;
+		this.imageLocked = true;
+	}
+
+	public void unlockImage() {
+		this.imageLocked = false;
+	}
+
+	public void changeCurrentTeam(Team team) {
+		this.currentTeam = team;
 	}
 
 	public void updateProfile(String realName, String birthDate, Integer age,

--- a/src/main/java/com/toy/nar/domain/participant/entity/Player.java
+++ b/src/main/java/com/toy/nar/domain/participant/entity/Player.java
@@ -64,6 +64,10 @@ public class Player {
 	@Column(name = "image_locked", nullable = false, columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
 	private boolean imageLocked;
 
+	// true면 프로필 크롤러가 game_accounts를 덮어쓰지 못한다(updateProfile에서 보존).
+	@Column(name = "game_accounts_locked", nullable = false, columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
+	private boolean gameAccountsLocked;
+
 	@Builder
 	public Player(String name, String imageUrl) {
 		this.name = Objects.requireNonNull(name, "Player name must not be null");
@@ -92,6 +96,16 @@ public class Player {
 		this.imageLocked = false;
 	}
 
+	// 백오피스 수동 수정: 계정 교체 + 크롤러 잠금.
+	public void overrideGameAccounts(String gameAccountsJson) {
+		this.gameAccounts = gameAccountsJson;
+		this.gameAccountsLocked = true;
+	}
+
+	public void unlockGameAccounts() {
+		this.gameAccountsLocked = false;
+	}
+
 	public void changeCurrentTeam(Team team) {
 		this.currentTeam = team;
 	}
@@ -102,6 +116,8 @@ public class Player {
 		this.birthDate = birthDate;
 		this.age = age;
 		this.role = role;
-		this.gameAccounts = gameAccounts;
+		if (!gameAccountsLocked) {
+			this.gameAccounts = gameAccounts;
+		}
 	}
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -1,6 +1,7 @@
 package com.toy.nar.domain.participant.repository;
 
 import com.toy.nar.domain.participant.entity.Player;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +17,8 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 
 	// 백오피스 검색: 선수명·실명 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
 	// 리그는 출전 기록(GameParticipant→Game→League) 기준 EXISTS 로 판정(전 시즌 통합).
+	// currentTeam은 목록 응답에 팀명을 실어야 해서 EntityGraph로 함께 로딩(N+1/LAZY 예외 방지).
+	@EntityGraph(attributePaths = {"currentTeam"})
 	@Query("""
 			SELECT p FROM Player p
 			WHERE (:q IS NULL
@@ -26,6 +29,13 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			                  WHERE gp.player = p AND gp.game.league.leagueName = :league))
 			""")
 	Page<Player> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
+
+	// 해당 리그 출전 이력 여부. 백오피스 선수 수정의 "LCK만 허용" 서버 검증에 사용.
+	@Query("""
+			SELECT COUNT(gp) > 0 FROM GameParticipant gp
+			WHERE gp.player.id = :playerId AND gp.game.league.leagueName = :leagueName
+			""")
+	boolean hasLeagueParticipation(@Param("playerId") Long playerId, @Param("leagueName") String leagueName);
 
 	Optional<Player> findByPlayerOriginId(String playerOriginId);
 

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -15,6 +15,10 @@ import java.util.Set;
 public interface PlayerRepository extends JpaRepository<Player, Long> {
 	Optional<Player> findByName(String name);
 
+	// 백오피스 수정 응답이 트랜잭션 밖(OSIV off)에서 currentTeam을 직렬화하므로 함께 로딩한다.
+	@EntityGraph(attributePaths = {"currentTeam"})
+	Optional<Player> findWithCurrentTeamById(Long id);
+
 	// 백오피스 검색: 선수명·실명 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
 	// 리그는 출전 기록(GameParticipant→Game→League) 기준 EXISTS 로 판정(전 시즌 통합).
 	// currentTeam은 목록 응답에 팀명을 실어야 해서 EntityGraph로 함께 로딩(N+1/LAZY 예외 방지).

--- a/src/main/resources/db/migration/V54__Add_player_current_team_and_image_lock.sql
+++ b/src/main/resources/db/migration/V54__Add_player_current_team_and_image_lock.sql
@@ -1,0 +1,24 @@
+-- 선수 "소속팀" 개념 신설 + 수동 이미지 잠금.
+-- current_team_id: 백오피스에서 수동 관리하는 현재 소속팀. 경기 기록(game_participants)과 무관하며 sync가 건드리지 않는다.
+-- image_locked: true면 자동 동기화(epromatch/디스크 마이그레이션 등)가 image_url을 덮어쓰지 못한다.
+ALTER TABLE players
+    ADD COLUMN current_team_id BIGINT NULL,
+    ADD COLUMN image_locked BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD CONSTRAINT fk_players_current_team FOREIGN KEY (current_team_id) REFERENCES teams (team_id);
+
+-- 백필: 선수별 가장 최근 경기의 팀(전 리그). 경기 기록 없는 선수는 NULL 유지.
+UPDATE players p
+JOIN (
+    SELECT playerId, teamId FROM (
+        SELECT gp.player_id AS playerId,
+               gp.team_id   AS teamId,
+               ROW_NUMBER() OVER (
+                   PARTITION BY gp.player_id
+                   ORDER BY g.actual_game_start_time DESC, g.game_id DESC
+               ) AS rn
+        FROM game_participants gp
+        JOIN games g ON gp.game_id = g.game_id
+    ) ranked
+    WHERE rn = 1
+) latest ON latest.playerId = p.player_id
+SET p.current_team_id = latest.teamId;

--- a/src/main/resources/db/migration/V55__Add_player_game_accounts_lock.sql
+++ b/src/main/resources/db/migration/V55__Add_player_game_accounts_lock.sql
@@ -1,0 +1,3 @@
+-- 솔랭 계정(game_accounts) 수동 잠금. true면 프로필 크롤러(매일 05:30)가 game_accounts를 덮어쓰지 못한다.
+ALTER TABLE players
+    ADD COLUMN game_accounts_locked BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
+++ b/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
@@ -2,6 +2,10 @@ package com.toy.nar.app.participant.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -16,6 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toy.nar.api.admin.BackofficeController;
+import com.toy.nar.app.riot.PlayerRiotAccountSyncService;
+import com.toy.nar.app.riot.RiotApiException;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -30,6 +36,8 @@ class PlayerAdminServiceTest {
 	private TeamRepository teamRepository;
 	@Mock
 	private ObjectMapper objectMapper;
+	@Mock
+	private PlayerRiotAccountSyncService playerRiotAccountSyncService;
 	@InjectMocks
 	private PlayerAdminService playerAdminService;
 
@@ -81,7 +89,7 @@ class PlayerAdminServiceTest {
 		Player player = Player.builder().name("Faker").build();
 		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
-		when(objectMapper.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+		when(objectMapper.writeValueAsString(any()))
 				.thenReturn("[{\"region\":\"KR\",\"riotId\":\"Hide on bush#KR1\",\"tier\":null}]");
 
 		Player updated = playerAdminService.update(1L, null, null, null, null,
@@ -89,6 +97,7 @@ class PlayerAdminServiceTest {
 
 		assertThat(updated.getGameAccounts()).contains("Hide on bush#KR1");
 		assertThat(updated.isGameAccountsLocked()).isTrue();
+		verify(playerRiotAccountSyncService).syncPlayerAccountNow(player);
 	}
 
 	@Test
@@ -101,5 +110,49 @@ class PlayerAdminServiceTest {
 		assertThatThrownBy(() -> playerAdminService.update(1L, null, null, null, null,
 				List.of(new BackofficeController.GameAccountEntry("KR", "NoTagLine", null))))
 				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("gameAccounts 수정 시 syncPlayerAccountNow 호출됨")
+	void callsSyncOnGameAccountsUpdate() throws Exception {
+		Player player = Player.builder().name("Faker").build();
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+		when(objectMapper.writeValueAsString(any()))
+				.thenReturn("[{\"region\":\"KR\",\"riotId\":\"Hide on bush#KR1\",\"tier\":null}]");
+
+		playerAdminService.update(1L, null, null, null, null,
+				List.of(new BackofficeController.GameAccountEntry("KR", "Hide on bush#KR1", null)));
+
+		verify(playerRiotAccountSyncService).syncPlayerAccountNow(player);
+	}
+
+	@Test
+	@DisplayName("syncPlayerAccountNow가 RiotApiException 던지면 update가 그대로 전파")
+	void propagatesRiotApiException() throws Exception {
+		Player player = Player.builder().name("Faker").build();
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+		when(objectMapper.writeValueAsString(any()))
+				.thenReturn("[{\"region\":\"KR\",\"riotId\":\"Ghost#KR1\",\"tier\":null}]");
+		doThrow(new RiotApiException("계정 없음", 404))
+				.when(playerRiotAccountSyncService).syncPlayerAccountNow(any());
+
+		assertThatThrownBy(() -> playerAdminService.update(1L, null, null, null, null,
+				List.of(new BackofficeController.GameAccountEntry("KR", "Ghost#KR1", null))))
+				.isInstanceOf(RiotApiException.class);
+	}
+
+	@Test
+	@DisplayName("unlockGameAccounts=true 경로에서는 syncPlayerAccountNow 호출 안 됨")
+	void doesNotSyncOnUnlock() throws Exception {
+		Player player = Player.builder().name("Faker").build();
+		player.overrideGameAccounts("[{\"region\":\"KR\",\"riotId\":\"Hide on bush#KR1\"}]");
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+
+		playerAdminService.update(1L, null, null, null, true, null);
+
+		verify(playerRiotAccountSyncService, never()).syncPlayerAccountNow(any());
 	}
 }

--- a/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
+++ b/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +14,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.api.admin.BackofficeController;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.entity.Team;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -25,6 +28,8 @@ class PlayerAdminServiceTest {
 	private PlayerRepository playerRepository;
 	@Mock
 	private TeamRepository teamRepository;
+	@Mock
+	private ObjectMapper objectMapper;
 	@InjectMocks
 	private PlayerAdminService playerAdminService;
 
@@ -35,7 +40,7 @@ class PlayerAdminServiceTest {
 		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(false);
 
-		assertThatThrownBy(() -> playerAdminService.update(1L, "img.png", null, null))
+		assertThatThrownBy(() -> playerAdminService.update(1L, "img.png", null, null, null, null))
 				.isInstanceOf(IllegalStateException.class)
 				.hasMessageContaining("LCK");
 	}
@@ -49,7 +54,7 @@ class PlayerAdminServiceTest {
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
 		when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
 
-		Player updated = playerAdminService.update(1L, "manual.png", null, 2L);
+		Player updated = playerAdminService.update(1L, "manual.png", null, 2L, null, null);
 
 		assertThat(updated.getImageUrl()).isEqualTo("manual.png");
 		assertThat(updated.isImageLocked()).isTrue();
@@ -64,9 +69,37 @@ class PlayerAdminServiceTest {
 		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
 
-		Player updated = playerAdminService.update(1L, null, true, null);
+		Player updated = playerAdminService.update(1L, null, true, null, null, null);
 
 		assertThat(updated.isImageLocked()).isFalse();
 		assertThat(updated.getImageUrl()).isEqualTo("manual.png");
+	}
+
+	@Test
+	@DisplayName("gameAccounts 수정 시 JSON 직렬화·잠금, riotId 형식(#) 검증")
+	void updatesGameAccounts() throws Exception {
+		Player player = Player.builder().name("Faker").build();
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+		when(objectMapper.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+				.thenReturn("[{\"region\":\"KR\",\"riotId\":\"Hide on bush#KR1\",\"tier\":null}]");
+
+		Player updated = playerAdminService.update(1L, null, null, null, null,
+				List.of(new BackofficeController.GameAccountEntry("KR", "Hide on bush#KR1", null)));
+
+		assertThat(updated.getGameAccounts()).contains("Hide on bush#KR1");
+		assertThat(updated.isGameAccountsLocked()).isTrue();
+	}
+
+	@Test
+	@DisplayName("riotId에 #이 없으면 IllegalArgumentException")
+	void rejectsInvalidRiotId() {
+		Player player = Player.builder().name("Faker").build();
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+
+		assertThatThrownBy(() -> playerAdminService.update(1L, null, null, null, null,
+				List.of(new BackofficeController.GameAccountEntry("KR", "NoTagLine", null))))
+				.isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
+++ b/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
@@ -1,0 +1,72 @@
+package com.toy.nar.app.participant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
+import com.toy.nar.domain.participant.repository.PlayerRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerAdminServiceTest {
+
+	@Mock
+	private PlayerRepository playerRepository;
+	@Mock
+	private TeamRepository teamRepository;
+	@InjectMocks
+	private PlayerAdminService playerAdminService;
+
+	@Test
+	@DisplayName("LCK 출전 이력 없는 선수는 수정 거부")
+	void rejectsNonLckPlayer() {
+		Player player = Player.builder().name("lplOnly").build();
+		when(playerRepository.findById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(false);
+
+		assertThatThrownBy(() -> playerAdminService.update(1L, "img.png", null, null))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("LCK");
+	}
+
+	@Test
+	@DisplayName("이미지 수정 시 잠금, 팀 변경 시 currentTeam 교체")
+	void updatesImageAndTeam() {
+		Player player = Player.builder().name("Faker").build();
+		Team team = Team.builder().name("Gen.G").build();
+		when(playerRepository.findById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+		when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
+
+		Player updated = playerAdminService.update(1L, "manual.png", null, 2L);
+
+		assertThat(updated.getImageUrl()).isEqualTo("manual.png");
+		assertThat(updated.isImageLocked()).isTrue();
+		assertThat(updated.getCurrentTeam()).isEqualTo(team);
+	}
+
+	@Test
+	@DisplayName("unlockImage=true면 잠금 해제(이미지 값은 유지)")
+	void unlocksImage() {
+		Player player = Player.builder().name("Faker").build();
+		player.overrideImage("manual.png");
+		when(playerRepository.findById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
+
+		Player updated = playerAdminService.update(1L, null, true, null);
+
+		assertThat(updated.isImageLocked()).isFalse();
+		assertThat(updated.getImageUrl()).isEqualTo("manual.png");
+	}
+}

--- a/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
+++ b/src/test/java/com/toy/nar/app/participant/service/PlayerAdminServiceTest.java
@@ -32,7 +32,7 @@ class PlayerAdminServiceTest {
 	@DisplayName("LCK 출전 이력 없는 선수는 수정 거부")
 	void rejectsNonLckPlayer() {
 		Player player = Player.builder().name("lplOnly").build();
-		when(playerRepository.findById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(false);
 
 		assertThatThrownBy(() -> playerAdminService.update(1L, "img.png", null, null))
@@ -45,7 +45,7 @@ class PlayerAdminServiceTest {
 	void updatesImageAndTeam() {
 		Player player = Player.builder().name("Faker").build();
 		Team team = Team.builder().name("Gen.G").build();
-		when(playerRepository.findById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
 		when(teamRepository.findById(2L)).thenReturn(Optional.of(team));
 
@@ -61,7 +61,7 @@ class PlayerAdminServiceTest {
 	void unlocksImage() {
 		Player player = Player.builder().name("Faker").build();
 		player.overrideImage("manual.png");
-		when(playerRepository.findById(1L)).thenReturn(Optional.of(player));
+		when(playerRepository.findWithCurrentTeamById(1L)).thenReturn(Optional.of(player));
 		when(playerRepository.hasLeagueParticipation(1L, "LCK")).thenReturn(true);
 
 		Player updated = playerAdminService.update(1L, null, true, null);

--- a/src/test/java/com/toy/nar/domain/participant/entity/PlayerImageLockTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/entity/PlayerImageLockTest.java
@@ -1,0 +1,36 @@
+package com.toy.nar.domain.participant.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+// 이미지 잠금 규칙: 수동 수정(overrideImage)하면 잠기고, 잠긴 뒤에는 sync 경로(setImageUrl)가 못 덮는다.
+class PlayerImageLockTest {
+
+	@Test
+	@DisplayName("overrideImage는 이미지를 바꾸고 잠근다; 이후 setImageUrl(sync)은 무시된다")
+	void overrideImage_locksAgainstSync() {
+		Player player = Player.builder().name("Faker").imageUrl("old.png").build();
+
+		player.overrideImage("manual.png");
+		assertThat(player.getImageUrl()).isEqualTo("manual.png");
+		assertThat(player.isImageLocked()).isTrue();
+
+		player.setImageUrl("sync.png"); // 자동 동기화 경로
+		assertThat(player.getImageUrl()).isEqualTo("manual.png"); // 덮어쓰기 차단
+	}
+
+	@Test
+	@DisplayName("unlockImage 후에는 sync가 다시 덮어쓸 수 있다")
+	void unlockImage_allowsSyncAgain() {
+		Player player = Player.builder().name("Faker").imageUrl("old.png").build();
+		player.overrideImage("manual.png");
+
+		player.unlockImage();
+		player.setImageUrl("sync.png");
+
+		assertThat(player.getImageUrl()).isEqualTo("sync.png");
+		assertThat(player.isImageLocked()).isFalse();
+	}
+}

--- a/src/test/java/com/toy/nar/domain/participant/entity/PlayerImageLockTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/entity/PlayerImageLockTest.java
@@ -33,4 +33,21 @@ class PlayerImageLockTest {
 		assertThat(player.getImageUrl()).isEqualTo("sync.png");
 		assertThat(player.isImageLocked()).isFalse();
 	}
+
+	@Test
+	@DisplayName("overrideGameAccounts는 계정을 바꾸고 잠근다; 이후 updateProfile(크롤러)은 gameAccounts만 보존한다")
+	void overrideGameAccounts_locksAgainstCrawler() {
+		Player player = Player.builder().name("Faker").build();
+
+		player.overrideGameAccounts("[{\"region\":\"KR\",\"riotId\":\"Hide on bush#KR1\",\"tier\":null}]");
+		assertThat(player.isGameAccountsLocked()).isTrue();
+
+		player.updateProfile("이상혁", "1996-05-07", 30, "MID", "[{\"riotId\":\"stale#OLD\"}]");
+		assertThat(player.getGameAccounts()).contains("Hide on bush#KR1"); // 계정은 보존
+		assertThat(player.getRealName()).isEqualTo("이상혁"); // 나머지 프로필은 갱신
+
+		player.unlockGameAccounts();
+		player.updateProfile("이상혁", "1996-05-07", 30, "MID", "[{\"riotId\":\"new#SYNC\"}]");
+		assertThat(player.getGameAccounts()).contains("new#SYNC");
+	}
 }

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckParticipationTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckParticipationTest.java
@@ -1,0 +1,109 @@
+package com.toy.nar.domain.participant.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+/**
+ * {@link PlayerRepository#hasLeagueParticipation}의 동작을 검증한다.
+ *
+ * <p>LCK 경기 출전 기록이 있으면 true, 다른 리그(LPL)만 출전한 선수는 false를 반환한다.
+ *
+ * <p>마이그레이션은 MySQL 전용 문법이라 H2에서는 엔티티 기반 스키마(create-drop)를 사용한다.
+ * 기존 PlayerRepositoryLckPlayerOptionsTest의 @SpringBootConfiguration 이너 클래스를 재사용해
+ * 동일 패키지에서 설정 충돌(multiple @SpringBootConfiguration)이 발생하지 않도록 한다.
+ */
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class PlayerRepositoryLckParticipationTest {
+
+	@Autowired
+	private PlayerRepository playerRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	// LCK 출전 기록이 있는 선수
+	private Long fakerId;
+	// LPL 경기만 출전한 선수
+	private Long lplOnlyId;
+
+	@BeforeEach
+	void seed() {
+		exec("INSERT INTO champions (champion_id, champion_name_kr, champion_name_en, image_url)"
+				+ " VALUES (1, '아리', 'Ahri', 'ahri.png')");
+
+		// 리그: LCK(100), LPL(101)
+		exec(league(100, "LCK", 2026));
+		exec(league(101, "LPL", 2026));
+
+		exec(team(10, "T1", "T1"));
+
+		// faker: LCK 출전, lplOnly: LPL만 출전
+		exec(player(1, "faker", "Mid"));
+		exec(player(2, "lplOnly", "Bot"));
+
+		// 경기
+		exec(game(1, 100, "2026-01-10 10:00:00")); // LCK
+		exec(game(2, 101, "2026-01-15 10:00:00")); // LPL
+
+		// 참가 기록
+		exec(gp(1, 1, 1, 10)); // faker @LCK
+		exec(gp(2, 2, 2, 10)); // lplOnly @LPL
+
+		em.flush();
+		em.clear();
+
+		fakerId = 1L;
+		lplOnlyId = 2L;
+	}
+
+	@Test
+	@DisplayName("LCK 경기 출전 기록이 있으면 true, 없으면 false")
+	void hasLeagueParticipation() {
+		assertThat(playerRepository.hasLeagueParticipation(fakerId, "LCK")).isTrue();
+		assertThat(playerRepository.hasLeagueParticipation(lplOnlyId, "LCK")).isFalse();
+	}
+
+	// ── 시딩 헬퍼 (네이티브 SQL) ─────────────────────────────────
+
+	private void exec(String sql) {
+		em.createNativeQuery(sql).executeUpdate();
+	}
+
+	private static String league(long id, String name, int year) {
+		return "INSERT INTO leagues (league_id, league_name, season_year, season_split, is_playoffs)"
+				+ " VALUES (" + id + ", '" + name + "', " + year + ", 'Spring', false)";
+	}
+
+	private static String team(long id, String name, String code) {
+		return "INSERT INTO teams (team_id, team_name, team_code, team_image_url)"
+				+ " VALUES (" + id + ", '" + name + "', '" + code + "', '" + code + ".png')";
+	}
+
+	private static String player(long id, String name, String role) {
+		return "INSERT INTO players (player_id, player_name, image_url, role)"
+				+ " VALUES (" + id + ", '" + name + "', '" + name + ".png', '" + role + "')";
+	}
+
+	private static String game(long id, long leagueId, String startTime) {
+		return "INSERT INTO games (game_id, league_id, actual_game_start_time, game_number, patch,"
+				+ " game_length_seconds, ckpm) VALUES (" + id + ", " + leagueId + ", '" + startTime
+				+ "', 1, '14.1', 1800, 0.5)";
+	}
+
+	private static String gp(long id, long gameId, long playerId, long teamId) {
+		return "INSERT INTO game_participants (participant_game_id, game_id, player_id, team_id,"
+				+ " side, position, champion_id, is_win) VALUES (" + id + ", " + gameId + ", "
+				+ playerId + ", " + teamId + ", 'Blue', 'mid', 1, true)";
+	}
+}

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckParticipationTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckParticipationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,23 @@ class PlayerRepositoryLckParticipationTest {
 	void hasLeagueParticipation() {
 		assertThat(playerRepository.hasLeagueParticipation(fakerId, "LCK")).isTrue();
 		assertThat(playerRepository.hasLeagueParticipation(lplOnlyId, "LCK")).isFalse();
+	}
+
+	@Test
+	@DisplayName("findWithCurrentTeamById는 currentTeam을 즉시 로딩한다(OSIV off 직렬화 대비)")
+	void findWithCurrentTeamById_initializesCurrentTeam() {
+		// 픽스처: faker 선수에 currentTeam(T1, id=10) 세팅
+		exec("UPDATE players SET current_team_id = 10 WHERE player_id = 1");
+		em.flush();
+		em.clear();
+
+		// EntityGraph 조회
+		com.toy.nar.domain.participant.entity.Player found =
+				playerRepository.findWithCurrentTeamById(fakerId).orElseThrow();
+
+		// 세션 경계 밖에서도 currentTeam이 초기화돼 있어야 한다(OSIV off 대비)
+		assertThat(Hibernate.isInitialized(found.getCurrentTeam())).isTrue();
+		assertThat(found.getCurrentTeam().getName()).isEqualTo("T1");
 	}
 
 	// ── 시딩 헬퍼 (네이티브 SQL) ─────────────────────────────────

--- a/src/test/resources/db/pre_v31_schema.sql
+++ b/src/test/resources/db/pre_v31_schema.sql
@@ -17,8 +17,10 @@ CREATE TABLE champions (
     champion_id BIGINT AUTO_INCREMENT PRIMARY KEY
 );
 
+-- actual_game_start_time: 프로드에는 엔티티 시절부터 존재. V54 소속팀 백필이 참조한다.
 CREATE TABLE games (
-    game_id BIGINT AUTO_INCREMENT PRIMARY KEY
+    game_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    actual_game_start_time DATETIME
 );
 
 CREATE TABLE league_match (
@@ -34,9 +36,12 @@ CREATE TABLE game_team_stat (
     team_id BIGINT
 );
 
+-- player_id/game_id: 프로드에는 엔티티 시절부터 존재. V54 소속팀 백필이 참조한다.
 CREATE TABLE game_participants (
     participant_game_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    team_id BIGINT
+    team_id BIGINT,
+    player_id BIGINT,
+    game_id BIGINT
 );
 
 CREATE TABLE league_teams (


### PR DESCRIPTION
## 요약
백오피스(admin.nar.kr)에서 쓰기 작업을 지원하는 admin API 확장.

- **선수 소속팀 개념 신설**: `players.current_team_id` (V54 마이그레이션, 최근 경기 팀으로 백필). 경기 기록(`game_participants`)은 불변.
- **LCK 선수 수정**: `PUT /api/admin/players/{id}` — 소속팀 변경, 이미지 URL 수정. 서버에서 LCK 출전 이력 검증(비LCK 400).
- **이미지 sync 보호**: 수동 수정 시 `image_locked` 잠금 — 자동 동기화(epromatch/디스크 마이그레이션)가 덮어쓰지 못함. 엔티티 `setImageUrl` 한 곳에서 가드.
- **삭제**: `DELETE /api/admin/{members,players,teams}/{id}`. 회원은 자식 10테이블 정리 후 삭제, 선수/팀은 경기 기록 FK 시 409 `{message}`.
- 선수 목록 응답에 `imageUrl`/`currentTeamId`/`currentTeamName`/`imageLocked` 추가.

## 배포 주의
- **이 PR을 프론트(warding-backoffice-fe PR)보다 먼저 머지/배포**해야 함.
- V54는 기동 시 Flyway 자동 적용 (players ALTER + 백필 UPDATE 1회).
- ⚠️ 미머지 `feat/match-alarm-toggles` 브랜치에 V53 존재 — 이 PR이 먼저 나가면 그쪽 V53을 V55로 리네임 필요.
- 배포 후 스모크 권장: ① LCK 선수 `PUT {"imageUrl":"..."}` → 200 + `imageLocked:true` ② 경기기록 있는 선수 `DELETE` → 409.

## 테스트
- 신규: 엔티티 잠금 규칙 2건, LCK 출전 판정 1건, EntityGraph 즉시 로딩 1건, PlayerAdminService 3건
- `./gradlew build` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)