### PR TITLE
feat: SET_END 푸시 스코어에 네이버 e스포츠 보조 소스 추가

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/NaverEsportsScoreClient.java
+++ b/src/main/java/com/toy/nar/app/lolesports/NaverEsportsScoreClient.java
@@ -1,0 +1,97 @@
+package com.toy.nar.app.lolesports;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 네이버 e스포츠 비공식 API에서 매치 세트 스코어를 조회한다.
+ *
+ * <p>Riot getEventDetails 의 gameWins 는 다음 세트 픽밴 시작에야 뒤집히지만(실측 46초~5분+,
+ * 마지막 세트는 25분+), 네이버는 세트 종료 직후 반영된다. SET_END 푸시 스코어 보정 전용
+ * 보조 소스 — 세트 종료 시점에만 호출되고(하루 수십 콜), 실패하면 조용히 null 을 돌려
+ * 기존 Riot 경로로 폴백한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverEsportsScoreClient {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	private final WebClient webClient;
+
+	/** 비공식 API 킬스위치. 스키마 변경·차단 시 끄면 Riot 경로만 쓴다. */
+	@Value("${live.notification.set-end-score.naver-enabled:true}")
+	private boolean enabled;
+
+	/**
+	 * 팀 코드(블루/레드)와 경기 시작 시각(UTC)으로 네이버 세트 스코어 [blue, red] 조회.
+	 * 미커버 리그·매칭 실패·API 오류 모두 null.
+	 */
+	public int[] fetchScore(String blueTeamCode, String redTeamCode, LocalDateTime matchDateUtc) {
+		if (!enabled || blueTeamCode == null || redTeamCode == null || matchDateUtc == null) {
+			return null;
+		}
+		try {
+			// 네이버는 경기 시작일(KST) 기준으로 묶는다 — 자정 넘겨 끝나도 시작일로 조회.
+			String day = matchDateUtc.atZone(ZoneOffset.UTC).withZoneSameInstant(KST)
+					.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE);
+			JsonNode root = webClient.get()
+					.uri(uri -> uri
+							.scheme("https")
+							.host("esports-api.game.naver.com")
+							.path("/service/v2/schedule/day")
+							.queryParam("day", day)
+							.build())
+					.header("User-Agent", "Mozilla/5.0")
+					.retrieve()
+					.bodyToMono(JsonNode.class)
+					.timeout(Duration.ofSeconds(3))
+					.block();
+			return extractScore(root, blueTeamCode, redTeamCode);
+		} catch (Exception e) {
+			log.warn("Naver esports score fetch failed. blue={} red={}: {}",
+					blueTeamCode, redTeamCode, e.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * day 응답에서 팀 약칭 쌍으로 경기를 찾아 [blue, red] 스코어 반환.
+	 * 네이버 home/away 순서가 우리 blue/red 와 다르면 스왑한다. 시작 전 경기는 무시.
+	 */
+	static int[] extractScore(JsonNode root, String blueTeamCode, String redTeamCode) {
+		if (root == null) {
+			return null;
+		}
+		for (JsonNode match : root.path("content").path("matches")) {
+			if ("BEFORE".equalsIgnoreCase(match.path("matchStatus").asText())) {
+				continue;
+			}
+			String home = match.path("homeTeam").path("nameEngAcronym").asText("");
+			String away = match.path("awayTeam").path("nameEngAcronym").asText("");
+			if (home.isEmpty() || away.isEmpty()) {
+				continue;
+			}
+			int homeScore = match.path("homeScore").asInt(0);
+			int awayScore = match.path("awayScore").asInt(0);
+			if (home.equalsIgnoreCase(blueTeamCode) && away.equalsIgnoreCase(redTeamCode)) {
+				return new int[] { homeScore, awayScore };
+			}
+			if (home.equalsIgnoreCase(redTeamCode) && away.equalsIgnoreCase(blueTeamCode)) {
+				return new int[] { awayScore, homeScore };
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/NaverEsportsScoreClient.java
+++ b/src/main/java/com/toy/nar/app/lolesports/NaverEsportsScoreClient.java
@@ -34,6 +34,9 @@ public class NaverEsportsScoreClient {
 	@Value("${live.notification.set-end-score.naver-enabled:true}")
 	private boolean enabled;
 
+	/** 같은 팀 쌍이 하루 2경기(더블헤더 등)일 때 오매칭을 막는 시작 시각 허용 오차. */
+	private static final long START_TIME_TOLERANCE_MS = Duration.ofHours(6).toMillis();
+
 	/**
 	 * 팀 코드(블루/레드)와 경기 시작 시각(UTC)으로 네이버 세트 스코어 [blue, red] 조회.
 	 * 미커버 리그·매칭 실패·API 오류 모두 null.
@@ -58,7 +61,13 @@ public class NaverEsportsScoreClient {
 					.bodyToMono(JsonNode.class)
 					.timeout(Duration.ofSeconds(3))
 					.block();
-			return extractScore(root, blueTeamCode, redTeamCode);
+			long startEpochMs = matchDateUtc.toInstant(ZoneOffset.UTC).toEpochMilli();
+			int[] score = extractScore(root, blueTeamCode, redTeamCode, startEpochMs);
+			if (score == null) {
+				// 미커버 리그·약칭 불일치는 조용히 폴백되면 원인을 못 찾는다 — 흔적을 남긴다.
+				log.info("Naver esports match not found. blue={} red={} day={}", blueTeamCode, redTeamCode, day);
+			}
+			return score;
 		} catch (Exception e) {
 			log.warn("Naver esports score fetch failed. blue={} red={}: {}",
 					blueTeamCode, redTeamCode, e.getMessage());
@@ -67,14 +76,21 @@ public class NaverEsportsScoreClient {
 	}
 
 	/**
-	 * day 응답에서 팀 약칭 쌍으로 경기를 찾아 [blue, red] 스코어 반환.
+	 * day 응답에서 LoL 종목 + 팀 약칭 쌍 + 시작 시각 근접(±6시간)으로 경기를 찾아
+	 * [blue, red] 스코어 반환. 같은 팀 쌍이 여러 경기면 시작 시각이 가장 가까운 경기를 쓴다.
 	 * 네이버 home/away 순서가 우리 blue/red 와 다르면 스왑한다. 시작 전 경기는 무시.
 	 */
-	static int[] extractScore(JsonNode root, String blueTeamCode, String redTeamCode) {
+	static int[] extractScore(JsonNode root, String blueTeamCode, String redTeamCode, long matchStartEpochMs) {
 		if (root == null) {
 			return null;
 		}
+		int[] best = null;
+		long bestGap = Long.MAX_VALUE;
 		for (JsonNode match : root.path("content").path("matches")) {
+			// 네이버 day 응답은 전 종목 포함 — 같은 조직이 타 종목에서 같은 날 붙으면 오매칭된다.
+			if (!"lol".equalsIgnoreCase(match.path("gameCode").asText())) {
+				continue;
+			}
 			if ("BEFORE".equalsIgnoreCase(match.path("matchStatus").asText())) {
 				continue;
 			}
@@ -85,13 +101,20 @@ public class NaverEsportsScoreClient {
 			}
 			int homeScore = match.path("homeScore").asInt(0);
 			int awayScore = match.path("awayScore").asInt(0);
+			int[] score;
 			if (home.equalsIgnoreCase(blueTeamCode) && away.equalsIgnoreCase(redTeamCode)) {
-				return new int[] { homeScore, awayScore };
+				score = new int[] { homeScore, awayScore };
+			} else if (home.equalsIgnoreCase(redTeamCode) && away.equalsIgnoreCase(blueTeamCode)) {
+				score = new int[] { awayScore, homeScore };
+			} else {
+				continue;
 			}
-			if (home.equalsIgnoreCase(redTeamCode) && away.equalsIgnoreCase(blueTeamCode)) {
-				return new int[] { awayScore, homeScore };
+			long gap = Math.abs(match.path("startDate").asLong(Long.MIN_VALUE) - matchStartEpochMs);
+			if (gap <= START_TIME_TOLERANCE_MS && gap < bestGap) {
+				best = score;
+				bestGap = gap;
 			}
 		}
-		return null;
+		return best;
 	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -52,15 +52,19 @@ public class TeamLiveEventPushService {
 	private final MobilePushGateway pushGateway;
 	private final MemberNotificationService notificationService;
 	private final com.toy.nar.app.lolesports.WorldsService worldsService;
+	private final com.toy.nar.app.lolesports.NaverEsportsScoreClient naverEsportsScoreClient;
 
 	@Value("${live.notification.fcm.enabled:false}")
 	private boolean fcmNotificationEnabled;
 
-	/** SET_END 스코어가 방금 끝난 세트를 반영할 때까지의 업스트림 재조회 횟수/간격. */
-	@Value("${live.notification.set-end-score.retry-attempts:3}")
+	/**
+	 * SET_END 스코어가 방금 끝난 세트를 반영할 때까지의 업스트림 재조회 횟수/간격.
+	 * 네이버는 세트 종료 후 ~1분 내 반영(실측)이라 10초 × 6회면 거의 항상 잡는다.
+	 */
+	@Value("${live.notification.set-end-score.retry-attempts:6}")
 	private int scoreRetryAttempts;
 
-	@Value("${live.notification.set-end-score.retry-delay-ms:4000}")
+	@Value("${live.notification.set-end-score.retry-delay-ms:10000}")
 	private long scoreRetryDelayMs;
 
 	public boolean isEnabled() {
@@ -167,9 +171,15 @@ public class TeamLiveEventPushService {
 			}
 
 			// DB stale — 업스트림이 방금 끝난 세트를 반영할 때까지 짧게 재시도.
+			// 네이버가 Riot gameWins 보다 항상 빨라(실측 46초~5분+ 선행) 시도마다 네이버 먼저 본다.
 			for (int attempt = 0; attempt < scoreRetryAttempts; attempt++) {
 				if (attempt > 0 && scoreRetryDelayMs > 0) {
 					Thread.sleep(scoreRetryDelayMs);
+				}
+				int[] naver = naverEsportsScoreClient.fetchScore(
+						match.getBlueTeamCode(), match.getRedTeamCode(), match.getMatchDate());
+				if (naver != null && naver[0] + naver[1] >= endedSetNumber) {
+					return scoreLine(match.getBlueTeamName(), naver[0], naver[1], match.getRedTeamName());
 				}
 				int[] wins = worldsService.fetchMatchGameWins(matchId);
 				if (wins != null && wins[0] + wins[1] >= endedSetNumber) {

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -166,24 +166,33 @@ public class TeamLiveEventPushService {
 			if (endedSetNumber <= 0) {
 				return dbSum > 0 ? scoreLine(match.getBlueTeamName(), blueScore, redScore, match.getRedTeamName()) : null;
 			}
-			if (dbSum >= endedSetNumber) {
-				return scoreLine(match.getBlueTeamName(), blueScore, redScore, match.getRedTeamName());
+			String dbLine = lineIfFresh(new int[] { blueScore == null ? 0 : blueScore, redScore == null ? 0 : redScore },
+					match, endedSetNumber);
+			if (dbLine != null) {
+				return dbLine;
 			}
 
 			// DB stale — 업스트림이 방금 끝난 세트를 반영할 때까지 짧게 재시도.
 			// 네이버가 Riot gameWins 보다 항상 빨라(실측 46초~5분+ 선행) 시도마다 네이버 먼저 본다.
+			// 단 네이버가 null(미커버 리그·매칭 실패·장애)이면 이후 시도에선 건너뛴다 —
+			// 그날 목록에 없는 매치는 10초 뒤에도 없고, 시도마다 3초 타임아웃만 쌓인다.
+			boolean naverUsable = true;
 			for (int attempt = 0; attempt < scoreRetryAttempts; attempt++) {
 				if (attempt > 0 && scoreRetryDelayMs > 0) {
 					Thread.sleep(scoreRetryDelayMs);
 				}
-				int[] naver = naverEsportsScoreClient.fetchScore(
-						match.getBlueTeamCode(), match.getRedTeamCode(), match.getMatchDate());
-				if (naver != null && naver[0] + naver[1] >= endedSetNumber) {
-					return scoreLine(match.getBlueTeamName(), naver[0], naver[1], match.getRedTeamName());
+				if (naverUsable) {
+					int[] naver = naverEsportsScoreClient.fetchScore(
+							match.getBlueTeamCode(), match.getRedTeamCode(), match.getMatchDate());
+					naverUsable = naver != null;
+					String line = lineIfFresh(naver, match, endedSetNumber);
+					if (line != null) {
+						return line;
+					}
 				}
-				int[] wins = worldsService.fetchMatchGameWins(matchId);
-				if (wins != null && wins[0] + wins[1] >= endedSetNumber) {
-					return scoreLine(match.getBlueTeamName(), wins[0], wins[1], match.getRedTeamName());
+				String line = lineIfFresh(worldsService.fetchMatchGameWins(matchId), match, endedSetNumber);
+				if (line != null) {
+					return line;
 				}
 			}
 			log.warn("Set-end score still stale after retries. matchId={} endedSet={} dbScore={}:{}",
@@ -196,6 +205,14 @@ public class TeamLiveEventPushService {
 			log.warn("Failed to load match score for set-end push matchId={}", matchId, e);
 			return null;
 		}
+	}
+
+	/** 스코어 합이 방금 끝난 세트 수 이상(=신선)일 때만 스코어 라인, 아니면 null. */
+	private String lineIfFresh(int[] score, com.toy.nar.app.lolesports.repository.LeagueMatch match, int endedSetNumber) {
+		if (score == null || score[0] + score[1] < endedSetNumber) {
+			return null;
+		}
+		return scoreLine(match.getBlueTeamName(), score[0], score[1], match.getRedTeamName());
 	}
 
 	private String scoreLine(String blueTeamName, Integer blueScore, Integer redScore, String redTeamName) {

--- a/src/test/java/com/toy/nar/app/lolesports/NaverEsportsScoreClientTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/NaverEsportsScoreClientTest.java
@@ -1,0 +1,72 @@
+package com.toy.nar.app.lolesports;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NaverEsportsScoreClientTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private JsonNode day(String matchesJson) throws Exception {
+		return objectMapper.readTree("{\"code\":200,\"content\":{\"matches\":[" + matchesJson + "]}}");
+	}
+
+	private static final String GEN_DK = """
+			{"gameCode":"lol","matchStatus":"STARTED","homeScore":1,"awayScore":2,
+			 "homeTeam":{"nameEngAcronym":"GEN"},"awayTeam":{"nameEngAcronym":"DK"}}
+			""";
+
+	@Test
+	void 블루_레드가_홈_어웨이와_같은_방향이면_그대로_매핑한다() throws Exception {
+		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "GEN", "DK");
+
+		assertThat(score).containsExactly(1, 2);
+	}
+
+	@Test
+	void 블루_레드가_뒤집혀_있으면_스왑해서_매핑한다() throws Exception {
+		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "DK", "GEN");
+
+		assertThat(score).containsExactly(2, 1);
+	}
+
+	@Test
+	void 대소문자_무시하고_매칭한다() throws Exception {
+		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "gen", "dk");
+
+		assertThat(score).containsExactly(1, 2);
+	}
+
+	@Test
+	void 시작_전_경기는_무시한다() throws Exception {
+		JsonNode root = day("""
+				{"gameCode":"lol","matchStatus":"BEFORE","homeScore":0,"awayScore":0,
+				 "homeTeam":{"nameEngAcronym":"GEN"},"awayTeam":{"nameEngAcronym":"DK"}}
+				""");
+
+		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK")).isNull();
+	}
+
+	@Test
+	void 팀_정보가_없는_경기는_건너뛴다() throws Exception {
+		JsonNode root = day("""
+				{"gameCode":"game","matchStatus":"STARTED","homeScore":0,"awayScore":0,
+				 "homeTeam":null,"awayTeam":null},
+				""" + GEN_DK);
+
+		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK")).containsExactly(1, 2);
+	}
+
+	@Test
+	void 매칭되는_경기가_없으면_null() throws Exception {
+		assertThat(NaverEsportsScoreClient.extractScore(day(GEN_DK), "T1", "KC")).isNull();
+	}
+
+	@Test
+	void 응답이_null이면_null() {
+		assertThat(NaverEsportsScoreClient.extractScore(null, "GEN", "DK")).isNull();
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/NaverEsportsScoreClientTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/NaverEsportsScoreClientTest.java
@@ -8,65 +8,101 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class NaverEsportsScoreClientTest {
 
+	/** 2026-07-18 22:30 KST */
+	private static final long START_MS = 1784381400000L;
+
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	private JsonNode day(String matchesJson) throws Exception {
 		return objectMapper.readTree("{\"code\":200,\"content\":{\"matches\":[" + matchesJson + "]}}");
 	}
 
-	private static final String GEN_DK = """
-			{"gameCode":"lol","matchStatus":"STARTED","homeScore":1,"awayScore":2,
-			 "homeTeam":{"nameEngAcronym":"GEN"},"awayTeam":{"nameEngAcronym":"DK"}}
-			""";
+	private static String lolMatch(String home, String away, int homeScore, int awayScore, long startDate) {
+		return String.format("""
+				{"gameCode":"lol","matchStatus":"STARTED","homeScore":%d,"awayScore":%d,"startDate":%d,
+				 "homeTeam":{"nameEngAcronym":"%s"},"awayTeam":{"nameEngAcronym":"%s"}}
+				""", homeScore, awayScore, startDate, home, away);
+	}
+
+	private static final String GEN_DK = lolMatch("GEN", "DK", 1, 2, START_MS);
 
 	@Test
 	void 블루_레드가_홈_어웨이와_같은_방향이면_그대로_매핑한다() throws Exception {
-		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "GEN", "DK");
+		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "GEN", "DK", START_MS);
 
 		assertThat(score).containsExactly(1, 2);
 	}
 
 	@Test
 	void 블루_레드가_뒤집혀_있으면_스왑해서_매핑한다() throws Exception {
-		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "DK", "GEN");
+		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "DK", "GEN", START_MS);
 
 		assertThat(score).containsExactly(2, 1);
 	}
 
 	@Test
 	void 대소문자_무시하고_매칭한다() throws Exception {
-		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "gen", "dk");
+		int[] score = NaverEsportsScoreClient.extractScore(day(GEN_DK), "gen", "dk", START_MS);
 
 		assertThat(score).containsExactly(1, 2);
 	}
 
 	@Test
+	void LoL이_아닌_종목은_같은_약칭이어도_무시한다() throws Exception {
+		// 같은 조직이 타 종목(발로란트 등)에서 같은 날 붙는 경우
+		JsonNode root = day("""
+				{"gameCode":"val","matchStatus":"RESULT","homeScore":2,"awayScore":0,"startDate":%d,
+				 "homeTeam":{"nameEngAcronym":"GEN"},"awayTeam":{"nameEngAcronym":"DK"}}
+				""".formatted(START_MS));
+
+		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK", START_MS)).isNull();
+	}
+
+	@Test
+	void 같은_팀_쌍이_두_경기면_시작_시각이_가까운_경기를_고른다() throws Exception {
+		// 더블헤더: 낮 경기(끝남, 3:1) + 밤 경기(진행 중, 0:1). 밤 경기 기준으로 조회.
+		long dayGameStart = START_MS - 8 * 3600_000L;
+		JsonNode root = day(lolMatch("GEN", "DK", 3, 1, dayGameStart) + "," + lolMatch("GEN", "DK", 0, 1, START_MS));
+
+		int[] score = NaverEsportsScoreClient.extractScore(root, "GEN", "DK", START_MS);
+
+		assertThat(score).containsExactly(0, 1);
+	}
+
+	@Test
+	void 시작_시각이_6시간_이상_어긋나면_매칭하지_않는다() throws Exception {
+		JsonNode root = day(lolMatch("GEN", "DK", 3, 1, START_MS - 7 * 3600_000L));
+
+		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK", START_MS)).isNull();
+	}
+
+	@Test
 	void 시작_전_경기는_무시한다() throws Exception {
 		JsonNode root = day("""
-				{"gameCode":"lol","matchStatus":"BEFORE","homeScore":0,"awayScore":0,
+				{"gameCode":"lol","matchStatus":"BEFORE","homeScore":0,"awayScore":0,"startDate":%d,
 				 "homeTeam":{"nameEngAcronym":"GEN"},"awayTeam":{"nameEngAcronym":"DK"}}
-				""");
+				""".formatted(START_MS));
 
-		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK")).isNull();
+		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK", START_MS)).isNull();
 	}
 
 	@Test
 	void 팀_정보가_없는_경기는_건너뛴다() throws Exception {
 		JsonNode root = day("""
-				{"gameCode":"game","matchStatus":"STARTED","homeScore":0,"awayScore":0,
+				{"gameCode":"lol","matchStatus":"STARTED","homeScore":0,"awayScore":0,"startDate":%d,
 				 "homeTeam":null,"awayTeam":null},
-				""" + GEN_DK);
+				""".formatted(START_MS) + GEN_DK);
 
-		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK")).containsExactly(1, 2);
+		assertThat(NaverEsportsScoreClient.extractScore(root, "GEN", "DK", START_MS)).containsExactly(1, 2);
 	}
 
 	@Test
 	void 매칭되는_경기가_없으면_null() throws Exception {
-		assertThat(NaverEsportsScoreClient.extractScore(day(GEN_DK), "T1", "KC")).isNull();
+		assertThat(NaverEsportsScoreClient.extractScore(day(GEN_DK), "T1", "KC", START_MS)).isNull();
 	}
 
 	@Test
 	void 응답이_null이면_null() {
-		assertThat(NaverEsportsScoreClient.extractScore(null, "GEN", "DK")).isNull();
+		assertThat(NaverEsportsScoreClient.extractScore(null, "GEN", "DK", START_MS)).isNull();
 	}
 }

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceScoreLineTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceScoreLineTest.java
@@ -1,5 +1,6 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.app.lolesports.NaverEsportsScoreClient;
 import com.toy.nar.app.lolesports.WorldsService;
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
@@ -43,6 +44,8 @@ class TeamLiveEventPushServiceScoreLineTest {
 	private MemberNotificationService notificationService;
 	@Mock
 	private WorldsService worldsService;
+	@Mock
+	private NaverEsportsScoreClient naverEsportsScoreClient;
 
 	private TeamLiveEventPushService service;
 
@@ -50,7 +53,8 @@ class TeamLiveEventPushServiceScoreLineTest {
 	void setUp() {
 		service = new TeamLiveEventPushService(
 				deviceRepository, deliveryRepository, teamExternalIdentityRepository,
-				leagueMatchRepository, pushGateway, notificationService, worldsService);
+				leagueMatchRepository, pushGateway, notificationService, worldsService,
+				naverEsportsScoreClient);
 		// 테스트에서 재시도 대기 없이 즉시 진행
 		ReflectionTestUtils.setField(service, "scoreRetryAttempts", 3);
 		ReflectionTestUtils.setField(service, "scoreRetryDelayMs", 0L);
@@ -60,11 +64,40 @@ class TeamLiveEventPushServiceScoreLineTest {
 		return LeagueMatch.builder()
 				.id("m1")
 				.leagueName("EWC")
+				.blueTeamCode("KC")
 				.blueTeamName("Karmine Corp")
+				.redTeamCode("T1")
 				.redTeamName("T1")
 				.blueScore(blueScore)
 				.redScore(redScore)
+				.matchDate(java.time.LocalDateTime.of(2026, 7, 18, 11, 30))
 				.build();
+	}
+
+	@Test
+	void DB가_stale이면_네이버_스코어를_먼저_쓴다() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(0, 1)));
+		when(naverEsportsScoreClient.fetchScore(org.mockito.ArgumentMatchers.eq("KC"),
+				org.mockito.ArgumentMatchers.eq("T1"), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(new int[] { 0, 2 });
+
+		String line = service.buildMatchScoreLine("m1", 2);
+
+		assertThat(line).isEqualTo("Karmine Corp 0 vs 2 T1");
+		verify(worldsService, never()).fetchMatchGameWins("m1");
+	}
+
+	@Test
+	void 네이버_스코어가_stale이면_쓰지_않고_Riot으로_넘어간다() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(0, 1)));
+		when(naverEsportsScoreClient.fetchScore(org.mockito.ArgumentMatchers.eq("KC"),
+				org.mockito.ArgumentMatchers.eq("T1"), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(new int[] { 0, 1 });
+		when(worldsService.fetchMatchGameWins("m1")).thenReturn(new int[] { 0, 2 });
+
+		String line = service.buildMatchScoreLine("m1", 2);
+
+		assertThat(line).isEqualTo("Karmine Corp 0 vs 2 T1");
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceScoreLineTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceScoreLineTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +86,22 @@ class TeamLiveEventPushServiceScoreLineTest {
 
 		assertThat(line).isEqualTo("Karmine Corp 0 vs 2 T1");
 		verify(worldsService, never()).fetchMatchGameWins("m1");
+	}
+
+	@Test
+	void 네이버가_null이면_이후_시도에서_네이버를_다시_호출하지_않는다() {
+		// 미커버 리그·매칭 실패 — 그날 목록에 없는 매치는 재시도해도 없다
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(0, 1)));
+		when(naverEsportsScoreClient.fetchScore(org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(null);
+		when(worldsService.fetchMatchGameWins("m1")).thenReturn(new int[] { 0, 1 });
+
+		service.buildMatchScoreLine("m1", 2);
+
+		verify(naverEsportsScoreClient, times(1)).fetchScore(org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+		verify(worldsService, times(3)).fetchMatchGameWins("m1");
 	}
 
 	@Test


### PR DESCRIPTION
## 배경

#278로 SET_END 스코어를 Riot getEventDetails 재시도로 보정했지만, 실측 결과 Riot gameWins는 **다음 세트 픽밴 시작에야 뒤집힘**:

| 이벤트 (EWC DK vs GEN, 7/18) | 네이버 반영 | Riot 반영 | 차이 |
|---|---|---|---|
| 1세트 종료 | 00:12:32 | 00:17:40 | 5분 8초 |
| 2세트 종료 | 01:15:04 | 01:15:50 | 46초 |
| 매치 종료 | 02:15:22 (winner 포함) | 수 분~수십 분 후 | — |

즉 Riot만으로는 재시도해도 스코어를 못 잡고 생략 발송되는 경우가 많음. 네이버 e스포츠 API는 세트 종료 직후 반영.

## 변경

- `NaverEsportsScoreClient` 신규: `esports-api.game.naver.com/service/v2/schedule/day` 조회 → 팀 약칭 쌍으로 매치 매핑 → [blue, red] 스코어 반환
  - 네이버 `nameEngAcronym`이 Riot 팀 코드와 일치(T1/KC/GEN/DK 실데이터 확인), home/away 방향 다르면 스왑
  - 시작 전 경기 무시, 팀 정보 없는 종목 스킵
- `buildMatchScoreLine` 재시도 체인: DB(합 일치) → **네이버** → Riot → 다음 시도. 재시도 기본 3회×4초 → 6회×10초
- 안전장치: `live.notification.set-end-score.naver-enabled` 킬스위치(기본 on), 타임아웃 3초, 모든 실패는 null → 기존 Riot 경로 폴백 (푸시 자체는 영향 없음)

## 호출량

세트 종료 시점에 DB 스코어가 stale일 때만 호출 — 하루 최대 수십 콜, 평시 0콜.

## 테스트

- `NaverEsportsScoreClientTest` 7건 (정방향/스왑/대소문자/BEFORE 무시/팀 null 스킵/미매칭/null)
- `TeamLiveEventPushServiceScoreLineTest` 8건 (네이버 우선/네이버 stale 시 Riot 폴백 추가)
- 전체 `./gradlew test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)