### PR TITLE
perf: 선수 리그 필터용 game_participants 커버링 인덱스 (~6배)

### DIFF
--- a/src/main/resources/db/migration/V56__Add_gp_game_player_covering_index.sql
+++ b/src/main/resources/db/migration/V56__Add_gp_game_player_covering_index.sql
@@ -1,0 +1,5 @@
+-- 백오피스 선수 검색의 리그 필터(출전 기록 EXISTS)용 커버링 인덱스.
+-- 기존 경로는 idx_game_champion(game_id)로 찾은 뒤 player_id를 행 룩업으로 읽어
+-- LCK 기준 참가기록 ~9천 행의 랜덤 액세스가 발생했다(페이지당 목록+카운트 2회).
+-- (game_id, player_id) 커버링으로 인덱스만 읽게 되어 실측 98ms → 15ms (동규모 로컬).
+CREATE INDEX idx_gp_game_player ON game_participants (game_id, player_id);


### PR DESCRIPTION
## 문제
어드민 선수 목록 페이징/검색이 느림 — prod DB 실측(EXPLAIN ANALYZE): **페이지당 목록 160ms + 카운트 97ms ≈ 257ms** (DB만). 원인: 리그 필터 EXISTS가 `idx_game_champion(game_id)`로 참가기록을 찾은 뒤 player_id를 **행 룩업 ~9,000회**로 읽음.

## 수정
`game_participants (game_id, player_id)` 커버링 인덱스 — V56 마이그레이션 한 줄. 쿼리 무변경.

- 동규모 로컬 실측: 목록 **98ms → 15ms**, 카운트 15ms → 13ms
- IN-서브쿼리 재작성안(79ms)보다 빠르고 diff 최소라 인덱스만 채택
- 테이블 16만행이라 인덱스 생성 수 초, 쓰기 오버헤드 미미 (경기당 INSERT 10행)

#273(출전 기록 기준 원복) 위에 얹는 성능 보완.

🤖 Generated with [Claude Code](https://claude.com/claude-code)