### PR TITLE
feat: 라이브 리스트·상세 스코어에 네이버 보조 소스 적용

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -70,6 +70,7 @@ public class LeagueMatchService {
 	private final ObjectMapper objectMapper;
 	private final TransactionTemplate transactionTemplate;
 	private final GameRepository gameRepository;
+	private final NaverEsportsScoreClient naverEsportsScoreClient;
 
 	// [Scheduler용] 특정 리그의 최신 경기를 가져와 DB에 저장 (1페이지)
 	public void syncMatches(String leagueSlug) {
@@ -93,6 +94,9 @@ public class LeagueMatchService {
 		String leagueSlug = match.getLeagueName() == null || match.getLeagueName().isBlank()
 				? fallbackLeagueSlug
 				: match.getLeagueName();
+		if ("inProgress".equalsIgnoreCase(match.getState())) {
+			overlayNaverScoreIfAhead(match);
+		}
 		MatchSyncUpsertResult result = upsertLeagueMatches(leagueSlug, List.of(match));
 		boolean changed = result.insertedMatches() > 0 || result.updatedMatches() > 0;
 		if (changed) {
@@ -103,6 +107,41 @@ public class LeagueMatchService {
 					match.getRedTeam() == null ? null : match.getRedTeam().getWins());
 		}
 		return changed;
+	}
+
+	/**
+	 * 라이브 중 Riot gameWins 는 다음 세트 픽밴에야 뒤집혀 몇 분간 stale 이다. 네이버 e스포츠는
+	 * 세트 종료 직후 반영되므로, 진행 중 경기의 스코어 합이 네이버에서 더 앞서면 그 값으로 덮어쓴다.
+	 * 리스트·상세·모바일이 모두 이 DB 스코어를 읽으므로 표시 지연이 함께 줄어든다.
+	 * 네이버 매칭 검증(팀코드·gameCode=lol·시작시각±6h)과 킬스위치는 클라이언트가 담당 — null 이면 Riot 유지.
+	 * ponytail: 상한 없음. 네이버 wrong-high 는 completed flip 때 Riot 최종값이 덮어써 self-heal.
+	 * false-high 관측되면 네이버 maxMatchCount 가드 추가.
+	 */
+	private void overlayNaverScoreIfAhead(MatchResultDto match) {
+		if (match.getBlueTeam() == null || match.getRedTeam() == null || match.getMatchDate() == null) {
+			return;
+		}
+		LocalDateTime matchDateUtc;
+		try {
+			matchDateUtc = LocalDateTime.parse(match.getMatchDate(), DateTimeFormatter.ISO_DATE_TIME);
+		} catch (Exception e) {
+			return;
+		}
+		int[] naver = naverEsportsScoreClient.fetchScore(
+				match.getBlueTeam().getCode(), match.getRedTeam().getCode(), matchDateUtc);
+		int[] ahead = pickAheadScore(naver, match.getBlueTeam().getWins(), match.getRedTeam().getWins());
+		if (ahead != null) {
+			match.getBlueTeam().setWins(ahead[0]);
+			match.getRedTeam().setWins(ahead[1]);
+		}
+	}
+
+	/** 네이버 스코어 합이 Riot 보다 앞서면 [blue, red] 반환, 아니면(같거나 뒤짐·null) null → Riot 유지. */
+	static int[] pickAheadScore(int[] naver, int riotBlue, int riotRed) {
+		if (naver == null) {
+			return null;
+		}
+		return naver[0] + naver[1] > riotBlue + riotRed ? naver : null;
 	}
 
 	public void syncMatches(String leagueSlug, boolean includeTeamMetadataSync) {

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceLeagueNameTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceLeagueNameTest.java
@@ -63,7 +63,8 @@ class LeagueMatchServiceLeagueNameTest {
 				worldsService,
 				new ObjectMapper(),
 				transactionTemplate,
-				gameRepository);
+				gameRepository,
+				null);
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePerformanceBaselineTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePerformanceBaselineTest.java
@@ -72,7 +72,8 @@ class LeagueMatchServicePerformanceBaselineTest {
                 null,
                 new ObjectMapper(),
                 null,
-                gameRepository);
+                gameRepository,
+                null);
         sessionFactory = entityManager.getEntityManagerFactory().unwrap(SessionFactory.class);
         sessionFactory.getStatistics().setStatisticsEnabled(true);
     }

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePickAheadScoreTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServicePickAheadScoreTest.java
@@ -1,0 +1,31 @@
+package com.toy.nar.app.lolesports;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 라이브 스코어 보정: 네이버가 Riot 보다 앞설 때만 채택. */
+class LeagueMatchServicePickAheadScoreTest {
+
+	@Test
+	void 네이버가_앞서면_네이버_채택() {
+		assertThat(LeagueMatchService.pickAheadScore(new int[] { 1, 0 }, 0, 0)).containsExactly(1, 0);
+		assertThat(LeagueMatchService.pickAheadScore(new int[] { 2, 1 }, 1, 1)).containsExactly(2, 1);
+	}
+
+	@Test
+	void 합이_같으면_Riot_유지() {
+		// 네이버 0-1, Riot 1-0 — 합 동일. 채택 안 함(승자 방향이 달라도 앞선 게 아니면 건드리지 않음).
+		assertThat(LeagueMatchService.pickAheadScore(new int[] { 0, 1 }, 1, 0)).isNull();
+	}
+
+	@Test
+	void Riot이_앞서면_Riot_유지() {
+		assertThat(LeagueMatchService.pickAheadScore(new int[] { 1, 0 }, 1, 1)).isNull();
+	}
+
+	@Test
+	void 네이버_null이면_Riot_유지() {
+		assertThat(LeagueMatchService.pickAheadScore(null, 0, 0)).isNull();
+	}
+}


