### PR TITLE
perf(deploy): 배포 속도 단축 + 배포 직후 JIT 워밍업

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/nar-gg:latest
             ${{ secrets.DOCKER_HUB_USERNAME }}/nar-gg:${{ github.sha }}
-          no-cache: true
 
   deploy:
     runs-on: ubuntu-latest
@@ -102,14 +101,11 @@ jobs:
             df -h
             docker system df || true
 
-            echo "Cleaning up unused Docker resources..."
+            # 이미지/빌더 prune 은 배포 성공 후로 미룬다(하단 백그라운드 정리).
+            # pull 전에 이미지를 지우면 temurin 베이스(~450MB)까지 매번 재다운로드되므로,
+            # 기존 이미지를 남겨 베이스 레이어를 공유하고 바뀐 앱 레이어만 받게 한다.
+            echo "Cleaning up stopped containers..."
             docker container prune -f || true
-            docker image prune -af || true
-            docker builder prune -af || true
-
-            echo "Checking disk usage after cleanup..."
-            df -h
-            docker system df || true
 
             # 1. 메인 Spring Boot 앱 blue/green 배포
             # nginx upstream(/etc/nginx/conf.d/nar-upstream.conf)이 가리키는 포트의 반대편에
@@ -197,28 +193,48 @@ jobs:
               sleep 2
             done
 
+            # JIT 워밍업 — nginx 전환 전 배포 스크립트가 hot-path 첫 타를 맞아
+            # 배포 직후 첫 실유저의 콜드스타트(t3.micro 기준 수 초)를 없앤다.
+            # DUMMY gameId·인증 실패라도 디스패치·필터·JPA·직렬화 경로는 데워진다. 실패는 무시.
+            echo "Warming up hot endpoints on port ${NEW_PORT}..."
+            for ep in champions events ratings; do
+              curl -fsS "http://localhost:${NEW_PORT}/api/mobile/live/games/DUMMY/${ep}" -o /dev/null 2>&1 || true
+            done
+
             echo "Switching nginx upstream to ${NEW_PORT}..."
             printf 'upstream nar_backend {\n    server 127.0.0.1:%s;\n}\n' "${NEW_PORT}" \
               | sudo tee "${UPSTREAM_CONF}" > /dev/null
             sudo nginx -t && sudo nginx -s reload
 
-            # Spring graceful shutdown 유예 30초보다 길게 대기 (SIGKILL 방지)
-            echo "Stopping old container..."
-            docker stop -t 35 "${OLD_NAME}" 2>/dev/null || true
-            docker rm "${OLD_NAME}" 2>/dev/null || true
-            # 구 배포 방식(nar-gg-container) 잔재 정리 — 최초 전환 이후엔 no-op
-            docker stop -t 35 nar-gg-container 2>/dev/null || true
-            docker rm nar-gg-container 2>/dev/null || true
+            # 구 컨테이너 정리 + 이미지/빌더 prune 을 백그라운드로 넘긴다.
+            # nginx 는 이미 전환됐으므로 graceful stop 35초와 prune 은 사용자 트래픽과 무관 —
+            # 배포 워크플로가 여기서 대기할 이유가 없다. nohup 으로 SSH 세션 종료와 분리.
+            echo "Cleaning up old container & images in background..."
+            nohup bash -c "
+              docker stop -t 35 '${OLD_NAME}' 2>/dev/null || true
+              docker rm '${OLD_NAME}' 2>/dev/null || true
+              docker stop -t 35 nar-gg-container 2>/dev/null || true
+              docker rm nar-gg-container 2>/dev/null || true
+              docker image prune -af || true
+              docker builder prune -af || true
+            " >/dev/null 2>&1 &
 
-            # 2. Dozzle 배포
-            echo "Deploying Dozzle..."
+            # 2. Dozzle — --restart always 라 상시 떠 있으므로 이미지가 갱신됐을 때만 재생성한다.
+            echo "Ensuring Dozzle is up to date..."
             docker pull amir20/dozzle:latest
-            docker stop dozzle || true
-            docker rm dozzle || true
-            docker run -d --name dozzle --restart always \
-              -v /var/run/docker.sock:/var/run/docker.sock:ro \
-              -p 127.0.0.1:8082:8080 \
-              -e DOZZLE_BASE=/dozzle \
-              amir20/dozzle:latest
-            
+            RUNNING_DOZZLE=$(docker inspect -f '{{.Image}}' dozzle 2>/dev/null || echo none)
+            LATEST_DOZZLE=$(docker inspect -f '{{.Id}}' amir20/dozzle:latest 2>/dev/null || echo latest)
+            if [ "${RUNNING_DOZZLE}" != "${LATEST_DOZZLE}" ]; then
+              echo "Dozzle image changed — recreating..."
+              docker stop dozzle || true
+              docker rm dozzle || true
+              docker run -d --name dozzle --restart always \
+                -v /var/run/docker.sock:/var/run/docker.sock:ro \
+                -p 127.0.0.1:8082:8080 \
+                -e DOZZLE_BASE=/dozzle \
+                amir20/dozzle:latest
+            else
+              echo "Dozzle already on latest image — skipping recreate."
+            fi
+
             echo "Deployment successful!"


### PR DESCRIPTION
## 배경
와탭 APM 분석 결과, 배포 전체 5m50s 중 EC2 스크립트가 ~4m40s로 병목. 또한 배포 직후 첫 유저가 hot-path(경기상세 3개 API) 첫 호출에서 5초대 콜드스타트를 겪음 — 원인은 JIT 미컴파일 + 클래스 지연 로딩 + 커넥션풀/JPA 초기화(코드/인덱스 문제 아님, 재호출은 수백 ms).

## 변경
### 속도
- **image/builder prune 을 pull 이전 → 전환 성공 후 백그라운드로 이동**. pull 전 prune 이 매 배포마다 temurin 베이스(~450MB)까지 통째로 재다운로드시켰다. 기존 이미지를 남기면 베이스 레이어를 공유하고 바뀐 앱 레이어만 받는다. (~1분+)
- **구 컨테이너 graceful stop(35초)을 `nohup` 백그라운드로 분리**. nginx 는 이미 전환됐으므로 워크플로가 대기할 이유 없음. (~35초)
- **Dozzle 은 이미지 갱신 시에만 재생성**. `--restart always` 라 상시 떠 있음. (~10초)
- **`no-cache: true` 제거** — docker 빌드 캐시를 무의미하게 무효화하던 옵션.

### 워밍업
- 헬스체크 통과 후 nginx 전환 **전에** hot-path 3개(`champions`·`events`·`ratings`)를 배포 스크립트가 먼저 호출. 첫 실유저 대신 스크립트가 콜드스타트를 흡수. DUMMY gameId·인증 실패라도 디스패치·필터·JPA·직렬화 경로는 데워진다. best-effort(`|| true`).

## 예상 효과
5m50s → **3m~3m30s**, 배포 직후 첫 유저 콜드스타트 제거.

## 리스크
- prune 을 뒤로 미뤄 배포 중 순간 디스크 사용량이 (구+신 이미지) 소폭 증가하나 베이스 레이어 공유로 실증가분은 앱 레이어(수십 MB)뿐.
- 워밍업/백그라운드 정리 모두 실패해도 배포 성공 경로엔 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)