### PR TITLE
feat: KeSPA Cup 리그 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,14 @@ docker-compose.yml
 /src/main/resources/application.yml
 /src/main/resources/application-dev.yml
 /src/main/resources/application-test.yml
-/src/main/resources/application-*.yml.DS_Store
+/src/main/resources/application-*.yml
 src/main/build/
+
+# macOS / 에디터
+.DS_Store
+
+# Claude Code 워크트리 (로컬 전용)
+.claude/worktrees/
 
 # 애플리케이션 로그
 logs/

--- a/src/main/java/com/toy/nar/app/kakao/KakaoScheduleSkillService.java
+++ b/src/main/java/com/toy/nar/app/kakao/KakaoScheduleSkillService.java
@@ -333,6 +333,11 @@ public class KakaoScheduleSkillService {
 		aliases.put("esports world cup", "EWC");
 		aliases.put("이스포츠 월드컵", "EWC");
 		aliases.put("이스포츠월드컵", "EWC");
+		aliases.put("kespa", "KESPA");
+		aliases.put("kespa cup", "KESPA");
+		aliases.put("케스파", "KESPA");
+		aliases.put("케스파컵", "KESPA");
+		aliases.put("케스파 컵", "KESPA");
 		return aliases;
 	}
 

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -17,13 +17,13 @@ public final class LeagueConstants {
      * 동기화 및 API 대상 리그 목록
      */
     public static final List<String> TARGET_LEAGUES = List.of(
-            "LCK", "LPL", "LEC", "LCS", "LCP", "CBLOL", "MSI", "WORLDS", "FIRST_STAND", "EWC");
+            "LCK", "LPL", "LEC", "LCS", "LCP", "CBLOL", "MSI", "WORLDS", "FIRST_STAND", "EWC", "KESPA");
 
     /**
      * 일정 조회 시 허용되는 리그 목록 (TARGET_LEAGUES + 추가 리그)
      */
     public static final Set<String> ALLOWED_LEAGUES = Set.of(
-            "LCK", "LPL", "LCP", "LEC", "LCS", "CBLOL", "MSI", "WORLDS", "FIRST_STAND", "EWC");
+            "LCK", "LPL", "LCP", "LEC", "LCS", "CBLOL", "MSI", "WORLDS", "FIRST_STAND", "EWC", "KESPA");
 
     /**
      * lolesports API의 리그 ID 매핑
@@ -38,7 +38,8 @@ public final class LeagueConstants {
             Map.entry("FIRST_STAND", "113464388705111224"),
             Map.entry("WORLDS", "98767975604431411"),
             Map.entry("MSI", "98767991325878492"),
-            Map.entry("EWC", "116838530616006090"));
+            Map.entry("EWC", "116838530616006090"),
+            Map.entry("KESPA", "116929044967296666"));
 
     /**
      * 리그별 기본 라이브 스트림 URL
@@ -61,11 +62,17 @@ public final class LeagueConstants {
     public static final String DEFAULT_STREAM_URL = "https://play.sooplive.co.kr/aflol";
 
     /**
-     * lolesports API 리그 slug → 내부 리그명. slug이 리그 코드와 다른 리그(EWC: ewc_lol)만 보정한다.
+     * lolesports API 리그 slug → 내부 리그명. slug이 리그 코드와 다른 리그(EWC: ewc_lol, KESPA: kespa_cup)만 보정한다.
      */
     public static String fromApiSlug(String slug) {
         String upper = slug == null ? "" : slug.trim().toUpperCase();
-        return "EWC_LOL".equals(upper) ? "EWC" : upper;
+        if ("EWC_LOL".equals(upper)) {
+            return "EWC";
+        }
+        if ("KESPA_CUP".equals(upper)) {
+            return "KESPA";
+        }
+        return upper;
     }
 
     /**
@@ -120,7 +127,9 @@ public final class LeagueConstants {
             "LPL", List.of(CHZZK_LPL),
             "LEC", List.of(new StreamLink("twitch", "Twitch", "LEC 공식", "https://www.twitch.tv/lec")),
             "LCS", List.of(new StreamLink("twitch", "Twitch", "LCS 공식", "https://www.twitch.tv/lcs")),
-            "EWC", List.of(CHZZK_EWC, TWITCH_EWC));
+            "EWC", List.of(CHZZK_EWC, TWITCH_EWC),
+            // KESPA컵은 LCK 국내 중계권 그대로 사용. 대회 편성이 바뀌면 교체 필요.
+            "KESPA", List.of(CHZZK_LCK, SOOP_AFLOL));
 
     /**
      * 리그의 중계 채널 목록 반환. 매핑이 없으면 SOOP 단일 링크로 폴백.

--- a/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueConstants.java
@@ -62,6 +62,12 @@ public final class LeagueConstants {
     public static final String DEFAULT_STREAM_URL = "https://play.sooplive.co.kr/aflol";
 
     /**
+     * 스트림 링크를 의도적으로 제공하지 않는 리그. SOOP 기본 폴백도 적용하지 않는다.
+     * KeSPA Cup 은 Disney+ 글로벌 독점이라 앱에서 링크를 노출할 대체 채널이 없다.
+     */
+    private static final Set<String> NO_STREAM_LEAGUES = Set.of("KESPA");
+
+    /**
      * lolesports API 리그 slug → 내부 리그명. slug이 리그 코드와 다른 리그(EWC: ewc_lol, KESPA: kespa_cup)만 보정한다.
      */
     public static String fromApiSlug(String slug) {
@@ -82,7 +88,11 @@ public final class LeagueConstants {
         if (leagueName == null) {
             return DEFAULT_STREAM_URL;
         }
-        return LIVE_STREAM_URLS.getOrDefault(leagueName.toUpperCase(), DEFAULT_STREAM_URL);
+        String upper = leagueName.toUpperCase();
+        if (NO_STREAM_LEAGUES.contains(upper)) {
+            return null;
+        }
+        return LIVE_STREAM_URLS.getOrDefault(upper, DEFAULT_STREAM_URL);
     }
 
     /**
@@ -127,9 +137,8 @@ public final class LeagueConstants {
             "LPL", List.of(CHZZK_LPL),
             "LEC", List.of(new StreamLink("twitch", "Twitch", "LEC 공식", "https://www.twitch.tv/lec")),
             "LCS", List.of(new StreamLink("twitch", "Twitch", "LCS 공식", "https://www.twitch.tv/lcs")),
-            "EWC", List.of(CHZZK_EWC, TWITCH_EWC),
-            // KESPA컵은 LCK 국내 중계권 그대로 사용. 대회 편성이 바뀌면 교체 필요.
-            "KESPA", List.of(CHZZK_LCK, SOOP_AFLOL));
+            // KeSPA Cup(Disney+ 독점)은 링크를 별도로 두지 않고 기본 폴백에 맡긴다.
+            "EWC", List.of(CHZZK_EWC, TWITCH_EWC));
 
     /**
      * 리그의 중계 채널 목록 반환. 매핑이 없으면 SOOP 단일 링크로 폴백.
@@ -138,6 +147,10 @@ public final class LeagueConstants {
         if (leagueName == null) {
             return List.of(SOOP_AFLOL);
         }
-        return STREAM_LINKS.getOrDefault(leagueName.toUpperCase(), List.of(SOOP_AFLOL));
+        String upper = leagueName.toUpperCase();
+        if (NO_STREAM_LEAGUES.contains(upper)) {
+            return List.of();
+        }
+        return STREAM_LINKS.getOrDefault(upper, List.of(SOOP_AFLOL));
     }
 }

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -450,8 +450,10 @@ public class MobileScheduleService {
 
 	private String liveStreamUrl(LeagueMatch match) {
 		// 하위호환: 구버전 앱이 쓰는 단일 링크. streamLinks 의 첫 번째(대표 채널)와 동일하게 유지한다.
+		// 링크 없는 리그(KeSPA=Disney+ 독점)는 빈 목록이라 null 을 내려 링크를 노출하지 않는다.
 		if ("inProgress".equalsIgnoreCase(match.getState())) {
-			return LeagueConstants.getStreamLinks(match.getLeagueName()).get(0).url();
+			List<LeagueConstants.StreamLink> links = LeagueConstants.getStreamLinks(match.getLeagueName());
+			return links.isEmpty() ? null : links.get(0).url();
 		}
 		return null;
 	}

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueConstantsTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueConstantsTest.java
@@ -24,4 +24,11 @@ class LeagueConstantsTest {
 		assertThat(LeagueConstants.getLiveStreamUrl("EWC")).isNotEqualTo(LeagueConstants.DEFAULT_STREAM_URL);
 		assertThat(LeagueConstants.getStreamLinks("EWC")).isNotEmpty();
 	}
+
+	@Test
+	void KeSPA는_스트림_링크가_없고_SOOP_폴백도_안_한다() {
+		// KeSPA Cup 은 Disney+ 독점 — 앱에 노출할 대체 채널이 없다. SOOP 폴백도 금지.
+		assertThat(LeagueConstants.getStreamLinks("KESPA")).isEmpty();
+		assertThat(LeagueConstants.getLiveStreamUrl("KESPA")).isNull();
+	}
 }


### PR DESCRIPTION
## 요약
2026 LoL KeSPA Cup(7/20~8/18, Disney+ 글로벌 독점) 리그를 추가한다. 리그 상수·일정 동기화·카카오 별칭은 EWC 추가와 동일 패턴을 따르고, 중계 링크는 Disney+ 독점 특성에 맞게 제거했다.

## 변경
- **리그 등록** (`86e3fba`): `LeagueConstants` TARGET/ALLOWED/LEAGUE_IDS·`fromApiSlug`(kespa_cup→KESPA), 카카오 스케줄 별칭(케스파/케스파컵 등).
- **스트림 링크 제거** (`3e8e5af`): KeSPA Cup 은 Disney+ 글로벌 독점이라 노출할 대체 채널이 없다. `NO_STREAM_LEAGUES(=KESPA)` 도입 → `getStreamLinks`=빈 목록, `getLiveStreamUrl`=null. 일반 미등록 리그의 SOOP 폴백은 유지. `MobileScheduleService`의 `.get(0)` NPE 가드 추가. 치지직 다채널 resolver 는 chzzk 전용이라 미해당.
- **.gitignore** (`3832d5e`): `.DS_Store`(기존 개행 버그로 미적용)·`.claude/worktrees/` 추가.

## 배포 후 자동 반영
`LeagueConfigService.seedMissing()`(@PostConstruct)가 KeSPA row 를 `liveEnabled=true, syncEnabled=true, notificationEnabled=false` 로 시드 → **일정 리스트·라이브 감지 자동 반영**. 디스코드/푸시 알림만 기본 OFF(원하면 admin 토글).

## 테스트
`LeagueConstantsTest` — KeSPA 무링크·무폴백 검증 추가, 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)