### PR TITLE
feat: LCK 선수 이미지 동기화를 LoL Esports 공식 프로필 사진으로 교체

### DIFF
--- a/src/main/java/com/toy/nar/api/v3/PlayerController.java
+++ b/src/main/java/com/toy/nar/api/v3/PlayerController.java
@@ -43,7 +43,7 @@ public class PlayerController {
 		return ResponseEntity.ok("Player image updated successfully.");
 	}
 
-	@Operation(summary = "LCK 선수 이미지 URL 일괄 동기화", description = "LCK 선수들의 이미지 URL을 확인하고 유효한 경우 업데이트하며, 실패한 선수 목록을 반환합니다.")
+	@Operation(summary = "LCK 선수 이미지 URL 일괄 동기화", description = "LoL Esports getTeams API의 공식 프로필 사진으로 LCK 선수 이미지를 동기화하고, 매칭 실패한 선수 목록을 반환합니다.")
 	@PostMapping("/sync-images")
 	public ResponseEntity<PlayerImageSyncResult> syncLckPlayerImages() {
 		PlayerImageSyncResult result = playerService.syncLckPlayerImages();

--- a/src/main/java/com/toy/nar/app/participant/service/PlayerService.java
+++ b/src/main/java/com/toy/nar/app/participant/service/PlayerService.java
@@ -1,6 +1,7 @@
 package com.toy.nar.app.participant.service;
 
 import com.toy.nar.app.participant.dto.PlayerImageSyncResult;
+import com.toy.nar.app.player.LolesportsPlayerImageClient;
 import com.toy.nar.app.player.PlayerProfileCrawlerService;
 import com.toy.nar.app.player.PlayerProfileDto;
 import com.toy.nar.app.player.PlayerProfileSyncResult;
@@ -13,10 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -25,6 +25,7 @@ public class PlayerService {
 
 	private final PlayerRepository playerRepository;
 	private final PlayerProfileCrawlerService playerProfileCrawlerService;
+	private final LolesportsPlayerImageClient lolesportsPlayerImageClient;
 	private final ObjectMapper objectMapper;
 
 	@Transactional
@@ -53,36 +54,32 @@ public class PlayerService {
 		return players.size();
 	}
 
+	/**
+	 * LCK 선수 이미지를 LoL Esports getTeams API의 공식 프로필 사진으로 동기화.
+	 * API에 이미지가 없는 선수는 기존 이미지를 유지하고 실패 목록으로 보고한다.
+	 */
 	@Transactional
 	public PlayerImageSyncResult syncLckPlayerImages() {
 		List<Player> players = playerRepository.findPlayersByLeagueName("LCK");
-		List<String> failedPlayers = Collections.synchronizedList(new ArrayList<>());
+		Map<String, String> imagesByName = lolesportsPlayerImageClient.fetchPlayerImages();
+		List<String> failedPlayers = new ArrayList<>();
+		int successCount = 0;
 
-		// 1. 유효한 이미지 URL 매핑 정보 수집 (병렬)
-		Map<Player, String> validImages = players.parallelStream()
-				.map(player -> {
-					String name = player.getName();
-					String encodedName = name.replace(" ", "%20");
-					String imageUrl = "https://images.epromatch.com/lol/player/" + encodedName + ".png";
-
-					if (isImageAvailable(imageUrl)) {
-						return new java.util.AbstractMap.SimpleEntry<>(player, imageUrl);
-					} else {
-						failedPlayers.add(name);
-						return null;
-					}
-				})
-				.filter(java.util.Objects::nonNull)
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-		// 2. DB 업데이트 (순차)
-		validImages.forEach(Player::setImageUrl);
+		for (Player player : players) {
+			String imageUrl = imagesByName.get(player.getName().trim().toLowerCase(Locale.ROOT));
+			if (imageUrl != null) {
+				player.setImageUrl(imageUrl);
+				successCount++;
+			} else {
+				failedPlayers.add(player.getName());
+			}
+		}
 
 		return PlayerImageSyncResult.builder()
 				.totalTarget(players.size())
-				.successCount(validImages.size())
+				.successCount(successCount)
 				.failCount(failedPlayers.size())
-				.failedPlayerNames(new ArrayList<>(failedPlayers))
+				.failedPlayerNames(failedPlayers)
 				.build();
 	}
 
@@ -138,22 +135,6 @@ public class PlayerService {
 		} catch (Exception e) {
 			log.warn("Failed to convert gameAccounts to JSON", e);
 			return null;
-		}
-	}
-
-	private boolean isImageAvailable(String urlString) {
-		try {
-			java.net.URL url = new java.net.URL(urlString);
-			java.net.HttpURLConnection connection = (java.net.HttpURLConnection) url.openConnection();
-			connection.setRequestMethod("HEAD");
-			connection.setConnectTimeout(1000);
-			connection.setReadTimeout(1000);
-			connection.setRequestProperty("User-Agent", "Mozilla/5.0");
-
-			int responseCode = connection.getResponseCode();
-			return (responseCode == 200);
-		} catch (Exception e) {
-			return false;
 		}
 	}
 }

