### PR TITLE
fix: 솔랭 폴 일시 오류(5xx/520) 알림 억제

### DIFF
--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
@@ -36,8 +36,8 @@ public class PlayerSoloRankMonitorService {
 	private static final int ARENA_RANKED_QUEUE_ID = 1710;
 	private static final String JOB_KEY = "PLAYER_RANKED_SOLO_MONITOR";
 	private static final String JOB_NAME = "선수 솔랭 감시";
-	// 한 사이클에 429가 이 수 이상이면 systemic으로 보고 경고. 미만이면 간헐로 간주(로그만).
-	private static final int RATE_LIMIT_ALERT_THRESHOLD = 10;
+	// 한 사이클에 일시 오류(429/5xx)가 이 수 이상이면 systemic으로 보고 경고. 미만이면 간헐로 간주(로그만).
+	private static final int TRANSIENT_ERROR_ALERT_THRESHOLD = 10;
 
 	private final PlayerRiotAccountRepository playerRiotAccountRepository;
 	private final ChampionDataService championDataService;
@@ -61,7 +61,7 @@ public class PlayerSoloRankMonitorService {
 		int rankedSoloCount = 0;
 		int alertsSentCount = 0;
 			int failedCount = 0;
-		int rateLimitedCount = 0;
+		int transientErrorCount = 0;
 
 		// 초당 호출 상한(버스트 429 방지). 호출 시작 간 최소 간격을 둔다.
 		int maxPerSec = riotMonitorProperties.getMaxRequestsPerSecond();
@@ -137,14 +137,15 @@ public class PlayerSoloRankMonitorService {
 				}
 			} catch (RiotApiException e) {
 				failedCount++;
-				if (e.isRateLimited()) {
-					// 429(server rate limit)는 Riot 공유·확률적 한도(Retry-After 20초 관측)라 낮은 rate에도 간헐 발생.
-					// 해당 계정만 스킵 → 다음 60초 주기에 재시도(솔랭 게임 20~35분이라 감지엔 무해).
-					// 개별 429는 알림하지 않고 로그만 — 예상된 일시 현상. 사이클 종합이 systemic일 때만 경고(아래).
-					rateLimitedCount++;
-					log.warn("Riot live poll rate limited (429) for player={}, skipping this cycle",
-							account.getPlayer().getName());
+				if (e.isTransient()) {
+					// 일시 오류 = 429(레이트리밋) 또는 5xx(Riot/Cloudflare 520~ 등 origin 장애)·타임아웃.
+					// 재시도로 자동 복구되는 유형이라 해당 계정만 스킵 → 다음 60초 주기 재시도(게임 20~35분이라 무해).
+					// 개별 건은 로그만 — 예상된 일시 현상. 사이클 종합이 systemic일 때만 경고(아래).
+					transientErrorCount++;
+					log.warn("Riot live poll transient error ({}) for player={}, skipping this cycle",
+							e.getStatusCode(), account.getPlayer().getName());
 				} else {
+					// 4xx 등 비일시 오류(우리 요청/설정 문제 가능)만 실패 알림.
 					log.warn("Riot live poll failed for player={}", account.getPlayer().getName(), e);
 					schedulerAlertService.recordFailure(
 							JOB_KEY,
@@ -155,13 +156,13 @@ public class PlayerSoloRankMonitorService {
 			}
 		}
 
-		// 429가 다수(systemic)일 때만 경고 — 간헐 1~2건은 정상(다음 주기 자동 복구)이라 노이즈로 알리지 않는다.
-		if (rateLimitedCount >= RATE_LIMIT_ALERT_THRESHOLD) {
+		// 일시 오류가 다수(systemic)일 때만 경고 — 간헐 1~2건은 정상(다음 주기 자동 복구)이라 노이즈로 알리지 않는다.
+		if (transientErrorCount >= TRANSIENT_ERROR_ALERT_THRESHOLD) {
 			schedulerAlertService.recordWarning(
 					JOB_KEY,
 					JOB_NAME,
-					"Riot API rate limit: " + rateLimitedCount + "/" + trackedAccounts.size()
-							+ " 계정 429 (systemic — 폴 주기·상한 점검 필요)");
+					"Riot API 일시 오류(429/5xx): " + transientErrorCount + "/" + trackedAccounts.size()
+							+ " 계정 (systemic — Riot 상태·폴 설정 점검 필요)");
 		}
 
 		long elapsed = System.currentTimeMillis() - startedAt;

--- a/src/main/java/com/toy/nar/app/riot/RiotApiException.java
+++ b/src/main/java/com/toy/nar/app/riot/RiotApiException.java
@@ -21,4 +21,10 @@ public class RiotApiException extends RuntimeException {
 	public boolean isRateLimited() {
 		return statusCode == 429;
 	}
+
+	// 일시 오류: 429(레이트리밋) 또는 5xx(업스트림/Cloudflare 520~ 포함)/타임아웃(500 래핑).
+	// 재시도로 자동 복구되는 유형 → 폴에서 개별 알림 대신 스킵·집계.
+	public boolean isTransient() {
+		return statusCode == 429 || statusCode >= 500;
+	}
 }


### PR DESCRIPTION
## 문제
na1(Contractz)에서 이번엔 **429가 아니라 HTTP 520** 발생:
`Error 520: Web server is returning an unknown error` (Cloudflare, zone=na1.api.riotgames.com, `retryable:true`, `retry_after:60`) → **Riot NA origin 일시 장애**.

#301은 **429만** 조용히 처리 → 520(비-429)은 `recordFailure`로 빠져 Discord "스케줄 실패" 노이즈.

## 원인
- 520/5xx는 Riot/Cloudflare 측 일시 장애 — 우리 문제/레이트리밋 아님. 재시도로 자동 복구.
- 감지 무해: 해당 계정만 스킵 → 다음 60초 주기 재시도, 솔랭 게임 20~35분이라 안 놓침.

## 변경
- `RiotApiException.isTransient()` 추가 = **429 또는 5xx**(Cloudflare 520~ 포함, 타임아웃은 500 래핑).
- 폴: 일시 오류(429/5xx/타임아웃)는 **개별 알림 없이 스킵·집계**. 비일시 4xx만 실패 알림.
- 사이클 종합 일시 오류가 임계(10) 이상 = systemic일 때만 경고(Riot 상태/설정 점검 신호).

## 검증
- 단위 테스트 통과(단일 일시 오류 → 다음 계정 계속 + Discord 경고 안 함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)