### PR TITLE
fix: 세트 종료 후 3분간 상세 화면이 LIVE 잔상으로 남던 문제

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -399,14 +399,18 @@ public class LivePollingScheduler {
 
 				// 세트 종료 1차 판정: 프레임 gameState=finished (실제 종료 후 수 초 내 반영).
 				// finished 프레임은 timestamp 가 멈춰 aggregator 의 stale 필터에 걸리므로 여기 raw 응답에서 본다.
-				if (isFrameFinished(window)
-						&& frameFinishedGameIds.add(activeGame.gameId())
-						&& teamLiveEventPushService.isEnabled()
-						&& isNotifiableLeague(activeGame.leagueName())
-						&& setEndNotifiedGameIds.add(activeGame.gameId())) {
-					log.info("[live-notify] set-end(frame) gameId={} matchId={} set={}",
-							activeGame.gameId(), activeGame.matchId(), activeGame.setNumber());
-					fireSetEndNotification(activeGame);
+				if (isFrameFinished(window)) {
+					// store 에 마킹해야 세트 상태(LIVE/ENDED)가 stale 3분 잔상 동안 LIVE 로 남지 않는다.
+					// 푸시 게이트(isEnabled/리그)와 무관하게 마킹한다.
+					liveStateStore.markFinished(activeGame.gameId());
+					if (frameFinishedGameIds.add(activeGame.gameId())
+							&& teamLiveEventPushService.isEnabled()
+							&& isNotifiableLeague(activeGame.leagueName())
+							&& setEndNotifiedGameIds.add(activeGame.gameId())) {
+						log.info("[live-notify] set-end(frame) gameId={} matchId={} set={}",
+								activeGame.gameId(), activeGame.matchId(), activeGame.setNumber());
+						fireSetEndNotification(activeGame);
+					}
 				}
 
 				liveFrameProcessor.process(activeGame, window, details);

--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStateStore.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStateStore.java
@@ -15,6 +15,11 @@ public class LiveStateStore {
 
 	private final Map<String, ActiveLiveGame> activeGames = new ConcurrentHashMap<>();
 	private final Map<String, LiveGameState> latestStates = new ConcurrentHashMap<>();
+	/**
+	 * 프레임 gameState=finished 로 종료가 확정된 gameId. 게임은 stale 확정(3분)까지 store 에
+	 * 남으므로, 그 잔상 동안 세트 상태를 LIVE 로 표시하지 않기 위한 마킹이다.
+	 */
+	private final java.util.Set<String> finishedGameIds = ConcurrentHashMap.newKeySet();
 
 	public Map<String, ActiveLiveGame> getActiveGames() {
 		return activeGames;
@@ -42,6 +47,15 @@ public class LiveStateStore {
 	public void removeGame(String gameId) {
 		activeGames.remove(gameId);
 		latestStates.remove(gameId);
+		finishedGameIds.remove(gameId);
+	}
+
+	public void markFinished(String gameId) {
+		finishedGameIds.add(gameId);
+	}
+
+	public boolean isFinished(String gameId) {
+		return finishedGameIds.contains(gameId);
 	}
 
 	public List<LiveGameSummaryResponse> getLiveGameSummaries() {

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -202,10 +202,13 @@ public class MobileScheduleService {
 		// 세트별 다시보기 VOD URL (setNumber == gameOrder 기준). 없으면 빈 맵.
 		Map<Integer, String> vodMap = parseVodMap(match.getMatchDetailsJson());
 		// 상태 판정용 집합: 현재 라이브(스토어) / 라이브 데이터 수집됨(영속 스냅샷, 종료 후에도 유지).
+		// 프레임 finished 로 종료 확정된 게임은 stale 확정(3분)까지 store 에 남는 잔상이므로
+		// LIVE 에서 제외한다 — SET_END 푸시와 세트 상태가 같은 신호(프레임)를 보게 된다.
 		java.util.Set<String> liveGameIds = liveStateStore.getActiveGames().values().stream()
 				.filter(live -> match.getId().equals(live.matchId()))
 				.map(ActiveLiveGame::gameId)
 				.filter(gameId -> gameId != null && !gameId.isBlank())
+				.filter(gameId -> !liveStateStore.isFinished(gameId))
 				.collect(Collectors.toCollection(java.util.LinkedHashSet::new));
 		List<String> recordedGameIds = minuteSnapshotRepository.findGameIdsByMatchIdOrderByStart(match.getId());
 		java.util.Set<String> recordedSet = new java.util.LinkedHashSet<>(recordedGameIds);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -118,6 +118,34 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void frameFinishedMarksGameFinishedInStore() {
+		// 프레임 finished 는 세트 상태(LIVE/ENDED) 표시의 1차 신호다. store 에 마킹해야
+		// 모바일 세트 목록이 stale 3분 잔상 동안 LIVE 로 남지 않는다. 푸시 게이트와 무관하게 마킹.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(false); // 푸시 꺼져 있어도
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();
+
+		assertThat(liveStateStore.isFinished("game-1")).isTrue();
+	}
+
+	@Test
+	void removeGameClearsFinishedMark() {
+		LiveStateStore liveStateStore = new LiveStateStore();
+		liveStateStore.markFinished("game-1");
+		assertThat(liveStateStore.isFinished("game-1")).isTrue();
+
+		liveStateStore.removeGame("game-1");
+
+		assertThat(liveStateStore.isFinished("game-1")).isFalse();
+	}
+
+	@Test
 	void firesSetEndImmediatelyWhenFrameGameStateFinished() {
 		LiveStateStore liveStateStore = new LiveStateStore();
 		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -313,6 +313,47 @@ class MobileScheduleServiceTest {
 	}
 
 	@Test
+	void getMatchGamesMarksFrameFinishedGameAsEndedDespiteStoreResidue() {
+		// 세트 종료 후 stale 3분 동안 게임이 store 에 남아 "LIVE" 잔상으로 표시되던 문제:
+		// 프레임 finished 로 확정된 게임은 store 잔상과 무관하게 ENDED 로 내려야
+		// SET_END 푸시(프레임 신호)와 상세 화면이 같은 시점에 종료로 보인다.
+		when(leagueMatchRepository.findById("match-1"))
+				.thenReturn(Optional.of(match("match-1", "EWC", LocalDateTime.of(2026, 7, 17, 13, 30), "DK", "BLG", "inProgress")));
+		when(leagueMatchGameRepository.findMappedGameRowsByMatchId("match-1", "LOLESPORTS"))
+				.thenReturn(List.of(new MappedRow("match-1", 1, "game-1", null)));
+		when(liveStateStore.getActiveGames()).thenReturn(new java.util.HashMap<>(java.util.Map.of(
+				"game-1", new com.toy.nar.app.lolesports.live.ActiveLiveGame(
+						"game-1", "match-1", "EWC", "DK", "BLG", LocalDateTime.of(2026, 7, 17, 13, 50), 0))));
+		when(liveStateStore.isFinished("game-1")).thenReturn(true);
+		when(minuteSnapshotRepository.findGameIdsByMatchIdOrderByStart("match-1"))
+				.thenReturn(List.of("game-1"));
+
+		MobileMatchGamesResponse response = service.getMatchGames("match-1");
+
+		assertThat(response.games()).singleElement()
+				.extracting(MobileScheduleListResponse.MobileGameSummary::status)
+				.isEqualTo("ENDED");
+	}
+
+	@Test
+	void getMatchGamesKeepsLiveStatusWhileFrameNotFinished() {
+		when(leagueMatchRepository.findById("match-1"))
+				.thenReturn(Optional.of(match("match-1", "EWC", LocalDateTime.of(2026, 7, 17, 13, 30), "DK", "BLG", "inProgress")));
+		when(leagueMatchGameRepository.findMappedGameRowsByMatchId("match-1", "LOLESPORTS"))
+				.thenReturn(List.of(new MappedRow("match-1", 1, "game-1", null)));
+		when(liveStateStore.getActiveGames()).thenReturn(new java.util.HashMap<>(java.util.Map.of(
+				"game-1", new com.toy.nar.app.lolesports.live.ActiveLiveGame(
+						"game-1", "match-1", "EWC", "DK", "BLG", LocalDateTime.of(2026, 7, 17, 13, 50), 0))));
+		when(liveStateStore.isFinished("game-1")).thenReturn(false);
+
+		MobileMatchGamesResponse response = service.getMatchGames("match-1");
+
+		assertThat(response.games()).singleElement()
+				.extracting(MobileScheduleListResponse.MobileGameSummary::status)
+				.isEqualTo("LIVE");
+	}
+
+	@Test
 	void getMatchGamesWithUnknownMatchThrowsDataNotFound() {
 		when(leagueMatchRepository.findById("missing")).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## 문제

세트가 끝나 SET_END 푸시는 즉시 오는데, 경기 상세의 세트 상태는 최대 3분간 "진행중(LIVE)" 유지. 2026-07-17 EWC DK vs BLG 실사례 — 세트1 이 22:50:18 KST 프레임 finished 로 종료됐는데 22:53 스크린샷에 "SET 1 진행중 · LIVE".

## 원인

세트 상태(`MobileScheduleService.gameStatus`)가 "gameId 가 liveStateStore 에 있냐"로만 판정. 게임은 디스커버리 stale 확정(3분)까지 store 에 남으므로, 프레임 finished(푸시가 쓰는 신호) 이후에도 3분간 LIVE 잔상.

## 수정

- `LiveStateStore` 에 `markFinished/isFinished` 추가 (removeGame 시 해제)
- `LivePollingScheduler.pollActiveGames`: 프레임 finished 감지 시 store 에 마킹 — 푸시 게이트(isEnabled/리그 알림 설정)와 무관
- `MobileScheduleService.getMatchGames`: finished 게임을 LIVE 집합에서 제외 → 스냅샷 보유 시 ENDED

푸시와 세트 상태가 같은 신호(프레임 finished)를 보게 됨 — 갭 3분 → 수초.

## 테스트

- `frameFinishedMarksGameFinishedInStore` — 푸시 꺼져 있어도 마킹
- `removeGameClearsFinishedMark`
- `getMatchGamesMarksFrameFinishedGameAsEndedDespiteStoreResidue` — 잔상 중 ENDED
- `getMatchGamesKeepsLiveStatusWhileFrameNotFinished` — 진행 중엔 LIVE 유지
- 전체 테스트 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)