### PR TITLE
perf: 솔랭 폴 호출 상한 20→10/s

### DIFF
--- a/src/main/java/com/toy/nar/app/riot/RiotMonitorProperties.java
+++ b/src/main/java/com/toy/nar/app/riot/RiotMonitorProperties.java
@@ -16,5 +16,5 @@ public class RiotMonitorProperties {
 	private String platform = "KR";
 	private int recentMatchFetchCount = 5;
 	// 폴 사이클의 Riot spectator 호출 상한(초당). 버스트로 인한 429 방지. 0 이하면 페이싱 없음.
-	private int maxRequestsPerSecond = 20;
+	private int maxRequestsPerSecond = 10;
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -115,7 +115,7 @@ riot:
     initial-delay-ms: ${RIOT_MONITOR_INITIAL_DELAY_MS:15000}
     target-league: ${RIOT_MONITOR_TARGET_LEAGUE:LCK}
     platform: ${RIOT_MONITOR_PLATFORM:KR}
-    max-requests-per-second: ${RIOT_MONITOR_MAX_RPS:20}
+    max-requests-per-second: ${RIOT_MONITOR_MAX_RPS:10}
 
 player:
   profile-sync:


### PR DESCRIPTION
## 배경
#298로 40→20/s 낮췄으나 na1(Contractz) 등에서 429 server rate limit 잔존 가능성.

## 원인
서울 EC2→KR Riot 지연이 극소 → KR 404 연사로 초당 버스트가 Riot 글로벌 서비스 한도를 트립 → 순서상 뒤인 na1 호출이 429. 20/s로도 서울 기준 여지 있음.

## 변경
- 초당 호출 상한 기본값 **20 → 10** (`RIOT_MONITOR_MAX_RPS`, application-prod.yml + RiotMonitorProperties).
- 94콜 ≈ 9.4초/사이클. 폴 주기 60초라 여유, 게임 감지엔 충분.
- 즉시 적용은 서버 env `RIOT_MONITOR_MAX_RPS=10`으로도 가능(재배포 X).

🤖 Generated with [Claude Code](https://claude.com/claude-code)