### PR TITLE
perf: 힙 상한 -Xmx512m 명시 — 기본 192MiB 포화 해소

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,7 +174,7 @@ jobs:
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
-              -e JAVA_TOOL_OPTIONS="-javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
+              -e JAVA_TOOL_OPTIONS="-Xmx512m -javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               -v /opt/whatap:/whatap \
               "${APP_IMAGE}"


### PR DESCRIPTION
## 배경
`-Xmx` 미지정 → JVM 기본 힙 상한 = 컨테이너 메모리 768m의 25% = **192MiB**.

WhaTap 메트릭 확인 결과 (배포 직후 10분):
- HeapMax: 185.62MiB
- HeapTotal: 185.62MiB (이미 상한까지 확장, 여유 없음)
- HeapUsed 피크: **175.76MiB (상한의 95%)**

트래픽 몰리면 Full GC 반복 → 응답시간 악화, 최악은 OOM.

## 변경
`JAVA_TOOL_OPTIONS` 에 `-Xmx512m` 추가 한 줄.

768m 컨테이너 배분: 힙 512m + 논힙(메타스페이스·스레드 스택·WhaTap 에이전트) ~256m.

## 확인
배포 후 WhaTap 메트릭스 차트에서 HeapMax ≈ 512MiB, HeapUsed/HeapMax 비율 하락 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)