### PR TITLE
perf(deploy): 힙 -Xmx1g → 768m (배포 겹침 안정)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,7 +176,7 @@ jobs:
               -e FIREBASE_MESSAGING_ENABLED="true" \
               -e LIVE_NOTIFICATION_FCM_ENABLED="true" \
               -e GOOGLE_APPLICATION_CREDENTIALS="/run/secrets/firebase-service-account.json" \
-              -e JAVA_TOOL_OPTIONS="-Xmx1g -javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
+              -e JAVA_TOOL_OPTIONS="-Xmx768m -javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               -v /opt/whatap:/whatap \
               "${APP_IMAGE}"


### PR DESCRIPTION
## 배경
t4g.small(2GB) blue/green 배포 시 old·new 컨테이너가 잠깐 동시 실행 → 힙 1g×2면 겹침 순간 메모리 초과 → 스왑/OOM 위험 (예전 t3.micro의 "배포 시 순간 느림" 재현 소지).

## 변경
- `JAVA_TOOL_OPTIONS -Xmx1g → -Xmx768m`
- 겹침 RSS 가 RAM 안에 들어와 스왑 안 탐 → 배포 매끄러움
- 컨테이너 `-m 1536m` 은 상한이라 유지 (힙 축소로 실제 RSS 자연 감소)

## 성능 영향
동접 낮은 워크로드라 힙 크기가 GC/지연에 주는 체감 ~0 (와탭 실사용 heap max ~345MiB). 안정성만 확보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)