--- a/src/main/java/com/toy/nar/app/player/LolesportsPlayerImageClient.java
+++ b/src/main/java/com/toy/nar/app/player/LolesportsPlayerImageClient.java
@@ -1,0 +1,82 @@
+package com.toy.nar.app.player;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * LoL Esports getTeams API에서 선수 공식 프로필 이미지 URL을 수집한다.
+ * 응답의 summonerName(소문자 트림) -> image URL 맵을 만든다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LolesportsPlayerImageClient {
+
+	private static final String DEFAULT_HEADSHOT = "default-headshot";
+
+	private final WebClient webClient;
+
+	@Value("${lolesports.riot-api.key}")
+	private String apiKey;
+
+	/**
+	 * 전체 팀 로스터에서 선수명 -> 이미지 URL 맵 조회. 실패 시 빈 맵.
+	 */
+	public Map<String, String> fetchPlayerImages() {
+		try {
+			JsonNode root = webClient.get()
+					.uri(uri -> uri
+							.scheme("https")
+							.host("esports-api.lolesports.com")
+							.path("/persisted/gw/getTeams")
+							.queryParam("hl", "ko-KR")
+							.build())
+					.header("x-api-key", apiKey)
+					.header("Referer", "https://lolesports.com/")
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.block();
+			return extractPlayerImages(root);
+		} catch (Exception e) {
+			log.error("Failed to fetch player images from LoL Esports getTeams API", e);
+			return Map.of();
+		}
+	}
+
+	/**
+	 * getTeams 응답에서 선수명(소문자) -> 이미지 URL 맵 추출.
+	 * default-headshot은 제외하고, 동명 선수는 LCK 소속팀 항목을 우선한다.
+	 */
+	static Map<String, String> extractPlayerImages(JsonNode root) {
+		Map<String, String> images = new HashMap<>();
+		if (root == null) {
+			return images;
+		}
+		Map<String, Boolean> fromLck = new HashMap<>();
+
+		for (JsonNode team : root.path("data").path("teams")) {
+			boolean isLck = "LCK".equalsIgnoreCase(team.path("homeLeague").path("name").asText());
+			for (JsonNode player : team.path("players")) {
+				String name = player.path("summonerName").asText("").trim();
+				String image = player.path("image").asText("");
+				if (name.isEmpty() || image.isEmpty() || image.contains(DEFAULT_HEADSHOT)) {
+					continue;
+				}
+				String key = name.toLowerCase(Locale.ROOT);
+				if (!images.containsKey(key) || (isLck && !fromLck.getOrDefault(key, false))) {
+					images.put(key, image);
+					fromLck.put(key, isLck);
+				}
+			}
+		}
+		return images;
+	}
+}

