### PR TITLE
fix: 세트 종료 푸시 스코어 재조회 창 60초→110초로 확대

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,11 @@ live:
   notification:
     fcm:
       enabled: ${LIVE_NOTIFICATION_FCM_ENABLED:false}
+    set-end-score:
+      # 세트 종료 푸시 스코어 재조회 창. 네이버 반영이 꼬리 케이스에서 60초를 넘겨
+      # 스코어 누락 발송되던 문제로 창을 ~110초로 넓힘(12회×10초). 그만큼 알림은 늦어진다.
+      retry-attempts: ${LIVE_SET_END_SCORE_RETRY_ATTEMPTS:12}
+      retry-delay-ms: ${LIVE_SET_END_SCORE_RETRY_DELAY_MS:10000}
 
 # 프로필 이미지 저장(Cloudinary 서명 업로드). 시크릿은 코드/깃에 박지 않고 env로 주입.
 cloudinary:


### PR DESCRIPTION
## 배경

EWC 3위전(GEN vs T1) 1세트 종료 푸시가 스코어 없이 발송됨(‘Gen.G Esports vs T1 · 1세트 종료’). 로그:

```
WARN Set-end score still stale after retries. matchId=116855104460702386 endedSet=1 dbScore=0:0
```

- `Naver esports match not found` 로그 **없음** → 네이버는 매치 매칭 성공(팀코드 GEN/T1, gameCode lol, startDate 일치)
- 즉 네이버 `homeScore/awayScore`가 재시도 창(6회×10초≈60초) **내내 0-0**이었고 창 종료 후에야 0-1로 반영
- Riot `gameWins`는 더 느려 폴백도 실패 → 스코어 생략 발송

PR #280 실측(2s~46s)보다 느린 네이버 반영 **꼬리 케이스**. 소스·로직은 정상, 재시도 창이 짧았을 뿐.

## 변경

`application.yml`에 재조회 창 설정 추가, 기본값 상향:

| | 기존 | 변경 |
|---|---|---|
| retry-attempts | 6 | **12** |
| 창 길이 | ~60초 | **~110초** |

- env(`LIVE_SET_END_SCORE_RETRY_ATTEMPTS`, `LIVE_SET_END_SCORE_RETRY_DELAY_MS`)로 무배포 튜닝 가능
- 가상 스레드(App-VT) 블로킹이라 서버 리소스 부담 없음

## 트레이드오프

푸시가 동기로 막히므로, 스코어를 못 잡는 세트는 알림이 최대 ~110초까지 늦어진다. 대신 잡히면 스코어가 붙는다. (지연 vs 스코어 누락 저울질에서 스코어 우선 선택)

## 테스트

로직 무변경(설정값만). 기존 `TeamLiveEventPushServiceScoreLineTest` 재시도 루프 커버 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)