### PR TITLE
feat: 백오피스 팀 구독 조회 API (구독 가능 팀 목록·팀별 구독자)

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -8,6 +8,8 @@ import com.toy.nar.app.riot.RiotApiException;
 import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberFavoritePlayerRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.member.repository.MemberTeamNotificationSubscriptionRepository;
+import com.toy.nar.domain.participant.LckTeamCatalog;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
@@ -53,6 +55,7 @@ public class BackofficeController {
     private final PlayerAdminService playerAdminService;
     private final MemberDeleteService memberDeleteService;
     private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
+    private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
@@ -108,6 +111,32 @@ public class BackofficeController {
         return memberFavoritePlayerRepository.findSubscribersByPlayerId(playerId, pageable)
                 .map(v -> new SubscriberRow(v.getMemberId(), v.getName() + "#" + v.getTag(),
                         v.getEmail(), v.getSubscribedAt()));
+    }
+
+    // 구독 탭 — 구독 가능한 팀 목록(LCK 카탈로그, 구독자 수 desc). q로 팀명·코드 검색.
+    // 정렬은 쿼리에 고정(인기순)이라 클라이언트 sort는 무시(page/size만 사용).
+    @GetMapping("/subscriptions/teams")
+    public Page<SubscribableTeamRow> subscribableTeams(@RequestParam(required = false) String q,
+                                                       Pageable pageable) {
+        Pageable pageOnly = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        return teamRepository.findSubscribableTeams(LckTeamCatalog.TEAM_CODES, blankToNull(q), pageOnly)
+                .map(v -> new SubscribableTeamRow(v.getTeamId(), v.getTeamName(), v.getTeamCode(),
+                        v.getImageUrl(), v.getSubscriberCount()));
+    }
+
+    // 구독 탭 — 특정 팀을 구독한 회원 목록(최근순) + 알림 토글 상태.
+    // field(memberId|nickname|email)+q 로 검색. field 없이 q만 오면 닉네임 기준.
+    @GetMapping("/subscriptions/teams/{teamId}/subscribers")
+    public Page<TeamSubscriberRow> teamSubscribers(@PathVariable Long teamId,
+                                                   @RequestParam(required = false) String field,
+                                                   @RequestParam(required = false) String q,
+                                                   Pageable pageable) {
+        String fieldParam = blankToNull(field);
+        return teamSubscriptionRepository.findSubscribersByTeamId(
+                        teamId, fieldParam == null ? "nickname" : fieldParam, blankToNull(q), pageable)
+                .map(v -> new TeamSubscriberRow(v.getMemberId(), v.getName() + "#" + v.getTag(),
+                        v.getEmail(), v.getSubscribedAt(), v.getSetStartEnabled(),
+                        v.getSetEndEnabled(), v.getLiveEventEnabled()));
     }
 
     // 빈 문자열/공백은 null 로 정규화 → 검색 쿼리의 ":q IS NULL" 분기가 전체 조회로 동작.
@@ -225,6 +254,13 @@ public class BackofficeController {
 
     // 구독 탭 — 구독자 행. id 필드는 FE rowKey 용(memberId).
     public record SubscriberRow(Long id, String nickname, String email, LocalDateTime subscribedAt) {}
+
+    public record SubscribableTeamRow(Long id, String teamName, String teamCode, String imageUrl,
+                                      long subscriberCount) {}
+
+    public record TeamSubscriberRow(Long id, String nickname, String email, LocalDateTime subscribedAt,
+                                    boolean setStartEnabled, boolean setEndEnabled,
+                                    boolean liveEventEnabled) {}
 
     public record PlayerRow(Long id, String name, String realName, String role, Integer age,
                             String imageUrl, Long currentTeamId, String currentTeamName, boolean imageLocked,

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamNotificationSubscriptionRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamNotificationSubscriptionRepository.java
@@ -1,9 +1,14 @@
 package com.toy.nar.domain.member.repository;
 
 import com.toy.nar.domain.member.entity.MemberTeamNotificationSubscription;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +20,56 @@ public interface MemberTeamNotificationSubscriptionRepository
 
 	@EntityGraph(attributePaths = "team")
 	Optional<MemberTeamNotificationSubscription> findByMember_IdAndTeam_Id(Long memberId, Long teamId);
+
+	// 백오피스 구독 탭: 특정 팀을 구독한 회원 목록(최근 구독순) + 알림 토글 상태. 페이징.
+	// field(memberId|nickname|email) + q 로 검색. 닉네임은 화면 표기와 동일한 "name#tag" 기준.
+	@Query(value = """
+			SELECT m.id AS memberId,
+			       m.name AS name,
+			       m.tag AS tag,
+			       m.email AS email,
+			       mtns.set_start_enabled AS setStartEnabled,
+			       mtns.set_end_enabled AS setEndEnabled,
+			       mtns.live_event_enabled AS liveEventEnabled,
+			       mtns.created_at AS subscribedAt
+			FROM member_team_notification_subscription mtns
+			JOIN member m ON m.id = mtns.member_id
+			WHERE mtns.team_id = :teamId
+			  AND (:q IS NULL
+			       OR (:field = 'memberId' AND CAST(m.id AS CHAR) LIKE CONCAT('%', :q, '%'))
+			       OR (:field = 'email' AND LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'nickname' AND LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%'))))
+			ORDER BY mtns.created_at DESC
+			""",
+			countQuery = """
+			SELECT COUNT(*)
+			FROM member_team_notification_subscription mtns
+			JOIN member m ON m.id = mtns.member_id
+			WHERE mtns.team_id = :teamId
+			  AND (:q IS NULL
+			       OR (:field = 'memberId' AND CAST(m.id AS CHAR) LIKE CONCAT('%', :q, '%'))
+			       OR (:field = 'email' AND LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'nickname' AND LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%'))))
+			""",
+			nativeQuery = true)
+	Page<TeamSubscriberView> findSubscribersByTeamId(@Param("teamId") Long teamId,
+			@Param("field") String field, @Param("q") String q, Pageable pageable);
+
+	interface TeamSubscriberView {
+		Long getMemberId();
+
+		String getName();
+
+		String getTag();
+
+		String getEmail();
+
+		Boolean getSetStartEnabled();
+
+		Boolean getSetEndEnabled();
+
+		Boolean getLiveEventEnabled();
+
+		LocalDateTime getSubscribedAt();
+	}
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/TeamRepository.java
@@ -73,4 +73,44 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 			              WHERE gp.team = t AND gp.game.league.leagueName = :league)
 			""")
 	Page<Team> searchForBackofficeInLeague(@Param("q") String q, @Param("league") String league, Pageable pageable);
+
+	// 백오피스 구독 탭: 구독 가능한 팀(LCK 카탈로그 코드) + 구독자 수. 인기순(구독자 수 desc) 정렬.
+	// q 는 팀명·코드 부분일치. 팀 수가 카탈로그 크기(~10)라 성능 고려 불필요.
+	@Query(value = """
+			SELECT t.team_id AS teamId,
+			       t.team_name AS teamName,
+			       t.team_code AS teamCode,
+			       t.team_image_url AS imageUrl,
+			       COUNT(mtns.id) AS subscriberCount
+			FROM teams t
+			LEFT JOIN member_team_notification_subscription mtns ON mtns.team_id = t.team_id
+			WHERE UPPER(t.team_code) IN (:codes)
+			  AND (:q IS NULL
+			       OR LOWER(t.team_name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(t.team_code) LIKE LOWER(CONCAT('%', :q, '%')))
+			GROUP BY t.team_id, t.team_name, t.team_code, t.team_image_url
+			ORDER BY subscriberCount DESC, t.team_name ASC
+			""",
+			countQuery = """
+			SELECT COUNT(*) FROM teams t
+			WHERE UPPER(t.team_code) IN (:codes)
+			  AND (:q IS NULL
+			       OR LOWER(t.team_name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(t.team_code) LIKE LOWER(CONCAT('%', :q, '%')))
+			""",
+			nativeQuery = true)
+	Page<SubscribableTeamView> findSubscribableTeams(@Param("codes") Collection<String> codes,
+			@Param("q") String q, Pageable pageable);
+
+	interface SubscribableTeamView {
+		Long getTeamId();
+
+		String getTeamName();
+
+		String getTeamCode();
+
+		String getImageUrl();
+
+		long getSubscriberCount();
+	}
 }


### PR DESCRIPTION
## 개요

백오피스 구독 페이지에 팀 구독 조회를 추가한다. 선수 구독 조회(#295)와 동일한 패턴.

## 변경

- `GET /api/admin/subscriptions/teams` — 구독 가능 팀(LCK 카탈로그) + 구독자 수, 인기순(구독자 수 desc). `q`로 팀명·코드 검색
- `GET /api/admin/subscriptions/teams/{teamId}/subscribers` — 특정 팀 구독 회원 목록(최근 구독순) + 알림 토글 3종(세트 시작/종료/라이브)
  - `field(memberId|nickname|email)` + `q` 검색. 닉네임은 화면 표기와 동일한 `name#tag` 기준. field 생략 시 닉네임
- `TeamRepository.findSubscribableTeams`, `MemberTeamNotificationSubscriptionRepository.findSubscribersByTeamId` 네이티브 쿼리 추가 (조회 전용, 마이그레이션 없음)

## 검증

- 로컬 DB(프로드 미러)에서 두 쿼리 직접 실행 — 팀 목록 집계·검색 3분기(email 히트/memberId 미스) 확인
- 로컬 부팅 후 `/api/admin/subscriptions/teams` 302(미인증 리다이렉트, ROLE_ADMIN 보호) 확인

## 연관

- FE: NAR-GG/warding-backoffice-fe 구독 페이지 선수/팀 탭 PR과 세트

🤖 Generated with [Claude Code](https://claude.com/claude-code)