### PR TITLE
fix: 리그 필터 출전 기록 기준 원복 — league_teams 오염으로 #271이 필터 무력화

### DIFF
--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -20,8 +20,9 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	Optional<Player> findWithCurrentTeamById(Long id);
 
 	// 백오피스 검색: 선수명·실명 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
-	// 리그는 현재 소속팀(current_team)의 LeagueTeam 등록 기준 — 팀 검색과 동일 기준.
-	// (과거 출전 이력 EXISTS는 참가기록 16만행을 페이지마다 semijoin 스캔해서 느렸음. 무소속 선수는 리그 필터에서 제외됨.)
+	// 리그는 출전 기록(GameParticipant→Game→League) 기준 EXISTS(전 시즌 통합).
+	// ⚠️ league_teams 기준으로 바꾸지 말 것: 해당 테이블은 오염돼 있음(LCK에 462팀 등록돼 필터가 전체 통과).
+	//    데이터 정리 전까지 출전 기록이 유일하게 신뢰 가능한 리그 판정.
 	// currentTeam은 목록 응답에 팀명을 실어야 해서 EntityGraph로 함께 로딩(N+1/LAZY 예외 방지).
 	@EntityGraph(attributePaths = {"currentTeam"})
 	@Query("""
@@ -30,8 +31,8 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			       OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%')))
 			  AND (:league IS NULL
-			       OR EXISTS (SELECT 1 FROM LeagueTeam lt
-			                  WHERE lt.team = p.currentTeam AND lt.league.leagueName = :league))
+			       OR EXISTS (SELECT 1 FROM GameParticipant gp
+			                  WHERE gp.player = p AND gp.game.league.leagueName = :league))
 			""")
 	Page<Player> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
 

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -52,15 +52,16 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	Optional<Team> findByNameIgnoreCase(@Param("name") String name);
 
 	// 백오피스 검색: 팀명·코드 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
-	// 리그는 LeagueTeam 조인 대신 EXISTS 로 걸러 페이징/카운트를 단순하게 유지(전 시즌 통합).
+	// 리그는 출전 기록(GameParticipant) 기준 EXISTS(전 시즌 통합).
+	// ⚠️ league_teams 기준 금지: 오염돼 있음(LCK에 462팀) — 선수 검색과 동일 사유. 정리 전까지 출전 기록으로 판정.
 	@Query("""
 			SELECT t FROM Team t
 			WHERE (:q IS NULL
 			       OR LOWER(t.name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(t.code) LIKE LOWER(CONCAT('%', :q, '%')))
 			  AND (:league IS NULL
-			       OR EXISTS (SELECT 1 FROM LeagueTeam lt
-			                  WHERE lt.team = t AND lt.league.leagueName = :league))
+			       OR EXISTS (SELECT 1 FROM GameParticipant gp
+			                  WHERE gp.team = t AND gp.game.league.leagueName = :league))
 			""")
 	Page<Team> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
 }

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositorySearchTest.java
@@ -7,19 +7,17 @@ import java.util.List;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 
-import com.toy.nar.domain.game.entity.League;
-import com.toy.nar.domain.game.entity.LeagueTeam;
 import com.toy.nar.domain.participant.entity.Player;
-import com.toy.nar.domain.participant.entity.Team;
 
