### PR TITLE
perf(deploy): t4g.small 힙 상향 + 재시작 정책

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,7 +139,8 @@ jobs:
             # awslogs: CloudWatch /nar/app 로 전송 (보존 30일). docker 20.10+ dual logging
             # 캐시 덕에 docker logs·Dozzle 도 그대로 동작한다. EC2 롤: NAR-CloudWatch-Role
             docker run -d --name "${NEW_NAME}" -p 127.0.0.1:${NEW_PORT}:8080 \
-              -m 768m \
+              --restart unless-stopped \
+              -m 1536m \
               --log-driver=awslogs \
               --log-opt awslogs-region=ap-northeast-2 \
               --log-opt awslogs-group=/nar/app \
@@ -175,7 +176,7 @@ jobs:
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
-              -e JAVA_TOOL_OPTIONS="-Xmx512m -javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
+              -e JAVA_TOOL_OPTIONS="-Xmx1g -javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               -v /opt/whatap:/whatap \
               "${APP_IMAGE}"


### PR DESCRIPTION
## 목적
t4g.small(2GB) 이전에 맞춰 힙을 늘리고, 재부팅 자동복구를 추가한다.

## 변경
- `-m 768m → 1536m`, `JAVA_TOOL_OPTIONS -Xmx512m → -Xmx1g` — 2GB RAM 활용, GC/워밍업 개선
- 앱 컨테이너 `--restart unless-stopped` 추가 — 인스턴스 재부팅 시 자동 기동 (기존엔 정책 없어 수동 `docker start` 필요)

## 배포 순서
**t4g 컷오버(EIP 이동) 완료 후** 머지 → 배포가 t4g 박스에 1g 힙 + restart 정책 적용. (지금 진행 중인 512m 배포/컷오버엔 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)