### PR TITLE
perf: 솔랭 폴 호출 상한 40→10/s

### DIFF
--- a/src/main/java/com/toy/nar/app/riot/RiotMonitorProperties.java
+++ b/src/main/java/com/toy/nar/app/riot/RiotMonitorProperties.java
@@ -16,5 +16,5 @@ public class RiotMonitorProperties {
 	private String platform = "KR";
 	private int recentMatchFetchCount = 5;
 	// 폴 사이클의 Riot spectator 호출 상한(초당). 버스트로 인한 429 방지. 0 이하면 페이싱 없음.
-	private int maxRequestsPerSecond = 40;
+	private int maxRequestsPerSecond = 20;
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -115,7 +115,7 @@ riot:
     initial-delay-ms: ${RIOT_MONITOR_INITIAL_DELAY_MS:15000}
     target-league: ${RIOT_MONITOR_TARGET_LEAGUE:LCK}
     platform: ${RIOT_MONITOR_PLATFORM:KR}
-    max-requests-per-second: ${RIOT_MONITOR_MAX_RPS:40}
+    max-requests-per-second: ${RIOT_MONITOR_MAX_RPS:20}
 
 player:
   profile-sync:


### PR DESCRIPTION
## 문제
#297(40/s 스로틀) 배포 후에도 `na1`(Contractz) 등에서 `429 server rate limit exceeded` 지속.

## 원인
- na1 단일 호출은 정상(5/5 404) → na1 자체 문제 아님.
- EC2(서울)→KR Riot 지연이 극히 낮아 KR 404가 순식간에 쏟아짐 → **초당 버스트**가 Riot 글로벌 서비스 한도를 트립 → 뒤 순서의 na1 호출이 429를 받음.
- 40/s로도 서울 기준 여전히 높음.

## 변경
- 초당 호출 상한 기본값 **40 → 20** (`RIOT_MONITOR_MAX_RPS`, application-prod.yml + RiotMonitorProperties).
- 94콜 ≈ 4.7초/사이클. 폴 주기 60초라 여유, 게임 감지엔 충분.
- 여전히 429면 env로 10까지 하향 가능(재배포 없이 env만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)