### PR TITLE
feat: 백오피스 구독 조회 API (구독 가능 선수·선수별 구독자)

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -6,6 +6,7 @@ import com.toy.nar.app.member.service.MemberDeleteService;
 import com.toy.nar.app.participant.service.PlayerAdminService;
 import com.toy.nar.app.riot.RiotApiException;
 import com.toy.nar.domain.game.repository.LeagueRepository;
+import com.toy.nar.domain.member.repository.MemberFavoritePlayerRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -13,6 +14,7 @@ import com.toy.nar.domain.participant.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -50,6 +52,7 @@ public class BackofficeController {
     private final LeagueConfigService leagueConfigService;
     private final PlayerAdminService playerAdminService;
     private final MemberDeleteService memberDeleteService;
+    private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
@@ -85,6 +88,26 @@ public class BackofficeController {
     @GetMapping("/leagues")
     public List<String> leagues() {
         return leagueRepository.findAllDistinctLeagueNames();
+    }
+
+    // 구독 탭 — 구독 가능한 선수 목록(구독자 수 desc). q로 선수명 검색.
+    // 정렬은 쿼리에 고정(인기순)이라 클라이언트 sort는 무시(page/size만 사용).
+    @GetMapping("/subscriptions/players")
+    public Page<SubscribablePlayerRow> subscribablePlayers(@RequestParam(required = false) String q,
+                                                           Pageable pageable) {
+        Pageable pageOnly = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        return playerRepository.findSubscribablePlayers(blankToNull(q), pageOnly)
+                .map(v -> new SubscribablePlayerRow(v.getPlayerId(), v.getPlayerName(), v.getImageUrl(),
+                        v.getRole(), v.getTeamId(), v.getTeamName(), v.getRiotId(), v.getPlatform(),
+                        v.getSubscriberCount()));
+    }
+
+    // 구독 탭 — 특정 선수를 구독한 회원 목록(최근순).
+    @GetMapping("/subscriptions/players/{playerId}/subscribers")
+    public Page<SubscriberRow> playerSubscribers(@PathVariable Long playerId, Pageable pageable) {
+        return memberFavoritePlayerRepository.findSubscribersByPlayerId(playerId, pageable)
+                .map(v -> new SubscriberRow(v.getMemberId(), v.getName() + "#" + v.getTag(),
+                        v.getEmail(), v.getSubscribedAt()));
     }
 
     // 빈 문자열/공백은 null 로 정규화 → 검색 쿼리의 ":q IS NULL" 분기가 전체 조회로 동작.
@@ -194,6 +217,14 @@ public class BackofficeController {
 
     public record MemberRow(Long id, String name, String email,
                             String favoriteLeagueName, LocalDateTime createdAt) {}
+
+    // 구독 탭 — 구독 가능 선수 행(구독자 수 포함). id 필드는 FE 데이터그리드 rowKey 용.
+    public record SubscribablePlayerRow(Long id, String playerName, String imageUrl, String role,
+                                        Long teamId, String teamName, String riotId, String platform,
+                                        long subscriberCount) {}
+
+    // 구독 탭 — 구독자 행. id 필드는 FE rowKey 용(memberId).
+    public record SubscriberRow(Long id, String nickname, String email, LocalDateTime subscribedAt) {}
 
     public record PlayerRow(Long id, String name, String realName, String role, Integer age,
                             String imageUrl, Long currentTeamId, String currentTeamName, boolean imageLocked,

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberFavoritePlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberFavoritePlayerRepository.java
@@ -1,11 +1,14 @@
 package com.toy.nar.domain.member.repository;
 
 import com.toy.nar.domain.member.entity.MemberFavoritePlayer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -24,4 +27,32 @@ public interface MemberFavoritePlayerRepository extends JpaRepository<MemberFavo
 			WHERE favorite.member.id = :memberId
 			""")
 	Set<Long> findPlayerIdsByMemberId(@Param("memberId") Long memberId);
+
+	// 백오피스 구독 탭: 특정 선수를 구독한 회원 목록(최근 구독순). 페이징.
+	@Query(value = """
+			SELECT m.id AS memberId,
+			       m.name AS name,
+			       m.tag AS tag,
+			       m.email AS email,
+			       mfp.created_at AS subscribedAt
+			FROM member_favorite_player mfp
+			JOIN member m ON m.id = mfp.member_id
+			WHERE mfp.player_id = :playerId
+			ORDER BY mfp.created_at DESC
+			""",
+			countQuery = "SELECT COUNT(*) FROM member_favorite_player WHERE player_id = :playerId",
+			nativeQuery = true)
+	Page<SubscriberView> findSubscribersByPlayerId(@Param("playerId") Long playerId, Pageable pageable);
+
+	interface SubscriberView {
+		Long getMemberId();
+
+		String getName();
+
+		String getTag();
+
+		String getEmail();
+
+		LocalDateTime getSubscribedAt();
+	}
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -338,4 +338,64 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 
 		String getTeamImageUrl();
 	}
+
+	// 백오피스 구독 탭: 구독 가능한 선수(솔랭 계정 보유 ∪ LCK 2026 출전) + 구독자 수. 인기순(구독자 수 desc) 정렬.
+	// platform 무관(KR/EUW1/NA1 모두) — 해외 이적 솔랭 선수도 포함.
+	@Query(value = """
+			SELECT p.player_id AS playerId,
+			       p.player_name AS playerName,
+			       p.image_url AS imageUrl,
+			       p.role AS role,
+			       t.team_id AS teamId,
+			       t.team_name AS teamName,
+			       pra.riot_id AS riotId,
+			       pra.platform AS platform,
+			       COUNT(mfp.id) AS subscriberCount
+			FROM players p
+			LEFT JOIN teams t ON t.team_id = p.current_team_id
+			LEFT JOIN player_riot_account pra
+			       ON pra.player_id = p.player_id AND pra.enabled = true AND pra.primary_account = true
+			LEFT JOIN member_favorite_player mfp ON mfp.player_id = p.player_id
+			WHERE (:q IS NULL OR LOWER(p.player_name) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND (pra.player_id IS NOT NULL OR EXISTS (
+			        SELECT 1 FROM game_participants gp
+			        JOIN games g ON g.game_id = gp.game_id
+			        JOIN leagues l ON l.league_id = g.league_id
+			        WHERE gp.player_id = p.player_id AND l.league_name = 'LCK' AND l.season_year = 2026))
+			GROUP BY p.player_id, p.player_name, p.image_url, p.role, t.team_id, t.team_name, pra.riot_id, pra.platform
+			ORDER BY subscriberCount DESC, p.player_name ASC
+			""",
+			countQuery = """
+			SELECT COUNT(*) FROM players p
+			LEFT JOIN player_riot_account pra
+			       ON pra.player_id = p.player_id AND pra.enabled = true AND pra.primary_account = true
+			WHERE (:q IS NULL OR LOWER(p.player_name) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND (pra.player_id IS NOT NULL OR EXISTS (
+			        SELECT 1 FROM game_participants gp
+			        JOIN games g ON g.game_id = gp.game_id
+			        JOIN leagues l ON l.league_id = g.league_id
+			        WHERE gp.player_id = p.player_id AND l.league_name = 'LCK' AND l.season_year = 2026))
+			""",
+			nativeQuery = true)
+	Page<SubscribablePlayerView> findSubscribablePlayers(@Param("q") String q, Pageable pageable);
+
+	interface SubscribablePlayerView {
+		Long getPlayerId();
+
+		String getPlayerName();
+
+		String getImageUrl();
+
+		String getRole();
+
+		Long getTeamId();
+
+		String getTeamName();
+
+		String getRiotId();
+
+		String getPlatform();
+
+		long getSubscriberCount();
+	}
 }


### PR DESCRIPTION
## 배경
백오피스에 "구독 탭"을 추가한다(프론트: warding-backoffice-fe 별도 PR). 이 PR은 그 백엔드 조회 API.

## 변경
- **`GET /api/admin/subscriptions/players`** — 구독 가능한 선수 목록 + 구독자 수
  - 대상: 솔랭 계정 보유(enabled·primary, platform 무관) ∪ LCK 2026 출전 선수
  - 구독자 많은 순 고정 정렬, `q`로 선수명 검색, 페이징
  - 응답: 선수 이미지·팀·포지션·솔랭 riotId·platform·구독자 수
- **`GET /api/admin/subscriptions/players/{playerId}/subscribers`** — 특정 선수 구독자 목록
  - 회원 닉네임(name#tag)·이메일·구독일, 최근순 페이징
- 리포지토리 네이티브 쿼리 2개(projection 인터페이스) + 컨트롤러 엔드포인트 2개 + record 2개

## 참고
- 조회 전용, DB 변경 없음. ROLE_ADMIN 보호(기존 백오피스 패턴).
- platform 무관 조회라 EUW/NA 솔랭 선수(해외 이적)도 구독 가능 목록에 포함.
- 로컬 검증: 구독자 수 정렬·선수별 구독자 조회 정상(curl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)