### PR TITLE
perf: 백오피스 선수 리그 필터 소속팀 기준 전환 (~8배 단축)

### DIFF
--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -20,7 +20,8 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	Optional<Player> findWithCurrentTeamById(Long id);
 
 	// 백오피스 검색: 선수명·실명 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
-	// 리그는 출전 기록(GameParticipant→Game→League) 기준 EXISTS 로 판정(전 시즌 통합).
+	// 리그는 현재 소속팀(current_team)의 LeagueTeam 등록 기준 — 팀 검색과 동일 기준.
+	// (과거 출전 이력 EXISTS는 참가기록 16만행을 페이지마다 semijoin 스캔해서 느렸음. 무소속 선수는 리그 필터에서 제외됨.)
 	// currentTeam은 목록 응답에 팀명을 실어야 해서 EntityGraph로 함께 로딩(N+1/LAZY 예외 방지).
 	@EntityGraph(attributePaths = {"currentTeam"})
 	@Query("""
@@ -29,8 +30,8 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			       OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%')))
 			  AND (:league IS NULL
-			       OR EXISTS (SELECT 1 FROM GameParticipant gp
-			                  WHERE gp.player = p AND gp.game.league.leagueName = :league))
+			       OR EXISTS (SELECT 1 FROM LeagueTeam lt
+			                  WHERE lt.team = p.currentTeam AND lt.league.leagueName = :league))
 			""")
 	Page<Player> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
 

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositorySearchTest.java
@@ -1,0 +1,79 @@
+package com.toy.nar.domain.participant.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+import com.toy.nar.domain.game.entity.League;
+import com.toy.nar.domain.game.entity.LeagueTeam;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
+
+// 백오피스 선수 검색의 리그 필터 검증. 기준 = 현재 소속팀(current_team)의 LeagueTeam 등록.
+// (과거에는 경기 출전 이력 EXISTS 스캔이라 참가기록 전체를 훑어 느렸다 — 소속팀 기준으로 교체.)
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class PlayerRepositorySearchTest {
+
+	@Autowired
+	private PlayerRepository playerRepository;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Test
+	@DisplayName("league를 주면 현재 소속팀이 그 리그(LeagueTeam)에 등록된 선수만 나온다")
+	void searchForBackoffice_filtersByCurrentTeamLeague() {
+		Team genG = teamRepository.save(Team.builder().name("Gen.G").code("GEN").build());
+		Team weibo = teamRepository.save(Team.builder().name("Weibo Gaming").code("WBG").build());
+
+		League lck = em.merge(League.builder().leagueName("LCK").seasonYear(2025)
+				.seasonSplit("Spring").isPlayoffs(false).build());
+		League lpl = em.merge(League.builder().leagueName("LPL").seasonYear(2025)
+				.seasonSplit("Spring").isPlayoffs(false).build());
+		em.persist(LeagueTeam.builder().league(lck).team(genG).build());
+		em.persist(LeagueTeam.builder().league(lpl).team(weibo).build());
+
+		Player chovy = Player.builder().name("Chovy").build();
+		chovy.changeCurrentTeam(genG);
+		playerRepository.save(chovy);
+
+		Player xiaohu = Player.builder().name("Xiaohu").build();
+		xiaohu.changeCurrentTeam(weibo);
+		playerRepository.save(xiaohu);
+
+		Player freeAgent = Player.builder().name("FreeAgent").build(); // 무소속
+		playerRepository.save(freeAgent);
+
+		em.flush();
+		em.clear();
+
+		// LCK 소속팀 선수만
+		List<String> lckPlayers = playerRepository.searchForBackoffice(null, "LCK", PageRequest.of(0, 10))
+				.map(Player::getName).getContent();
+		assertThat(lckPlayers).containsExactly("Chovy");
+
+		// league 없으면 전체(무소속 포함)
+		assertThat(playerRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
+				.isEqualTo(3);
+
+		// q 결합
+		List<String> lckCho = playerRepository.searchForBackoffice("cho", "LCK", PageRequest.of(0, 10))
+				.map(Player::getName).getContent();
+		assertThat(lckCho).containsExactly("Chovy");
+	}
+}


### PR DESCRIPTION
## 문제
어드민 선수 목록의 페이징/검색이 느림. 원인: 리그 필터가 **전 시즌 출전 이력**(game_participants 16만행) EXISTS 스캔 — 페이지 이동·검색 타이핑마다 목록+count 쿼리가 매번 9천행 semijoin을 반복 (로컬 실측 ~98ms, prod는 크론/라이브 폴링과 경합해 더 느림).

## 수정
리그 필터 기준을 **현재 소속팀(current_team)의 LeagueTeam 등록**으로 교체 — 팀 검색과 동일 기준, 인덱스 직행.

- 로컬 실측: 98ms → **12.7ms**
- 의미 변화: 과거 해당 리그에 출전했지만 현재 무소속/타리그 팀 선수는 리그 필터에서 빠짐 (리그 전체 조회에는 그대로 표시). 로스터 관리 용도에 부합 — 운영자 확인 완료.
- 선수 수정의 LCK 검증(`hasLeagueParticipation`)은 기존 출전 이력 기준 유지.

## 테스트
- 신규 `PlayerRepositorySearchTest` — 소속팀 리그 필터/전체 조회/q 결합 검증 (구 쿼리에선 FAIL 확인 후 교체)
- `./gradlew build` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)