### PR TITLE
ci: Docker 이미지 멀티아치(amd64+arm64) 빌드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 
+      - name: Set up QEMU  # arm64(t4g) 크로스 빌드용 에뮬레이터
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -63,6 +66,8 @@ jobs:
         with:
           context: .
           push: true
+          # amd64(t3)·arm64(t4g) 둘 다 빌드 — 인스턴스 아키텍처 무관하게 실행 + 롤백 안전.
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/nar-gg:latest
             ${{ secrets.DOCKER_HUB_USERNAME }}/nar-gg:${{ github.sha }}


### PR DESCRIPTION
## 목적
t4g.small(Graviton, arm64) 인스턴스 이전 준비. Docker 이미지를 amd64·arm64 둘 다 빌드해 아키텍처 무관 실행 + x86 롤백 안전.

## 변경
- `docker/setup-qemu-action@v3` 추가 (arm64 크로스 빌드 에뮬레이터)
- `build-push-action` 에 `platforms: linux/amd64,linux/arm64`

## 영향
- 빌드 시간 다소 증가(arm64 QEMU 에뮬레이션). 배포 빈도 낮아 수용 가능.
- 현재 t3.micro(amd64) 배포는 그대로 amd64 매니페스트 pull → 무영향.
- 머지·배포 후 Docker Hub 이미지가 멀티아치가 되면 t4g 박스가 arm64 variant pull 가능.

## 후속 (별도 진행)
t4g.small 새 인스턴스 프로비저닝 → EIP 이동 무중단 컷오버 → 기존 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)