-// 백오피스 선수 검색의 리그 필터 검증. 기준 = 현재 소속팀(current_team)의 LeagueTeam 등록.
-// (과거에는 경기 출전 이력 EXISTS 스캔이라 참가기록 전체를 훑어 느렸다 — 소속팀 기준으로 교체.)
+// 백오피스 선수 검색의 리그 필터 검증. 기준 = 출전 기록(GameParticipant→Game→League).
+// league_teams는 오염돼 있어(LCK에 462팀) 판정 기준으로 쓰지 않는다 — 회귀 방지용 테스트.
 @DataJpaTest(properties = {
 		"spring.flyway.enabled=false",
 		"spring.jpa.hibernate.ddl-auto=create-drop"
@@ -29,45 +27,39 @@ class PlayerRepositorySearchTest {
 	@Autowired
 	private PlayerRepository playerRepository;
 
-	@Autowired
-	private TeamRepository teamRepository;
-
 	@PersistenceContext
 	private EntityManager em;
 
-	@Test
-	@DisplayName("league를 주면 현재 소속팀이 그 리그(LeagueTeam)에 등록된 선수만 나온다")
-	void searchForBackoffice_filtersByCurrentTeamLeague() {
-		Team genG = teamRepository.save(Team.builder().name("Gen.G").code("GEN").build());
-		Team weibo = teamRepository.save(Team.builder().name("Weibo Gaming").code("WBG").build());
+	@BeforeEach
+	void seed() {
+		exec("INSERT INTO champions (champion_id, champion_name_kr, champion_name_en, image_url)"
+				+ " VALUES (1, '아리', 'Ahri', 'ahri.png')");
+		exec(league(100, "LCK", 2026));
+		exec(league(101, "LPL", 2026));
+		exec(team(10, "T1", "T1"));
+		exec(team(11, "Weibo Gaming", "WBG"));
 
-		League lck = em.merge(League.builder().leagueName("LCK").seasonYear(2025)
-				.seasonSplit("Spring").isPlayoffs(false).build());
-		League lpl = em.merge(League.builder().leagueName("LPL").seasonYear(2025)
-				.seasonSplit("Spring").isPlayoffs(false).build());
-		em.persist(LeagueTeam.builder().league(lck).team(genG).build());
-		em.persist(LeagueTeam.builder().league(lpl).team(weibo).build());
+		exec(player(1, "Chovy", "Mid"));   // LCK 출전
+		exec(player(2, "Xiaohu", "Mid"));  // LPL만 출전
+		exec(player(3, "Rookie", "Mid"));  // 출전 기록 없음
 
-		Player chovy = Player.builder().name("Chovy").build();
-		chovy.changeCurrentTeam(genG);
-		playerRepository.save(chovy);
-
-		Player xiaohu = Player.builder().name("Xiaohu").build();
-		xiaohu.changeCurrentTeam(weibo);
-		playerRepository.save(xiaohu);
-
-		Player freeAgent = Player.builder().name("FreeAgent").build(); // 무소속
-		playerRepository.save(freeAgent);
+		exec(game(1, 100, "2026-01-10 10:00:00")); // LCK
+		exec(game(2, 101, "2026-01-15 10:00:00")); // LPL
+		exec(gp(1, 1, 1, 10)); // Chovy @LCK
+		exec(gp(2, 2, 2, 11)); // Xiaohu @LPL
 
 		em.flush();
 		em.clear();
+	}
 
-		// LCK 소속팀 선수만
+	@Test
+	@DisplayName("league를 주면 그 리그 출전 기록이 있는 선수만 나온다")
+	void searchForBackoffice_filtersByParticipationLeague() {
 		List<String> lckPlayers = playerRepository.searchForBackoffice(null, "LCK", PageRequest.of(0, 10))
 				.map(Player::getName).getContent();
 		assertThat(lckPlayers).containsExactly("Chovy");
 
-		// league 없으면 전체(무소속 포함)
+		// league 없으면 전체(출전 기록 없는 선수 포함)
 		assertThat(playerRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
 				.isEqualTo(3);
 
@@ -75,5 +67,43 @@ class PlayerRepositorySearchTest {
 		List<String> lckCho = playerRepository.searchForBackoffice("cho", "LCK", PageRequest.of(0, 10))
 				.map(Player::getName).getContent();
 		assertThat(lckCho).containsExactly("Chovy");
+
+		// LPL만 뛴 선수는 LCK 필터에 안 걸린다
+		List<String> lpl = playerRepository.searchForBackoffice(null, "LPL", PageRequest.of(0, 10))
+				.map(Player::getName).getContent();
+		assertThat(lpl).containsExactly("Xiaohu");
+	}
+
+	// ── 시딩 헬퍼 (PlayerRepositoryLckParticipationTest와 동일 패턴) ──
+
+	private void exec(String sql) {
+		em.createNativeQuery(sql).executeUpdate();
+	}
+
+	private static String league(long id, String name, int year) {
+		return "INSERT INTO leagues (league_id, league_name, season_year, season_split, is_playoffs)"
+				+ " VALUES (" + id + ", '" + name + "', " + year + ", 'Spring', false)";
+	}
+
+	private static String team(long id, String name, String code) {
+		return "INSERT INTO teams (team_id, team_name, team_code, team_image_url)"
+				+ " VALUES (" + id + ", '" + name + "', '" + code + "', '" + code + ".png')";
+	}
+
+	private static String player(long id, String name, String role) {
+		return "INSERT INTO players (player_id, player_name, image_url, role)"
+				+ " VALUES (" + id + ", '" + name + "', '" + name + ".png', '" + role + "')";
+	}
+
+	private static String game(long id, long leagueId, String startTime) {
+		return "INSERT INTO games (game_id, league_id, actual_game_start_time, game_number, patch,"
+				+ " game_length_seconds, ckpm) VALUES (" + id + ", " + leagueId + ", '" + startTime
+				+ "', 1, '14.1', 1800, 0.5)";
+	}
+
+	private static String gp(long id, long gameId, long playerId, long teamId) {
+		return "INSERT INTO game_participants (participant_game_id, game_id, player_id, team_id,"
+				+ " side, position, champion_id, is_win) VALUES (" + id + ", " + gameId + ", "
+				+ playerId + ", " + teamId + ", 'Blue', 'mid', 1, true)";
 	}
 }

--- a/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
@@ -14,8 +14,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
-import com.toy.nar.domain.game.entity.League;
-import com.toy.nar.domain.game.entity.LeagueTeam;
 import com.toy.nar.domain.participant.entity.Team;
 
 // 백오피스 검색 쿼리(searchForBackoffice) 검증. H2 격리 실행(마이그레이션은 MySQL 전용이라 엔티티 기반 스키마 사용).
@@ -58,23 +56,34 @@ class TeamRepositorySearchTest {
 	}
 
 	@Test
-	@DisplayName("league을 주면 해당 리그(LeagueTeam)에 속한 팀만, q와 함께도 동작한다")
+	@DisplayName("league를 주면 그 리그 출전 기록이 있는 팀만, q와 함께도 동작한다")
 	void searchForBackoffice_filtersByLeague() {
-		Team genG = teamRepository.save(Team.builder().name("Gen.G").code("GEN").build());
-		Team t1 = teamRepository.save(Team.builder().name("T1").code("T1").build());
-		Team weibo = teamRepository.save(Team.builder().name("Weibo Gaming").code("WBG").build());
-
-		League lck = em.merge(League.builder().leagueName("LCK").seasonYear(2025)
-				.seasonSplit("Spring").isPlayoffs(false).build());
-		League lpl = em.merge(League.builder().leagueName("LPL").seasonYear(2025)
-				.seasonSplit("Spring").isPlayoffs(false).build());
-		em.persist(LeagueTeam.builder().league(lck).team(genG).build());
-		em.persist(LeagueTeam.builder().league(lck).team(t1).build());
-		em.persist(LeagueTeam.builder().league(lpl).team(weibo).build());
+		// 출전 기록(GameParticipant) 기준 — league_teams는 오염돼 있어 판정에 쓰지 않는다.
+		exec("INSERT INTO champions (champion_id, champion_name_kr, champion_name_en, image_url)"
+				+ " VALUES (1, '아리', 'Ahri', 'ahri.png')");
+		exec("INSERT INTO leagues (league_id, league_name, season_year, season_split, is_playoffs)"
+				+ " VALUES (100, 'LCK', 2025, 'Spring', false)");
+		exec("INSERT INTO leagues (league_id, league_name, season_year, season_split, is_playoffs)"
+				+ " VALUES (101, 'LPL', 2025, 'Spring', false)");
+		exec("INSERT INTO teams (team_id, team_name, team_code, team_image_url) VALUES (10, 'Gen.G', 'GEN', 'g.png')");
+		exec("INSERT INTO teams (team_id, team_name, team_code, team_image_url) VALUES (11, 'T1', 'T1', 't.png')");
+		exec("INSERT INTO teams (team_id, team_name, team_code, team_image_url) VALUES (12, 'Weibo Gaming', 'WBG', 'w.png')");
+		exec("INSERT INTO players (player_id, player_name, image_url, role) VALUES (1, 'p1', 'p1.png', 'Mid')");
+		exec("INSERT INTO games (game_id, league_id, actual_game_start_time, game_number, patch,"
+				+ " game_length_seconds, ckpm) VALUES (1, 100, '2025-01-10 10:00:00', 1, '14.1', 1800, 0.5)");
+		exec("INSERT INTO games (game_id, league_id, actual_game_start_time, game_number, patch,"
+				+ " game_length_seconds, ckpm) VALUES (2, 101, '2025-01-15 10:00:00', 1, '14.1', 1800, 0.5)");
+		// LCK 경기: Gen.G, T1 출전 / LPL 경기: Weibo 출전
+		exec("INSERT INTO game_participants (participant_game_id, game_id, player_id, team_id, side, position,"
+				+ " champion_id, is_win) VALUES (1, 1, 1, 10, 'Blue', 'mid', 1, true)");
+		exec("INSERT INTO game_participants (participant_game_id, game_id, player_id, team_id, side, position,"
+				+ " champion_id, is_win) VALUES (2, 1, 1, 11, 'Red', 'mid', 1, false)");
+		exec("INSERT INTO game_participants (participant_game_id, game_id, player_id, team_id, side, position,"
+				+ " champion_id, is_win) VALUES (3, 2, 1, 12, 'Blue', 'mid', 1, true)");
 		em.flush();
 		em.clear();
 
-		// LCK 소속 팀만
+		// LCK 출전 팀만
 		List<String> lckTeams = teamRepository.searchForBackoffice(null, "LCK", PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(lckTeams).containsExactlyInAnyOrder("Gen.G", "T1");
@@ -84,8 +93,12 @@ class TeamRepositorySearchTest {
 				.map(Team::getName).getContent();
 		assertThat(lckGen).containsExactly("Gen.G");
 
-		// 소속 팀 없는 리그
+		// 출전 팀 없는 리그
 		assertThat(teamRepository.searchForBackoffice(null, "LEC", PageRequest.of(0, 10)).getTotalElements())
 				.isZero();
+	}
+
+	private void exec(String sql) {
+		em.createNativeQuery(sql).executeUpdate();
 	}
 }


### PR DESCRIPTION
## 문제 (prod, #271 배포 후)
LCK 필터가 안 먹힘 — 전체 선수(239페이지)가 그대로 노출.

원인: #271이 필터 기준으로 삼은 **league_teams 테이블이 오염**돼 있음.
- LCK에 등록된 팀: **462개** (9z Globant, 100 Thieves, 아마추어 팀 전부)
- LCK 필터 매칭 선수: 3,046명 ≈ 전체
- 팀 목록의 LCK 필터도 (원래부터 league_teams 기준이라) 동일하게 깨져 있었음

## 수정
- 선수: 출전 기록(GameParticipant) EXISTS 기준으로 **원복** (정상 동작 확인된 방식, 로컬 ~98ms)
- 팀: league_teams → 출전 기록 기준으로 **교체** (팀 필터도 이 PR로 처음 정상화)
- 두 쿼리에 "league_teams 기준 금지(오염)" 주석 고정, 회귀 방지 테스트를 출전 기록 픽스처로 재작성

## 남는 과제 (별도)
1. **league_teams 데이터 정리** — LeagueTeamInitializer는 출전 기록 기반이라 정상인데 다른 writer(LeagueService/DataReconciliationService/CategoryService 중)가 오염시키는 것으로 보임. 정리 후 소속팀 기준 전환 재시도 가능(12.7ms).
2. 성능은 원복으로 ~98ms/쿼리 수준 — prod 체감 느림이 계속되면 인스턴스 경합(크론) 조사.

🤖 Generated with [Claude Code](https://claude.com/claude-code)