### PR TITLE
feat: WhaTap Java APM 에이전트 연결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,10 @@ jobs:
             echo "Pulling app image: ${APP_IMAGE}"
             docker pull "${APP_IMAGE}"
 
+            # WhaTap Java APM — 에이전트·whatap.conf는 호스트 /opt/whatap 에 사전 설치.
+            # 최신 jar 자동 선택하므로 에이전트 업데이트는 tar만 다시 풀면 된다.
+            WHATAP_JAR=$(basename "$(ls /opt/whatap/whatap.agent-*.jar | sort -V | tail -1)")
+
             # awslogs: CloudWatch /nar/app 로 전송 (보존 30일). docker 20.10+ dual logging
             # 캐시 덕에 docker logs·Dozzle 도 그대로 동작한다. EC2 롤: NAR-CloudWatch-Role
             docker run -d --name "${NEW_NAME}" -p 127.0.0.1:${NEW_PORT}:8080 \
@@ -170,7 +174,9 @@ jobs:
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
+              -e JAVA_TOOL_OPTIONS="-javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
+              -v /opt/whatap:/whatap \
               "${APP_IMAGE}"
 
             # micro+swap 환경은 기동이 느릴 수 있어 상한 120초(60회 x 2초)


### PR DESCRIPTION
## 개요
EC2 호스트 `/opt/whatap` 에 사전 설치한 WhaTap Java 에이전트를 배포 컨테이너에 연결한다.

## 변경 내용
- `docker pull` 직후 호스트에서 최신 에이전트 jar 자동 선택 (`sort -V | tail -1`)
- `docker run` 에 추가:
  - `-v /opt/whatap:/whatap` — 에이전트 + whatap.conf 마운트 (라이선스 키는 호스트에만 존재, 레포/이미지 미포함)
  - `-e JAVA_TOOL_OPTIONS` — `-javaagent` 주입 (Dockerfile 무수정, JVM이 자동 인식)
  - `--add-opens=java.base/java.lang=ALL-UNNAMED` — Java 17+ 필수 옵션
  - `-Dwhatap.oname=${NEW_NAME}` — blue/green 공존 시 대시보드에서 컨테이너 구분

## 사전 조건 (완료됨)
- [x] 호스트 `/opt/whatap` 에 에이전트 설치 + `whatap.conf` (license, server.host, `weaving=spring-boot-3.0`)
- [ ] `ls /opt/whatap/whatap.agent-*.jar` 로 jar 존재 확인 — **머지 전 필수**

## 확인 방법
배포 후 앱 로그에 WhaTap 배너 → 와탭 애플리케이션 대시보드에 `nar-gg-blue`/`green` 인스턴스 표시.

## 주의
컨테이너 `-m 768m` 에 에이전트 오버헤드(~80–150MB) 추가됨. 배포 후 `docker stats` 확인, 빡빡하면 상향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)