--- a/src/test/java/com/toy/nar/app/player/LolesportsPlayerImageClientTest.java
+++ b/src/test/java/com/toy/nar/app/player/LolesportsPlayerImageClientTest.java
@@ -1,0 +1,82 @@
+package com.toy.nar.app.player;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LolesportsPlayerImageClientTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private JsonNode json(String body) throws Exception {
+		return objectMapper.readTree(body);
+	}
+
+	@Test
+	void 선수_이름_소문자_키로_이미지_URL을_추출한다() throws Exception {
+		JsonNode root = json("""
+				{"data":{"teams":[
+					{"name":"T1","homeLeague":{"name":"LCK"},"players":[
+						{"summonerName":"Faker","image":"http://static.lolesports.com/players/faker.png"}
+					]}
+				]}}
+				""");
+
+		Map<String, String> images = LolesportsPlayerImageClient.extractPlayerImages(root);
+
+		assertThat(images).containsEntry("faker", "http://static.lolesports.com/players/faker.png");
+	}
+
+	@Test
+	void 기본_헤드샷_이미지는_제외한다() throws Exception {
+		JsonNode root = json("""
+				{"data":{"teams":[
+					{"name":"T1","homeLeague":{"name":"LCK"},"players":[
+						{"summonerName":"Rookie1","image":"http://static.lolesports.com/players/default-headshot.png"},
+						{"summonerName":"NoImage"}
+					]}
+				]}}
+				""");
+
+		Map<String, String> images = LolesportsPlayerImageClient.extractPlayerImages(root);
+
+		assertThat(images).isEmpty();
+	}
+
+	@Test
+	void 이름_충돌시_LCK_소속팀_이미지를_우선한다() throws Exception {
+		JsonNode root = json("""
+				{"data":{"teams":[
+					{"name":"Foreign Team","homeLeague":{"name":"LEC"},"players":[
+						{"summonerName":"Duro","image":"http://static.lolesports.com/players/duro-lec.png"}
+					]},
+					{"name":"DN SOOPers","homeLeague":{"name":"LCK"},"players":[
+						{"summonerName":"Duro","image":"http://static.lolesports.com/players/duro-lck.png"}
+					]}
+				]}}
+				""");
+
+		Map<String, String> images = LolesportsPlayerImageClient.extractPlayerImages(root);
+
+		assertThat(images).containsEntry("duro", "http://static.lolesports.com/players/duro-lck.png");
+	}
+
+	@Test
+	void LCK_외_리그_선수도_포함한다_공백은_트림한다() throws Exception {
+		JsonNode root = json("""
+				{"data":{"teams":[
+					{"name":"LYON","homeLeague":{"name":"LTA North"},"players":[
+						{"summonerName":"Berserker ","image":"http://static.lolesports.com/players/berserker.png"}
+					]}
+				]}}
+				""");
+
+		Map<String, String> images = LolesportsPlayerImageClient.extractPlayerImages(root);
+
+		assertThat(images).containsEntry("berserker", "http://static.lolesports.com/players/berserker.png");
+	}
+}


### PR DESCRIPTION
## 배경

- `POST /api/players/sync-images`는 epromatch 이름 기반 URL 추정 + HEAD 체크 방식이라 신규 선수(예: Berserker)가 누락되고, epromatch 서버 TLS 체인 문제로 HEAD 체크 자체가 실패할 수 있음
- 이미 사용 중인 LoL Esports API(`esports-api.lolesports.com`, 같은 x-api-key)의 `getTeams`가 선수별 공식 프로필 사진 URL을 직접 제공 — 실측 기준 2026 LCK 로스터 116명 중 108명 사진 보유(나머지 8명은 default-headshot), Berserker도 포함

## 변경

- `LolesportsPlayerImageClient` 신규: `getTeams?hl=ko-KR` 호출 → 선수명(소문자 트림) → 이미지 URL 맵 추출
  - `default-headshot` 제외 (기존 이미지 유지)
  - 동명 선수 충돌 시 LCK 소속팀 항목 우선
- `PlayerService.syncLckPlayerImages()`: epromatch HEAD 체크 로직 제거, API 맵 매칭으로 교체 (엔드포인트·응답 DTO 불변)
- `imageLocked` 선수는 기존대로 `setImageUrl` no-op으로 보호됨

## 테스트

- `LolesportsPlayerImageClientTest` 4건 (추출/기본헤드샷 제외/LCK 우선/트림) 통과
- 전체 `./gradlew test` 통과

## 배포 후

- prod에서 `POST /api/players/sync-images` 1회 수동 실행 필요 (이미지 동기화는 스케줄러 없음, 수동 트리거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)