### PR TITLE
fix: 온보딩 선수 목록에서 시즌 중 이적 선수 중복 노출 수정

### DIFF
--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -81,6 +81,8 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			""")
 	List<Player> findSoloRankSyncTargets(@Param("leagueName") String leagueName);
 
+	// 시즌 중 이적한 선수가 이적 전/후 팀 양쪽 목록에 중복으로 뜨는 것을 막기 위해
+	// 선수별 "가장 최근 경기"의 참가 기록만 남긴다(findLckPlayerOption과 동일한 패턴).
 	@Query("""
 			SELECT DISTINCT p
 			FROM GameParticipant gp
@@ -91,6 +93,15 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			WHERE l.leagueName = :leagueName
 			  AND l.seasonYear = :year
 			  AND (:teamId IS NULL OR t.id = :teamId)
+			  AND g.actualGameStartTime = (
+				  SELECT MAX(g2.actualGameStartTime)
+				  FROM GameParticipant gp2
+				  JOIN gp2.game g2
+				  JOIN g2.league l2
+				  WHERE gp2.player = p
+				    AND l2.leagueName = :leagueName
+				    AND l2.seasonYear = :year
+			  )
 			ORDER BY p.name
 			""")
 	List<Player> findOnboardingPlayers(

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -82,7 +82,9 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	List<Player> findSoloRankSyncTargets(@Param("leagueName") String leagueName);
 
 	// 시즌 중 이적한 선수가 이적 전/후 팀 양쪽 목록에 중복으로 뜨는 것을 막기 위해
-	// 선수별 "가장 최근 경기"의 참가 기록만 남긴다(findLckPlayerOption과 동일한 패턴).
+	// 상관 서브쿼리로 선수별 "가장 최근 경기"의 참가 기록만 남긴다.
+	// 참고: findLckPlayerOption은 성능 때문에 이 상관 서브쿼리를 ROW_NUMBER()로 대체했다.
+	// 여기서는 페이징·정렬이 없고 보통 teamId로 한 팀만 조회해 스캔 범위가 작으므로 유지한다.
 	@Query("""
 			SELECT DISTINCT p
 			FROM GameParticipant gp


### PR DESCRIPTION
## 요약
- 온보딩 "선호 선수 선택" 화면(`GET /api/auth/onboarding/players`)에서 시즌 중 팀을 옮긴 선수가 이적 전/후 팀 목록 양쪽에 중복으로 뜨는 버그 수정
  - 예: Diable(BFX→농심), Sharvel(DPlus KIA→DN Soopers)
- 원인: `PlayerRepository.findOnboardingPlayers`가 `GameParticipant` 출전 기록에 있는 팀을 그대로 필터링해, 이적 전 팀 소속으로 뛴 경기 기록도 걸러지지 않고 매칭됨
- 조치: 기존 `findLckPlayerOption`과 동일한 패턴으로, 선수별 "가장 최근 경기" 참가 기록만 남기는 서브쿼리(`g.actualGameStartTime = (SELECT MAX(...))`)를 추가

## 테스트 플랜
- [ ] 로컬 빌드/컴파일 확인 (이 세션 환경에 JDK가 없어 직접 실행 못 함 — CI에서 확인 필요)
- [ ] `GET /api/auth/onboarding/players?teamId={이적전팀ID}` 호출 시 이적한 선수가 더 이상 포함되지 않는지 확인
- [ ] `GET /api/auth/onboarding/players?teamId={이적후팀ID}` 호출 시 이적한 선수가 정상 포함되는지 확인