### PR TITLE
feat: 모바일 일정 API 복수 리그·팀 필터 지원

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/schedule/MobileScheduleController.java
+++ b/src/main/java/com/toy/nar/api/mobile/schedule/MobileScheduleController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.List;
 
 @Tag(name = "Mobile. 경기 일정", description = "모바일 앱 경기일정/경기리스트 전용 API")
 @RestController
@@ -39,10 +40,10 @@ public class MobileScheduleController {
 	public ResponseEntity<MobileScheduleCalendarResponse> getCalendar(
 			@Parameter(description = "조회 월", example = "2026-04")
 			@RequestParam("month") @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
-			@Parameter(description = "리그 (전체는 ALL)", example = "LCK")
-			@RequestParam(defaultValue = "LCK") String league,
-			@Parameter(description = "팀 ID", example = "1")
-			@RequestParam(required = false) Long teamId) {
+			@Parameter(description = "리그 (전체는 ALL). 복수 지정 가능: league=LCK&league=LEC", example = "LCK")
+			@RequestParam(defaultValue = "LCK") List<String> league,
+			@Parameter(description = "팀 ID. 복수 지정 가능: teamId=1&teamId=3", example = "1")
+			@RequestParam(required = false) List<Long> teamId) {
 		return ResponseEntity.ok(mobileScheduleService.getCalendar(month, league, teamId));
 	}
 
@@ -51,10 +52,10 @@ public class MobileScheduleController {
 	public ResponseEntity<MobileScheduleListResponse> getDailySchedules(
 			@Parameter(description = "조회 일자", example = "2026-04-01")
 			@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-			@Parameter(description = "리그 (전체는 ALL)", example = "LCK")
-			@RequestParam(defaultValue = "LCK") String league,
-			@Parameter(description = "팀 ID", example = "1")
-			@RequestParam(required = false) Long teamId) {
+			@Parameter(description = "리그 (전체는 ALL). 복수 지정 가능: league=LCK&league=KESPA", example = "LCK")
+			@RequestParam(defaultValue = "LCK") List<String> league,
+			@Parameter(description = "팀 ID. 복수 지정 가능: teamId=1&teamId=5", example = "1")
+			@RequestParam(required = false) List<Long> teamId) {
 		return ResponseEntity.ok(mobileScheduleService.getDailySchedules(date, league, teamId));
 	}
 }

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -61,34 +61,34 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
+			WHERE (:leagueNames IS NULL OR m.leagueName IN :leagueNames)
 			  AND m.matchDate >= :start
 			  AND m.matchDate < :end
 			ORDER BY m.matchDate ASC
 			""")
 	List<LeagueMatch> findMobileMatchesInRange(
-			@Param("leagueName") String leagueName,
+			@Param("leagueNames") List<String> leagueNames,
 			@Param("start") LocalDateTime start,
 			@Param("end") LocalDateTime end);
 
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
-			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
+			WHERE (:leagueNames IS NULL OR m.leagueName IN :leagueNames)
 			  AND m.matchDate >= :start
 			  AND m.matchDate < :end
 			  AND (
-					LOWER(m.blueTeamName) = LOWER(:teamName)
-					OR LOWER(m.redTeamName) = LOWER(:teamName)
-					OR (:teamCode IS NOT NULL AND m.blueTeamCode IS NOT NULL AND LOWER(m.blueTeamCode) = LOWER(:teamCode))
-					OR (:teamCode IS NOT NULL AND m.redTeamCode IS NOT NULL AND LOWER(m.redTeamCode) = LOWER(:teamCode))
+					LOWER(m.blueTeamName) IN :teamNames
+					OR LOWER(m.redTeamName) IN :teamNames
+					OR (:teamCodes IS NOT NULL AND m.blueTeamCode IS NOT NULL AND LOWER(m.blueTeamCode) IN :teamCodes)
+					OR (:teamCodes IS NOT NULL AND m.redTeamCode IS NOT NULL AND LOWER(m.redTeamCode) IN :teamCodes)
 			  )
 			ORDER BY m.matchDate ASC
 			""")
 	List<LeagueMatch> findMobileTeamMatchesInRange(
-			@Param("leagueName") String leagueName,
-			@Param("teamName") String teamName,
-			@Param("teamCode") String teamCode,
+			@Param("leagueNames") List<String> leagueNames,
+			@Param("teamNames") List<String> teamNames,
+			@Param("teamCodes") List<String> teamCodes,
 			@Param("start") LocalDateTime start,
 			@Param("end") LocalDateTime end);
 

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -88,15 +88,15 @@ public class MobileScheduleService {
 		return new MobileScheduleFilterResponse(DEFAULT_LEAGUE, leagues, teams, seasons);
 	}
 
