### PR TITLE
perf: 리그 필터 'IS NULL OR EXISTS' 제거 — 페이지 3.4초 → ~0.2초

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -61,16 +61,23 @@ public class BackofficeController {
     public Page<PlayerRow> players(@RequestParam(required = false) String q,
                                    @RequestParam(required = false) String league,
                                    Pageable pageable) {
-        return playerRepository.searchForBackoffice(blankToNull(q), blankToNull(league), pageable)
-                .map(PlayerRow::from);
+        // 리그 유무로 쿼리 분리 — "(:league IS NULL OR EXISTS)" 단일 쿼리는 semijoin이 막혀 1.7초/쿼리.
+        String leagueParam = blankToNull(league);
+        Page<com.toy.nar.domain.participant.entity.Player> page = (leagueParam == null)
+                ? playerRepository.searchForBackoffice(blankToNull(q), pageable)
+                : playerRepository.searchForBackofficeInLeague(blankToNull(q), leagueParam, pageable);
+        return page.map(PlayerRow::from);
     }
 
     @GetMapping("/teams")
     public Page<TeamRow> teams(@RequestParam(required = false) String q,
                                @RequestParam(required = false) String league,
                                Pageable pageable) {
-        return teamRepository.searchForBackoffice(blankToNull(q), blankToNull(league), pageable)
-                .map(t -> new TeamRow(t.getId(), t.getName(), t.getCode()));
+        String leagueParam = blankToNull(league);
+        Page<com.toy.nar.domain.participant.entity.Team> page = (leagueParam == null)
+                ? teamRepository.searchForBackoffice(blankToNull(q), pageable)
+                : teamRepository.searchForBackofficeInLeague(blankToNull(q), leagueParam, pageable);
+        return page.map(t -> new TeamRow(t.getId(), t.getName(), t.getCode()));
     }
 
     // 리그 필터 옵션. 실제 데이터에 존재하는 리그명(전 시즌) distinct.

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -19,10 +19,7 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	@EntityGraph(attributePaths = {"currentTeam"})
 	Optional<Player> findWithCurrentTeamById(Long id);
 
-	// 백오피스 검색: 선수명·실명 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
-	// 리그는 출전 기록(GameParticipant→Game→League) 기준 EXISTS(전 시즌 통합).
-	// ⚠️ league_teams 기준으로 바꾸지 말 것: 해당 테이블은 오염돼 있음(LCK에 462팀 등록돼 필터가 전체 통과).
-	//    데이터 정리 전까지 출전 기록이 유일하게 신뢰 가능한 리그 판정.
+	// 백오피스 검색(리그 필터 없음): 선수명·실명 부분일치. q 가 null 이면 전체.
 	// currentTeam은 목록 응답에 팀명을 실어야 해서 EntityGraph로 함께 로딩(N+1/LAZY 예외 방지).
 	@EntityGraph(attributePaths = {"currentTeam"})
 	@Query("""
@@ -30,11 +27,24 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			WHERE (:q IS NULL
 			       OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%')))
-			  AND (:league IS NULL
-			       OR EXISTS (SELECT 1 FROM GameParticipant gp
-			                  WHERE gp.player = p AND gp.game.league.leagueName = :league))
 			""")
-	Page<Player> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
+	Page<Player> searchForBackoffice(@Param("q") String q, Pageable pageable);
+
+	// 백오피스 검색(리그 필터): 출전 기록(GameParticipant→Game→League) 기준 EXISTS(전 시즌 통합).
+	// ⚠️ 리그 없는 검색과 합쳐서 "(:league IS NULL OR EXISTS …)" 한 방 쿼리로 만들지 말 것:
+	//    EXISTS가 OR 안에 들어가면 MySQL이 semijoin 변환을 못 해 선수마다 상관 서브쿼리가 돌아
+	//    쿼리당 1.7초(참가기록 14.7만행 순회)가 걸렸다. 순수 AND 조건이면 93ms.
+	// ⚠️ league_teams 기준으로 바꾸지 말 것: 오염돼 있음(LCK에 462팀 등록 → 필터 전체 통과).
+	@EntityGraph(attributePaths = {"currentTeam"})
+	@Query("""
+			SELECT p FROM Player p
+			WHERE (:q IS NULL
+			       OR LOWER(p.name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(p.realName) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND EXISTS (SELECT 1 FROM GameParticipant gp
+			              WHERE gp.player = p AND gp.game.league.leagueName = :league)
+			""")
+	Page<Player> searchForBackofficeInLeague(@Param("q") String q, @Param("league") String league, Pageable pageable);
 
 	// 해당 리그 출전 이력 여부. 백오피스 선수 수정의 "LCK만 허용" 서버 검증에 사용.
 	@Query("""

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -51,17 +51,26 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	@Query("SELECT t FROM Team t WHERE LOWER(t.name) = LOWER(:name)")
 	Optional<Team> findByNameIgnoreCase(@Param("name") String name);
 
-	// 백오피스 검색: 팀명·코드 부분일치 + 리그 필터. q/league 가 null 이면 각 조건 무시.
-	// 리그는 출전 기록(GameParticipant) 기준 EXISTS(전 시즌 통합).
-	// ⚠️ league_teams 기준 금지: 오염돼 있음(LCK에 462팀) — 선수 검색과 동일 사유. 정리 전까지 출전 기록으로 판정.
+	// 백오피스 검색(리그 필터 없음): 팀명·코드 부분일치. q 가 null 이면 전체.
 	@Query("""
 			SELECT t FROM Team t
 			WHERE (:q IS NULL
 			       OR LOWER(t.name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(t.code) LIKE LOWER(CONCAT('%', :q, '%')))
-			  AND (:league IS NULL
-			       OR EXISTS (SELECT 1 FROM GameParticipant gp
-			                  WHERE gp.team = t AND gp.game.league.leagueName = :league))
 			""")
-	Page<Team> searchForBackoffice(@Param("q") String q, @Param("league") String league, Pageable pageable);
+	Page<Team> searchForBackoffice(@Param("q") String q, Pageable pageable);
+
+	// 백오피스 검색(리그 필터): 출전 기록(GameParticipant) 기준 EXISTS(전 시즌 통합).
+	// ⚠️ "(:league IS NULL OR EXISTS …)" 한 방 쿼리 금지: EXISTS가 OR 안이면 semijoin 변환이 막혀
+	//    행마다 상관 서브쿼리가 돈다(선수 검색에서 쿼리당 1.7초 실측) — 순수 AND 유지.
+	// ⚠️ league_teams 기준 금지: 오염돼 있음(LCK에 462팀) — 정리 전까지 출전 기록으로 판정.
+	@Query("""
+			SELECT t FROM Team t
+			WHERE (:q IS NULL
+			       OR LOWER(t.name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(t.code) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND EXISTS (SELECT 1 FROM GameParticipant gp
+			              WHERE gp.team = t AND gp.game.league.leagueName = :league)
+			""")
+	Page<Team> searchForBackofficeInLeague(@Param("q") String q, @Param("league") String league, Pageable pageable);
 }

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositorySearchTest.java
@@ -55,21 +55,21 @@ class PlayerRepositorySearchTest {
 	@Test
 	@DisplayName("league를 주면 그 리그 출전 기록이 있는 선수만 나온다")
 	void searchForBackoffice_filtersByParticipationLeague() {
-		List<String> lckPlayers = playerRepository.searchForBackoffice(null, "LCK", PageRequest.of(0, 10))
+		List<String> lckPlayers = playerRepository.searchForBackofficeInLeague(null, "LCK", PageRequest.of(0, 10))
 				.map(Player::getName).getContent();
 		assertThat(lckPlayers).containsExactly("Chovy");
 
 		// league 없으면 전체(출전 기록 없는 선수 포함)
-		assertThat(playerRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(playerRepository.searchForBackoffice(null, PageRequest.of(0, 10)).getTotalElements())
 				.isEqualTo(3);
 
 		// q 결합
-		List<String> lckCho = playerRepository.searchForBackoffice("cho", "LCK", PageRequest.of(0, 10))
+		List<String> lckCho = playerRepository.searchForBackofficeInLeague("cho", "LCK", PageRequest.of(0, 10))
 				.map(Player::getName).getContent();
 		assertThat(lckCho).containsExactly("Chovy");
 
 		// LPL만 뛴 선수는 LCK 필터에 안 걸린다
-		List<String> lpl = playerRepository.searchForBackoffice(null, "LPL", PageRequest.of(0, 10))
+		List<String> lpl = playerRepository.searchForBackofficeInLeague(null, "LPL", PageRequest.of(0, 10))
 				.map(Player::getName).getContent();
 		assertThat(lpl).containsExactly("Xiaohu");
 	}

--- a/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/TeamRepositorySearchTest.java
@@ -37,21 +37,21 @@ class TeamRepositorySearchTest {
 		teamRepository.save(Team.builder().name("T1").code("T1").build());
 
 		// null → 전체
-		assertThat(teamRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(teamRepository.searchForBackoffice(null, PageRequest.of(0, 10)).getTotalElements())
 				.isEqualTo(3);
 
 		// 팀명 부분일치(소문자 입력도 매칭)
-		List<String> byName = teamRepository.searchForBackoffice("gen", null, PageRequest.of(0, 10))
+		List<String> byName = teamRepository.searchForBackoffice("gen", PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(byName).containsExactly("Gen.G");
 
 		// 코드 부분일치
-		List<String> byCode = teamRepository.searchForBackoffice("dk", null, PageRequest.of(0, 10))
+		List<String> byCode = teamRepository.searchForBackoffice("dk", PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(byCode).containsExactly("Dplus KIA");
 
 		// 매칭 없음
-		Page<Team> none = teamRepository.searchForBackoffice("zzz", null, PageRequest.of(0, 10));
+		Page<Team> none = teamRepository.searchForBackoffice("zzz", PageRequest.of(0, 10));
 		assertThat(none.getTotalElements()).isZero();
 	}
 
@@ -84,17 +84,17 @@ class TeamRepositorySearchTest {
 		em.clear();
 
 		// LCK 출전 팀만
-		List<String> lckTeams = teamRepository.searchForBackoffice(null, "LCK", PageRequest.of(0, 10))
+		List<String> lckTeams = teamRepository.searchForBackofficeInLeague(null, "LCK", PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(lckTeams).containsExactlyInAnyOrder("Gen.G", "T1");
 
 		// LCK + q 결합
-		List<String> lckGen = teamRepository.searchForBackoffice("gen", "LCK", PageRequest.of(0, 10))
+		List<String> lckGen = teamRepository.searchForBackofficeInLeague("gen", "LCK", PageRequest.of(0, 10))
 				.map(Team::getName).getContent();
 		assertThat(lckGen).containsExactly("Gen.G");
 
 		// 출전 팀 없는 리그
-		assertThat(teamRepository.searchForBackoffice(null, "LEC", PageRequest.of(0, 10)).getTotalElements())
+		assertThat(teamRepository.searchForBackofficeInLeague(null, "LEC", PageRequest.of(0, 10)).getTotalElements())
 				.isZero();
 	}
 


### PR DESCRIPTION
## 원인 (prod에서 실행 중인 쿼리를 processlist로 직접 포착)
JPQL의 `(:league IS NULL OR EXISTS(...))` 패턴 — **EXISTS가 OR 안에 있으면 MySQL이 semijoin 변환을 포기**하고 행마다 상관 서브쿼리를 실행한다. 선수 3,772행 × 각자 전체 출전 기록 스캔 = 참가기록 147,353행 순회. 리터럴 'LCK'가 들어와도 옵티마이저가 OR 분기를 semijoin 판단 전에 제거하지 않음.

- 앱 실제 쿼리(캡처본) EXPLAIN ANALYZE: **1,724ms** × 목록+카운트 2회 = 관측된 3.4초와 일치
- 같은 쿼리에서 EXISTS를 순수 AND로: **92.8ms**
- V56 인덱스가 안 먹혔던 이유도 동일 — semijoin이 아예 안 걸리는 플랜이라 인덱스 무관

## 수정
선수·팀 검색을 리그 유/무 2개 메서드로 분리(`searchForBackoffice` / `searchForBackofficeInLeague`), 컨트롤러에서 분기. EXISTS는 항상 순수 AND 조건 — semijoin + V56 커버링 인덱스 활성.

재발 방지 주석 고정: ① OR+EXISTS 금지(semijoin), ② league_teams 금지(오염).

## 검증
- prod DB에서 수정 형태 EXPLAIN ANALYZE 92.8ms 확인 후 구현
- 리포지토리 테스트 분리 메서드로 갱신, `./gradlew build` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)