### PR DESCRIPTION
## 배경

경기 리스트/상세 상단 스코어가 실경기보다 몇 분씩 뒤처짐. 원인은 푸시 #280 과 동일:

- 리스트·상세·모바일 모두 DB `LeagueMatch.blueScore/redScore` **한 곳**만 읽음 (라이브 fetch 없음)
- 라이브 중 이 값은 `LivePollingScheduler(60초) → syncRealtimeMatchStatus`가 **Riot gameWins**로 갱신
- Riot gameWins 는 다음 세트 픽밴에야 뒤집혀 stale → DB stale → 표시 stale

## 변경

진행 중(`inProgress`) 경기 sync 직전 네이버 스코어를 조회해, **합이 Riot 보다 앞서면** DTO 스코어를 덮어쓰고 upsert.

- score 변경 시 기존 경로가 `changed=true`로 캐시(`todaySchedules`/`todayMatchDetails`) evict → **리스트·상세·모바일 자동 최신화**
- 네이버 매칭 검증(팀코드·`gameCode=lol`·시작시각±6h)·킬스위치는 `NaverEsportsScoreClient` 재사용 (#280) — null 이면 Riot 유지, 무해 폴백
- `completed` flip 때 Riot 최종값이 덮어써 라이브 중 오차는 self-heal (숫자 상한 없음, false-high 관측 시 `maxMatchCount` 가드 추가)

## 신뢰 정책

"네이버 앞서면 네이버 채택" — 라이브에서 가장 빠른 반영 우선.

## 호출량

live 매치당 60초 discovery 사이클마다 네이버 1콜(3초 타임아웃). 라이브 경기 소수라 무시할 수준.

## 테스트

- `LeagueMatchServicePickAheadScoreTest` 4건 (앞섬 채택 / 합 동일 유지 / 뒤짐 유지 / null 유지)
- `./gradlew test --tests ...PickAheadScoreTest` BUILD SUCCESSFUL

## 관련

- #280 (SET_END 푸시 네이버 소스) — 같은 클라이언트 재사용
- #282 (푸시 재시도 창 확대) — 별개 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)