-	public MobileScheduleCalendarResponse getCalendar(YearMonth month, String league, Long teamId) {
+	public MobileScheduleCalendarResponse getCalendar(YearMonth month, List<String> league, List<Long> teamId) {
 		if (month == null) {
 			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
 		}
-		String normalizedLeague = normalizeLeague(league);
-		TeamFilter teamFilter = resolveTeamFilter(teamId);
+		List<String> normalizedLeagues = normalizeLeagues(league);
+		TeamFilters teamFilters = resolveTeamFilters(teamId);
 		LocalDateTime startUtc = toUtc(month.atDay(1).atStartOfDay());
 		LocalDateTime endUtc = toUtc(month.plusMonths(1).atDay(1).atStartOfDay());
-		List<LeagueMatch> matches = findMatches(normalizedLeague, teamFilter, startUtc, endUtc);
+		List<LeagueMatch> matches = findMatches(normalizedLeagues, teamFilters, startUtc, endUtc);
 
 		Map<String, MobileScheduleCalendarResponse.DateSummary> summaries = new LinkedHashMap<>();
 		for (LeagueMatch match : matches) {
@@ -119,26 +119,26 @@ public class MobileScheduleService {
 
 		return new MobileScheduleCalendarResponse(
 				month.toString(),
-				normalizedLeague,
-				teamId,
+				echoLeague(normalizedLeagues),
+				echoTeamId(teamId),
 				new ArrayList<>(summaries.values()));
 	}
 
-	public MobileScheduleListResponse getDailySchedules(LocalDate date, String league, Long teamId) {
+	public MobileScheduleListResponse getDailySchedules(LocalDate date, List<String> league, List<Long> teamId) {
 		if (date == null) {
 			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
 		}
-		String normalizedLeague = normalizeLeague(league);
-		TeamFilter teamFilter = resolveTeamFilter(teamId);
+		List<String> normalizedLeagues = normalizeLeagues(league);
+		TeamFilters teamFilters = resolveTeamFilters(teamId);
 		LocalDateTime startUtc = toUtc(date.atStartOfDay());
 		LocalDateTime endUtc = toUtc(date.plusDays(1).atStartOfDay());
-		List<LeagueMatch> found = findMatches(normalizedLeague, teamFilter, startUtc, endUtc);
+		List<LeagueMatch> found = findMatches(normalizedLeagues, teamFilters, startUtc, endUtc);
 		Map<String, List<MobileScheduleListResponse.MobileGameSummary>> gamesByMatchId = loadGames(found);
 		List<MobileScheduleListResponse.MobileMatchSummary> matches = found.stream()
 				.map(match -> toMatchSummary(match, gamesByMatchId))
 				.toList();
 
-		return new MobileScheduleListResponse(date.toString(), normalizedLeague, teamId, matches);
+		return new MobileScheduleListResponse(date.toString(), echoLeague(normalizedLeagues), echoTeamId(teamId), matches);
 	}
 
 	public MobileMatchPageResponse getMatchPage(
@@ -246,18 +246,18 @@ public class MobileScheduleService {
 	}
 
 	private List<LeagueMatch> findMatches(
-			String league,
-			TeamFilter teamFilter,
+			List<String> leagues,
+			TeamFilters teamFilters,
 			LocalDateTime startUtc,
 			LocalDateTime endUtc) {
-		String leagueParam = leagueParam(league);
-		if (teamFilter == null) {
-			return leagueMatchRepository.findMobileMatchesInRange(leagueParam, startUtc, endUtc);
+		List<String> leagueParams = leagueParams(leagues);
+		if (teamFilters == null) {
+			return leagueMatchRepository.findMobileMatchesInRange(leagueParams, startUtc, endUtc);
 		}
 		return leagueMatchRepository.findMobileTeamMatchesInRange(
-				leagueParam,
-				teamFilter.name(),
-				teamFilter.code(),
+				leagueParams,
+				teamFilters.names(),
+				teamFilters.codes(),
 				startUtc,
 				endUtc);
 	}
@@ -504,6 +504,47 @@ public class MobileScheduleService {
 		return new TeamFilter(team.getName(), team.getCode());
 	}
 
+	/** 복수 팀 필터. teamId 미전송이면 null(팀 조건 없음). 이름·코드는 소문자로 정규화해 IN 비교에 쓴다. */
+	private TeamFilters resolveTeamFilters(List<Long> teamIds) {
+		if (teamIds == null || teamIds.isEmpty()) {
+			return null;
+		}
+		List<String> names = new ArrayList<>();
+		List<String> codes = new ArrayList<>();
+		for (Long teamId : teamIds) {
+			Team team = teamRepository.findById(teamId)
+					.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
+			names.add(team.getName().toLowerCase(Locale.ROOT));
+			if (team.getCode() != null && !team.getCode().isBlank()) {
+				codes.add(team.getCode().toLowerCase(Locale.ROOT));
+			}
+		}
+		return new TeamFilters(names, codes.isEmpty() ? null : codes);
+	}
+
+	/** 리스트 리그 정규화. 비었으면 기본 리그. 각 원소는 단일 정규화(검증·대문자·ALL 처리)를 재사용한다. */
+	private List<String> normalizeLeagues(List<String> leagues) {
+		if (leagues == null || leagues.isEmpty()) {
+			return List.of(DEFAULT_LEAGUE);
+		}
+		return leagues.stream().map(this::normalizeLeague).distinct().toList();
+	}
+
+	/** 리포지토리 필터용 리그 목록. ALL 이 하나라도 있으면 null 을 반환해 리그 조건을 걷는다. */
+	private List<String> leagueParams(List<String> normalizedLeagues) {
+		return normalizedLeagues.contains(ALL_LEAGUES) ? null : normalizedLeagues;
+	}
+
+	/** 응답 에코용 리그 값(하위호환: 단일 String 필드). 첫 리그만 반영한다. */
+	private String echoLeague(List<String> normalizedLeagues) {
+		return normalizedLeagues.get(0);
+	}
+
+	/** 응답 에코용 팀 값(하위호환: 단일 Long 필드). 첫 팀만 반영한다. */
+	private Long echoTeamId(List<Long> teamIds) {
+		return teamIds == null || teamIds.isEmpty() ? null : teamIds.get(0);
+	}
+
 	private String normalizeLeague(String league) {
 		String normalized = league == null || league.isBlank()
 				? DEFAULT_LEAGUE
@@ -523,6 +564,9 @@ public class MobileScheduleService {
 	}
 
 	private record TeamFilter(String name, String code) {
+	}
+
+	private record TeamFilters(List<String> names, List<String> codes) {
 	}
 
 	private record MatchCursor(LocalDateTime matchDate, String matchId) {

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -56,7 +56,7 @@ class MobileScheduleControllerTest {
 
 	@Test
 	void getCalendarReturnsMobileCalendarShape() throws Exception {
-		when(mobileScheduleService.getCalendar(YearMonth.of(2026, 4), "LCK", 1L))
+		when(mobileScheduleService.getCalendar(YearMonth.of(2026, 4), List.of("LCK"), List.of(1L)))
 				.thenReturn(new MobileScheduleCalendarResponse(
 						"2026-04",
 						"LCK",
@@ -90,7 +90,7 @@ class MobileScheduleControllerTest {
 
 	@Test
 	void getDailySchedulesReturnsMobileListShape() throws Exception {
-		when(mobileScheduleService.getDailySchedules(LocalDate.of(2026, 4, 1), "LCK", null))
+		when(mobileScheduleService.getDailySchedules(LocalDate.of(2026, 4, 1), List.of("LCK"), null))
 				.thenReturn(new MobileScheduleListResponse(
 						"2026-04-01",
 						"LCK",

--- a/src/test/java/com/toy/nar/app/lolesports/repository/LeagueMatchMobileFilterMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/repository/LeagueMatchMobileFilterMySqlIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.toy.nar.app.lolesports.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 모바일 일정 필터 쿼리의 복수 리그·팀(List IN) 및 ALL(null=조건 제거) 동작을 실제 MySQL 8 + Hibernate 6.6 에서 검증한다.
+ * null 컬렉션 파라미터 관용구({@code :leagueNames IS NULL OR m.leagueName IN :leagueNames})가 런타임에 깨지지 않음을 보장한다.
+ * 로컬 dev MySQL(docker-compose, 3308)의 격리 스키마 nar_mobile_filter_test 에 대해 ddl-auto=create-drop 으로 실행한다.
+ * 사전 준비(최초 1회): CREATE DATABASE nar_mobile_filter_test; GRANT ALL ON nar_mobile_filter_test.* TO 'nar_id'@'%';
+ * 실행: ./gradlew test -Ddataintegrity.local.enabled=true --tests "...LeagueMatchMobileFilterMySqlIntegrationTest"
+ * (dataintegrity. prefix 는 build.gradle 이 테스트 JVM 으로 포워딩하는 로컬 통합 테스트용 플래그다.)
+ */
+@EnabledIfSystemProperty(named = "dataintegrity.local.enabled", matches = "true")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LeagueMatchMobileFilterMySqlIntegrationTest {
+
+	@DynamicPropertySource
+	static void datasource(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url",
+				() -> "jdbc:mysql://localhost:3308/nar_mobile_filter_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8");
+		registry.add("spring.datasource.username", () -> "nar_id");
+		registry.add("spring.datasource.password", () -> "nar_pw");
+		registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+		registry.add("spring.flyway.enabled", () -> "false");
+	}
+
+	@Autowired
+	private LeagueMatchRepository repository;
+
+	private static final LocalDateTime START = LocalDateTime.of(2026, 7, 1, 0, 0);
+	private static final LocalDateTime END = LocalDateTime.of(2026, 8, 1, 0, 0);
+
+	@BeforeEach
+	void seed() {
+		repository.saveAll(List.of(
+				match("m-lck", "LCK", LocalDateTime.of(2026, 7, 10, 9, 0), "T1", "GEN"),
+				match("m-lec", "LEC", LocalDateTime.of(2026, 7, 11, 9, 0), "G2", "FNC"),
+				match("m-kespa", "KESPA", LocalDateTime.of(2026, 7, 12, 9, 0), "T1", "KT")));
+	}
+
+	@Test
+	void nullLeagueNamesReturnsAllLeagues() {
+		List<LeagueMatch> result = repository.findMobileMatchesInRange(null, START, END);
+
+		assertThat(result).extracting(LeagueMatch::getId)
+				.containsExactlyInAnyOrder("m-lck", "m-lec", "m-kespa");
+	}
+
+	@Test
+	void leagueNamesListFiltersByIn() {
+		List<LeagueMatch> result = repository.findMobileMatchesInRange(List.of("LCK", "KESPA"), START, END);
+
+		assertThat(result).extracting(LeagueMatch::getId)
+				.containsExactlyInAnyOrder("m-lck", "m-kespa");
+	}
+
+	@Test
+	void teamNamesListMatchesEitherSide() {
+		// 팀 이름은 소문자로 정규화해 넘긴다(서비스와 동일). T1 은 m-lck(blue)·m-kespa(blue) 두 경기 출전.
+		List<LeagueMatch> result = repository.findMobileTeamMatchesInRange(
+				null, List.of("t1", "fnc"), null, START, END);
+
+		assertThat(result).extracting(LeagueMatch::getId)
+				.containsExactlyInAnyOrder("m-lck", "m-lec", "m-kespa");
+	}
+
+	@Test
+	void teamCodesListMatchesWhenProvided() {
+		List<LeagueMatch> result = repository.findMobileTeamMatchesInRange(
+				List.of("LCK"), List.of("nomatch"), List.of("gen"), START, END);
+
+		assertThat(result).extracting(LeagueMatch::getId)
+				.containsExactly("m-lck");
+	}
+
+	private LeagueMatch match(String id, String league, LocalDateTime date, String blue, String red) {
+		return LeagueMatch.builder()
+				.id(id)
+				.leagueName(league)
+				.matchTitle(blue + " vs " + red)
+				.matchDate(date)
+				.state("unstarted")
+				.blueTeamName(blue)
+				.blueTeamCode(blue)
+				.redTeamName(red)
+				.redTeamCode(red)
+				.build();
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -77,12 +77,12 @@ class MobileScheduleServiceTest {
 	void getCalendarGroupsLeagueMatchesByKstDate() {
 		LocalDateTime startUtc = LocalDateTime.of(2026, 3, 31, 15, 0);
 		LocalDateTime endUtc = LocalDateTime.of(2026, 4, 30, 15, 0);
-		when(leagueMatchRepository.findMobileMatchesInRange("LCK", startUtc, endUtc))
+		when(leagueMatchRepository.findMobileMatchesInRange(List.of("LCK"), startUtc, endUtc))
 				.thenReturn(List.of(
 						match("match-1", "LCK", LocalDateTime.of(2026, 3, 31, 15, 30), "T1", "GEN", "unstarted"),
 						match("match-2", "LCK", LocalDateTime.of(2026, 4, 1, 10, 0), "DK", "HLE", "unstarted")));
 
-		MobileScheduleCalendarResponse response = service.getCalendar(YearMonth.of(2026, 4), "lck", null);
+		MobileScheduleCalendarResponse response = service.getCalendar(YearMonth.of(2026, 4), List.of("lck"), null);
 
 		assertThat(response.month()).isEqualTo("2026-04");
 		assertThat(response.league()).isEqualTo("LCK");
@@ -104,9 +104,9 @@ class MobileScheduleServiceTest {
 		Team t1 = team(1L, "T1", "T1", "https://example.com/t1.png");
 		when(teamRepository.findById(1L)).thenReturn(Optional.of(t1));
 		when(leagueMatchRepository.findMobileTeamMatchesInRange(
-				"LCK",
-				"T1",
-				"T1",
+				List.of("LCK"),
+				List.of("t1"),
+				List.of("t1"),
 				LocalDateTime.of(2026, 3, 31, 15, 0),
 				LocalDateTime.of(2026, 4, 1, 15, 0)))
 				.thenReturn(List.of(match(
@@ -119,8 +119,8 @@ class MobileScheduleServiceTest {
 
 		MobileScheduleListResponse response = service.getDailySchedules(
 				LocalDate.of(2026, 4, 1),
-				"LCK",
-				1L);
+				List.of("LCK"),
+				List.of(1L));
 
 		assertThat(response.date()).isEqualTo("2026-04-01");
 		assertThat(response.teamId()).isEqualTo(1L);
@@ -144,7 +144,7 @@ class MobileScheduleServiceTest {
 	@Test
 	void getDailySchedulesQueriesOneKstDayAsUtcRange() {
 		when(leagueMatchRepository.findMobileMatchesInRange(
-				"LCK",
+				List.of("LCK"),
 				LocalDateTime.of(2026, 3, 31, 15, 0),
 				LocalDateTime.of(2026, 4, 1, 15, 0)))
 				.thenReturn(List.of());
@@ -154,7 +154,7 @@ class MobileScheduleServiceTest {
 		ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
 		ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
 		verify(leagueMatchRepository).findMobileMatchesInRange(
-				org.mockito.ArgumentMatchers.eq("LCK"),
+				org.mockito.ArgumentMatchers.eq(List.of("LCK")),
 				startCaptor.capture(),
 				endCaptor.capture());
 		assertThat(startCaptor.getValue()).isEqualTo(LocalDateTime.of(2026, 3, 31, 15, 0));
@@ -164,7 +164,7 @@ class MobileScheduleServiceTest {
 	@Test
 	void getDailySchedulesAttachesGamesPerMatch() {
 		when(leagueMatchRepository.findMobileMatchesInRange(
-				"LCK",
+				List.of("LCK"),
 				LocalDateTime.of(2026, 3, 31, 15, 0),
 				LocalDateTime.of(2026, 4, 1, 15, 0)))
 				.thenReturn(List.of(match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed")));
@@ -173,7 +173,7 @@ class MobileScheduleServiceTest {
 						new MappedRow("match-1", 1, "game-1", 100L),
 						new MappedRow("match-1", 2, "game-2", null)));
 
-		MobileScheduleListResponse response = service.getDailySchedules(LocalDate.of(2026, 4, 1), "LCK", null);
+		MobileScheduleListResponse response = service.getDailySchedules(LocalDate.of(2026, 4, 1), List.of("LCK"), null);
 
 		assertThat(response.matches()).singleElement()
 				.satisfies(match -> {
@@ -365,7 +365,7 @@ class MobileScheduleServiceTest {
 
 	@Test
 	void invalidLeagueThrowsInvalidInput() {
-		assertThatThrownBy(() -> service.getDailySchedules(LocalDate.of(2026, 4, 1), "abc", null))
+		assertThatThrownBy(() -> service.getDailySchedules(LocalDate.of(2026, 4, 1), List.of("abc"), null))
 				.isInstanceOf(CustomException.class)
 				.extracting("errorCode")
 				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
@@ -382,7 +382,7 @@ class MobileScheduleServiceTest {
 						match("m-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed"),
 						match("m-2", "LPL", LocalDateTime.of(2026, 4, 1, 11, 0), "BLG", "JDG", "completed")));
 
-		MobileScheduleListResponse response = service.getDailySchedules(LocalDate.of(2026, 4, 1), "ALL", null);
+		MobileScheduleListResponse response = service.getDailySchedules(LocalDate.of(2026, 4, 1), List.of("ALL"), null);
 
 		assertThat(response.league()).isEqualTo("ALL");
 		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
@@ -436,7 +436,7 @@ class MobileScheduleServiceTest {
 	void unknownTeamThrowsDataNotFound() {
 		when(teamRepository.findById(999L)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> service.getCalendar(YearMonth.of(2026, 4), "LCK", 999L))
+		assertThatThrownBy(() -> service.getCalendar(YearMonth.of(2026, 4), List.of("LCK"), List.of(999L)))
 				.isInstanceOf(CustomException.class)
 				.extracting("errorCode")
 				.isEqualTo(ErrorCode.DATA_NOT_FOUND);


### PR DESCRIPTION
## 개요
`GET /api/mobile/schedules/calendar`, `GET /api/mobile/schedules` 의 `league`·`teamId` 를 배열(복수)로 확장.

| 파라미터 | 기존 | 변경 후 |
|---|---|---|
| league | String (기본 LCK) | List<String> (기본 LCK) |
| teamId | Long (선택) | List<Long> (선택) |

## 동작
- 리그끼리 OR(`IN`), 팀끼리 OR, 리그묶음·팀묶음은 AND
- `league` 에 `ALL` 포함 시 전체 리그(조건 제거)
- 단일 지정 = 기존과 동일 → 하위호환
- 응답 DTO 는 String/Long 필드 유지(첫 값 에코)로 구버전 클라 호환
- `filters` 엔드포인트·`getMatchPage`(무한스크롤) 는 범위 밖이라 단일 유지

예시:
```
GET /api/mobile/schedules/calendar?month=2026-07&league=LCK&league=LEC&teamId=1&teamId=3
```

## 구현
- Controller: `@RequestParam` 타입 String→List<String>, Long→List<Long>
- Repository: `= :leagueName` → `:leagueNames IS NULL OR m.leagueName IN :leagueNames`, 팀 매칭 `LOWER(...) = :teamName` → `IN :teamNames`(파라미터 소문자화)

## 검증
- 단위 테스트(service·controller) 그린 — 리스트 시그니처로 갱신
- 실 MySQL 8 + Hibernate 6.6 통합 테스트 신규 — null 컬렉션 IN 관용구 런타임 검증(복수 리그 IN·복수 팀 IN·ALL(null)·null 코드) 4/4 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)