### PR TITLE
feat: 솔랭 완료 매치(match-v5) 폴백 — 스트리머 모드 계정 알림 복구

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -40,9 +40,35 @@ public class PlayerSoloRankPushService {
 		if (player == null || player.getId() == null || gameId == null || !pushGateway.isAvailable()) {
 			return;
 		}
-
 		MobilePushMessage message = buildMessage(
-				player, gameId, championName, championImageUrl, queueDisplayName, opggUrl);
+				player, gameId, championName, championImageUrl, queueDisplayName, opggUrl,
+				player.getName() + " 선수가 솔랭을 시작했어요",
+				normalizeChampionName(championName) + "로 " + normalizeQueue(queueDisplayName) + " 플레이 중");
+		dispatch(player, gameId, message);
+	}
+
+	/**
+	 * 경기 종료 후 폴백 알림(match-v5 감지). 스트리머 모드 계정은 라이브 감지가 불가능해
+	 * 사후에라도 발송한다. 문구만 다르고 발송 파이프라인·중복 방지는 라이브 알림과 동일.
+	 */
+	public void notifySubscribersPostGame(
+			Player player,
+			String gameId,
+			String championName,
+			String championImageUrl,
+			String resultLine,
+			String opggUrl) {
+		if (player == null || player.getId() == null || gameId == null || !pushGateway.isAvailable()) {
+			return;
+		}
+		MobilePushMessage message = buildMessage(
+				player, gameId, championName, championImageUrl, "솔로 랭크", opggUrl,
+				player.getName() + " 선수가 솔랭 한 판을 마쳤어요",
+				resultLine);
+		dispatch(player, gameId, message);
+	}
+
+	private void dispatch(Player player, String gameId, MobilePushMessage message) {
 
 		// 전체 선수 솔랭 알림 토픽 구독자에게 발송 (구독 여부와 무관). 게임당 1회.
 		sendToAllSoloRankTopic(player, gameId, message);
@@ -168,20 +194,16 @@ public class PlayerSoloRankPushService {
 			String championName,
 			String championImageUrl,
 			String queueDisplayName,
-			String opggUrl) {
-		String normalizedChampionName = championName == null || championName.isBlank()
-				? "챔피언 정보 확인 중"
-				: championName;
-		String normalizedQueue = queueDisplayName == null || queueDisplayName.isBlank()
-				? "솔로 랭크"
-				: queueDisplayName;
+			String opggUrl,
+			String title,
+			String body) {
 		Map<String, String> data = new LinkedHashMap<>();
 		data.put("type", PUSH_TYPE);
 		data.put("playerId", String.valueOf(player.getId()));
 		data.put("playerName", player.getName());
 		data.put("gameId", gameId);
-		data.put("championName", normalizedChampionName);
-		data.put("queueType", normalizedQueue);
+		data.put("championName", normalizeChampionName(championName));
+		data.put("queueType", normalizeQueue(queueDisplayName));
 		data.put("deepLink", "nar://players/" + player.getId());
 		if (championImageUrl != null && !championImageUrl.isBlank()) {
 			data.put("championImageUrl", championImageUrl);
@@ -189,10 +211,15 @@ public class PlayerSoloRankPushService {
 		if (opggUrl != null && !opggUrl.isBlank()) {
 			data.put("opggUrl", opggUrl);
 		}
-		return new MobilePushMessage(
-				player.getName() + " 선수가 솔랭을 시작했어요",
-				normalizedChampionName + "로 " + normalizedQueue + " 플레이 중",
-				Map.copyOf(data));
+		return new MobilePushMessage(title, body, Map.copyOf(data));
+	}
+
+	private String normalizeChampionName(String championName) {
+		return championName == null || championName.isBlank() ? "챔피언 정보 확인 중" : championName;
+	}
+
+	private String normalizeQueue(String queueDisplayName) {
+		return queueDisplayName == null || queueDisplayName.isBlank() ? "솔로 랭크" : queueDisplayName;
 	}
 
 	private String truncate(String message) {

--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -1,6 +1,7 @@
 package com.toy.nar.app.mobile.push;
 
 import com.toy.nar.app.mobile.notification.MemberNotificationService;
+import com.toy.nar.common.util.KoreanParticle;
 import com.toy.nar.domain.member.entity.MemberDevice;
 import com.toy.nar.domain.member.entity.MemberNotificationType;
 import com.toy.nar.domain.member.repository.MemberDeviceRepository;
@@ -40,10 +41,12 @@ public class PlayerSoloRankPushService {
 		if (player == null || player.getId() == null || gameId == null || !pushGateway.isAvailable()) {
 			return;
 		}
+		String normalizedChampion = normalizeChampionName(championName);
 		MobilePushMessage message = buildMessage(
 				player, gameId, championName, championImageUrl, queueDisplayName, opggUrl,
 				player.getName() + " 선수가 솔랭을 시작했어요",
-				normalizeChampionName(championName) + "로 " + normalizeQueue(queueDisplayName) + " 플레이 중");
+				normalizedChampion + KoreanParticle.ro(normalizedChampion) + " "
+						+ normalizeQueue(queueDisplayName) + " 플레이 중");
 		dispatch(player, gameId, message);
 	}
 

--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackScheduler.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackScheduler.java
@@ -1,0 +1,26 @@
+package com.toy.nar.app.riot;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlayerSoloRankMatchFallbackScheduler {
+
+	private final PlayerSoloRankMatchFallbackService playerSoloRankMatchFallbackService;
+	private final RiotMatchFallbackProperties riotMatchFallbackProperties;
+
+	@Scheduled(
+			fixedDelayString = "${riot.match-fallback.poll-interval-ms:300000}",
+			initialDelayString = "${riot.match-fallback.initial-delay-ms:45000}")
+	public void pollCompletedSoloRankMatches() {
+		if (!riotMatchFallbackProperties.isEnabled()) {
+			return;
+		}
+		playerSoloRankMatchFallbackService.pollTrackedAccounts();
+		log.debug("Completed scheduled solo rank match fallback poll");
+	}
+}

--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackService.java
@@ -6,6 +6,7 @@ import com.toy.nar.app.mobile.push.PlayerSoloRankPushService;
 import com.toy.nar.app.monitor.SchedulerAlertService;
 import com.toy.nar.app.riot.dto.PlayerSoloRankMatchFallbackResult;
 import com.toy.nar.app.riot.dto.RiotMatchResponse;
+import com.toy.nar.common.util.KoreanParticle;
 import com.toy.nar.domain.participant.entity.Champion;
 import com.toy.nar.domain.participant.entity.PlayerRiotAccount;
 import com.toy.nar.domain.participant.repository.PlayerRiotAccountRepository;
@@ -145,7 +146,7 @@ public class PlayerSoloRankMatchFallbackService {
 				buildOpggUrl(account.getGameName(), account.getTagLine(), account.getPlatform()));
 	}
 
-	/** 예: "멜로 승리 · 4/2/8" — 정보 없으면 단계적으로 축약. */
+	/** 예: "멜로 승리 · 4/2/8", "가렌으로 패배 · 1/5/9" — 정보 없으면 단계적으로 축약. */
 	private String buildResultLine(String championName, RiotMatchResponse.Participant tracked) {
 		String champion = championName == null || championName.isBlank() ? "솔로 랭크" : championName;
 		if (tracked == null) {
@@ -153,7 +154,7 @@ public class PlayerSoloRankMatchFallbackService {
 		}
 		StringBuilder line = new StringBuilder(champion);
 		if (tracked.win() != null) {
-			line.append("로 ").append(tracked.win() ? "승리" : "패배");
+			line.append(KoreanParticle.ro(champion)).append(" ").append(tracked.win() ? "승리" : "패배");
 		} else {
 			line.append(" 경기 종료");
 		}

--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackService.java
@@ -1,0 +1,203 @@
+package com.toy.nar.app.riot;
+
+import com.toy.nar.app.data.source.ChampionDataService;
+import com.toy.nar.app.data.source.NotificationService;
+import com.toy.nar.app.mobile.push.PlayerSoloRankPushService;
+import com.toy.nar.app.monitor.SchedulerAlertService;
+import com.toy.nar.app.riot.dto.PlayerSoloRankMatchFallbackResult;
+import com.toy.nar.app.riot.dto.RiotMatchResponse;
+import com.toy.nar.domain.participant.entity.Champion;
+import com.toy.nar.domain.participant.entity.PlayerRiotAccount;
+import com.toy.nar.domain.participant.repository.PlayerRiotAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 솔랭 완료 매치(match-v5) 폴백 감지.
+ *
+ * <p>스트리머 모드 계정은 spectator-v5가 라이브 게임을 내려주지 않아
+ * ({@code "filtered"} 404) 라이브 모니터가 영구히 놓친다. match-v5 완료 매치
+ * 목록은 필터링되지 않으므로, 경기 종료 후 새 솔랭 게임을 감지해 이력 적재·알림한다.
+ *
+ * <p>중복 방지: 게임 ID를 라이브 모니터와 같은 형식(플랫폼 접두사 제거)으로 정규화하고,
+ * {@link SoloRankGameHistoryRecorder}의 신규 적재 여부를 알림 게이트로 쓴다.
+ * 라이브 모니터가 이미 잡은 게임은 이력에 존재 → 알림 없음.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlayerSoloRankMatchFallbackService {
+
+	private static final String JOB_KEY = "riot-solo-rank-match-fallback";
+	private static final String JOB_NAME = "솔랭 완료 매치 폴백 감지";
+	private static final int RANKED_SOLO_QUEUE_ID = 420;
+
+	private final PlayerRiotAccountRepository playerRiotAccountRepository;
+	private final RiotApiClient riotApiClient;
+	private final RiotMatchFallbackProperties properties;
+	private final ChampionDataService championDataService;
+	private final NotificationService notificationService;
+	private final PlayerSoloRankPushService playerSoloRankPushService;
+	private final SoloRankGameHistoryRecorder soloRankGameHistoryRecorder;
+	private final SchedulerAlertService schedulerAlertService;
+
+	@Transactional(readOnly = true)
+	public PlayerSoloRankMatchFallbackResult pollTrackedAccounts() {
+		long startedAt = System.currentTimeMillis();
+		riotApiClient.assertConfigured();
+		List<PlayerRiotAccount> trackedAccounts = playerRiotAccountRepository.findAllTrackedAccounts();
+
+		int checkedCount = 0;
+		int newGameCount = 0;
+		int alertsSentCount = 0;
+		int failedCount = 0;
+
+		for (PlayerRiotAccount account : trackedAccounts) {
+			try {
+				List<String> matchIds = riotApiClient.getRecentSoloRankMatchIdsByPuuid(
+						account.getPuuid(), properties.getFetchCount(), account.getPlatform());
+				checkedCount++;
+
+				for (String matchId : matchIds) {
+					String gameId = normalizeGameId(matchId);
+					if (soloRankGameHistoryRecorder.exists(account.getPlayer().getId(), gameId)) {
+						continue;
+					}
+					RiotMatchResponse match = riotApiClient.getMatch(matchId, account.getPlatform());
+					if (match == null || match.info() == null
+							|| match.info().queueId() == null
+							|| match.info().queueId() != RANKED_SOLO_QUEUE_ID) {
+						continue;
+					}
+
+					RiotMatchResponse.Participant tracked = findTrackedParticipant(match, account.getPuuid());
+					Champion champion = tracked == null || tracked.championId() == null
+							? null
+							: championDataService.findChampionByRiotKey(tracked.championId()).orElse(null);
+
+					boolean newlyRecorded = soloRankGameHistoryRecorder.record(
+							account.getPlayer(), gameId, champion, LocalDateTime.now());
+					if (!newlyRecorded) {
+						continue;
+					}
+					newGameCount++;
+
+					if (isFresh(match.info().gameEndTimestamp())) {
+						sendAlerts(account, gameId, champion, tracked);
+						alertsSentCount++;
+					}
+				}
+			} catch (RiotApiException e) {
+				failedCount++;
+				log.warn("Solo rank match fallback poll failed for player={}",
+						account.getPlayer().getName(), e);
+				if (e.isRateLimited()) {
+					schedulerAlertService.recordWarning(
+							JOB_KEY, JOB_NAME,
+							"Riot API rate limit reached while polling match fallback");
+				} else {
+					schedulerAlertService.recordFailure(
+							JOB_KEY, JOB_NAME, e,
+							"player=" + account.getPlayer().getName());
+				}
+			}
+		}
+
+		long elapsed = System.currentTimeMillis() - startedAt;
+		schedulerAlertService.recordSuccess(JOB_KEY, JOB_NAME, elapsed);
+		return new PlayerSoloRankMatchFallbackResult(
+				trackedAccounts.size(), checkedCount, newGameCount, alertsSentCount, failedCount);
+	}
+
+	private void sendAlerts(
+			PlayerRiotAccount account,
+			String gameId,
+			Champion champion,
+			RiotMatchResponse.Participant tracked) {
+		String championName = champion == null ? null : champion.getChampionNameKr();
+		String championIconUrl = champion == null ? null : champion.getImageUrl();
+		String resultLine = buildResultLine(championName, tracked);
+
+		notificationService.sendPlayerGameNotification(
+				account.getPlayer().getName(),
+				account.getRiotId(),
+				account.getGameName(),
+				account.getTagLine(),
+				gameId,
+				"솔로 랭크 (경기 종료·폴백)",
+				championName,
+				championIconUrl);
+		playerSoloRankPushService.notifySubscribersPostGame(
+				account.getPlayer(),
+				gameId,
+				championName,
+				championIconUrl,
+				resultLine,
+				buildOpggUrl(account.getGameName(), account.getTagLine(), account.getPlatform()));
+	}
+
+	/** 예: "멜로 승리 · 4/2/8" — 정보 없으면 단계적으로 축약. */
+	private String buildResultLine(String championName, RiotMatchResponse.Participant tracked) {
+		String champion = championName == null || championName.isBlank() ? "솔로 랭크" : championName;
+		if (tracked == null) {
+			return champion + " 경기 종료";
+		}
+		StringBuilder line = new StringBuilder(champion);
+		if (tracked.win() != null) {
+			line.append("로 ").append(tracked.win() ? "승리" : "패배");
+		} else {
+			line.append(" 경기 종료");
+		}
+		if (tracked.kills() != null && tracked.deaths() != null && tracked.assists() != null) {
+			line.append(" · ")
+					.append(tracked.kills()).append("/")
+					.append(tracked.deaths()).append("/")
+					.append(tracked.assists());
+		}
+		return line.toString();
+	}
+
+	private RiotMatchResponse.Participant findTrackedParticipant(RiotMatchResponse match, String puuid) {
+		if (match.info().participants() == null) {
+			return null;
+		}
+		return match.info().participants().stream()
+				.filter(participant -> puuid.equals(participant.puuid()))
+				.findFirst()
+				.orElse(null);
+	}
+
+	private boolean isFresh(Long gameEndTimestampMs) {
+		if (gameEndTimestampMs == null) {
+			return false;
+		}
+		Duration age = Duration.between(Instant.ofEpochMilli(gameEndTimestampMs), Instant.now());
+		return !age.isNegative() && age.toMinutes() <= properties.getAlertFreshnessMinutes();
+	}
+
+	/** match-v5 ID("KR_8292488921")를 spectator 게임 ID("8292488921") 형식으로 정규화. */
+	static String normalizeGameId(String matchId) {
+		if (matchId == null) {
+			return null;
+		}
+		int separatorIndex = matchId.indexOf('_');
+		return separatorIndex < 0 ? matchId : matchId.substring(separatorIndex + 1);
+	}
+
+	private String buildOpggUrl(String gameName, String tagLine, String platform) {
+		if (gameName == null || gameName.isBlank() || tagLine == null || tagLine.isBlank()) {
+			return "";
+		}
+		String path = URLEncoder.encode(gameName + "-" + tagLine, StandardCharsets.UTF_8);
+		return "https://www.op.gg/summoners/" + RiotPlatform.opggRegion(platform) + "/" + path;
+	}
+}

--- a/src/main/java/com/toy/nar/app/riot/RiotApiClient.java
+++ b/src/main/java/com/toy/nar/app/riot/RiotApiClient.java
@@ -58,6 +58,27 @@ public class RiotApiClient {
 		return Arrays.asList(response);
 	}
 
+	/** 최근 솔로 랭크(queue=420) 매치 ID 목록. match-v5는 스트리머 모드 필터 대상이 아니다. */
+	public List<String> getRecentSoloRankMatchIdsByPuuid(String puuid, int count, String platform) {
+		ensureConfigured();
+		URI uri = URI.create(RiotPlatform.regionalHost(platform)
+				+ "/lol/match/v5/matches/by-puuid/"
+				+ encodePathSegment(puuid)
+				+ "/ids?queue=420&start=0&count="
+				+ count);
+		String[] response = getRequired(uri, String[].class, "Riot solo rank match list fetch failed");
+		return Arrays.asList(response);
+	}
+
+	/** 매치 상세(플랫폼별 지역 라우팅). 완료 매치 폴백 감지용. */
+	public RiotMatchResponse getMatch(String matchId, String platform) {
+		ensureConfigured();
+		URI uri = URI.create(RiotPlatform.regionalHost(platform)
+				+ "/lol/match/v5/matches/"
+				+ encodePathSegment(matchId));
+		return getRequired(uri, RiotMatchResponse.class, "Riot match fetch failed");
+	}
+
 	public RiotMatchResponse getMatch(String matchId) {
 		ensureConfigured();
 		URI uri = URI.create(riotApiProperties.getRegionalBaseUrl()

--- a/src/main/java/com/toy/nar/app/riot/RiotMatchFallbackProperties.java
+++ b/src/main/java/com/toy/nar/app/riot/RiotMatchFallbackProperties.java
@@ -1,0 +1,26 @@
+package com.toy.nar.app.riot;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 솔랭 완료 매치(match-v5) 폴백 감지 설정.
+ *
+ * <p>스트리머 모드 계정은 spectator-v5에서 필터링되어 라이브 감지가 불가능하다
+ * (Riot 2025-10 익명성 정책). match-v5 완료 매치 목록은 필터링되지 않으므로,
+ * 경기 종료 후라도 감지·알림하기 위한 폴백 경로다.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "riot.match-fallback")
+public class RiotMatchFallbackProperties {
+	private boolean enabled;
+	private long pollIntervalMs = 300000;
+	private long initialDelayMs = 45000;
+	/** 계정당 조회할 최근 솔랭 매치 수. */
+	private int fetchCount = 5;
+	/** 이 시간(분) 내에 끝난 게임만 알림 발송. 초과분은 이력만 적재(첫 가동 백필 스팸 방지). */
+	private long alertFreshnessMinutes = 60;
+}

--- a/src/main/java/com/toy/nar/app/riot/RiotPlatform.java
+++ b/src/main/java/com/toy/nar/app/riot/RiotPlatform.java
@@ -73,4 +73,29 @@ public final class RiotPlatform {
 	public static String opggRegion(String platform) {
 		return PLATFORM_TO_OPGG.getOrDefault(toPlatform(platform), "kr");
 	}
+
+	// 플랫폼 라우팅 값 → match-v5 등 지역(regional) 라우팅 그룹.
+	private static final Map<String, String> PLATFORM_TO_REGIONAL = Map.ofEntries(
+			Map.entry("KR", "asia"),
+			Map.entry("JP1", "asia"),
+			Map.entry("NA1", "americas"),
+			Map.entry("BR1", "americas"),
+			Map.entry("LA1", "americas"),
+			Map.entry("LA2", "americas"),
+			Map.entry("EUW1", "europe"),
+			Map.entry("EUN1", "europe"),
+			Map.entry("TR1", "europe"),
+			Map.entry("RU", "europe"),
+			Map.entry("OC1", "sea"),
+			Map.entry("VN2", "sea"),
+			Map.entry("TW2", "sea"),
+			Map.entry("SG2", "sea"),
+			Map.entry("TH2", "sea"),
+			Map.entry("PH2", "sea"));
+
+	/** 지역(regional) API 호스트. match-v5용. 예: KR → https://asia.api.riotgames.com */
+	public static String regionalHost(String platform) {
+		String regional = PLATFORM_TO_REGIONAL.getOrDefault(toPlatform(platform), "asia");
+		return "https://" + regional + ".api.riotgames.com";
+	}
 }

--- a/src/main/java/com/toy/nar/app/riot/SoloRankGameHistoryRecorder.java
+++ b/src/main/java/com/toy/nar/app/riot/SoloRankGameHistoryRecorder.java
@@ -26,21 +26,34 @@ public class SoloRankGameHistoryRecorder {
 
 	private final PlayerSoloRankGameRepository repository;
 
+	/** 이미 적재된 게임인지 확인. 폴백 경로에서 매치 상세 조회 전 선필터로 쓴다. */
+	@Transactional(readOnly = true)
+	public boolean exists(Long playerId, String gameId) {
+		if (playerId == null || gameId == null || gameId.isBlank()) {
+			return false;
+		}
+		return repository.existsByPlayer_IdAndGameId(playerId, gameId);
+	}
+
+	/** @return 신규 적재 여부. 이미 존재·실패 시 false — 폴백 경로의 알림 중복 방지 게이트로 쓴다. */
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void record(Player player, String gameId, Champion champion, LocalDateTime detectedAt) {
+	public boolean record(Player player, String gameId, Champion champion, LocalDateTime detectedAt) {
 		if (player == null || player.getId() == null || gameId == null || gameId.isBlank()) {
-			return;
+			return false;
 		}
 		try {
 			if (repository.existsByPlayer_IdAndGameId(player.getId(), gameId)) {
-				return;
+				return false;
 			}
 			repository.save(new PlayerSoloRankGame(player, gameId, champion, detectedAt));
+			return true;
 		} catch (DataIntegrityViolationException e) {
 			// 동시 폴링으로 인한 (player, gameId) 중복 — 무시.
+			return false;
 		} catch (Exception e) {
 			log.warn("Failed to record solo rank game history playerId={} gameId={}",
 					player.getId(), gameId, e);
+			return false;
 		}
 	}
 }

--- a/src/main/java/com/toy/nar/app/riot/dto/PlayerSoloRankMatchFallbackResult.java
+++ b/src/main/java/com/toy/nar/app/riot/dto/PlayerSoloRankMatchFallbackResult.java
@@ -1,0 +1,9 @@
+package com.toy.nar.app.riot.dto;
+
+public record PlayerSoloRankMatchFallbackResult(
+		int totalTrackedAccounts,
+		int checkedCount,
+		int newGameCount,
+		int alertsSentCount,
+		int failedCount) {
+}

--- a/src/main/java/com/toy/nar/app/riot/dto/RiotMatchResponse.java
+++ b/src/main/java/com/toy/nar/app/riot/dto/RiotMatchResponse.java
@@ -1,5 +1,7 @@
 package com.toy.nar.app.riot.dto;
 
+import java.util.List;
+
 public record RiotMatchResponse(
 		Metadata metadata,
 		Info info) {
@@ -9,6 +11,17 @@ public record RiotMatchResponse(
 	}
 
 	public record Info(
-			Integer queueId) {
+			Integer queueId,
+			Long gameEndTimestamp,
+			List<Participant> participants) {
+	}
+
+	public record Participant(
+			String puuid,
+			Integer championId,
+			Boolean win,
+			Integer kills,
+			Integer deaths,
+			Integer assists) {
 	}
 }

--- a/src/main/java/com/toy/nar/common/util/KoreanParticle.java
+++ b/src/main/java/com/toy/nar/common/util/KoreanParticle.java
@@ -1,0 +1,24 @@
+package com.toy.nar.common.util;
+
+/** 한국어 조사 선택 유틸. */
+public final class KoreanParticle {
+
+	private KoreanParticle() {
+	}
+
+	/**
+	 * "로/으로" 선택. 받침 없음(티모 → 티모로)·ㄹ받침(멜 → 멜로) → "로",
+	 * 그 외 받침(가렌 → 가렌으로) → "으로". 한글이 아닌 마지막 글자(영문·숫자 등)는 "로" 폴백.
+	 */
+	public static String ro(String word) {
+		if (word == null || word.isBlank()) {
+			return "로";
+		}
+		char last = word.charAt(word.length() - 1);
+		if (last < 0xAC00 || last > 0xD7A3) {
+			return "로";
+		}
+		int jongseong = (last - 0xAC00) % 28;
+		return (jongseong == 0 || jongseong == 8) ? "로" : "으로";
+	}
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -116,6 +116,13 @@ riot:
     target-league: ${RIOT_MONITOR_TARGET_LEAGUE:LCK}
     platform: ${RIOT_MONITOR_PLATFORM:KR}
     max-requests-per-second: ${RIOT_MONITOR_MAX_RPS:10}
+  # 스트리머 모드 계정용 완료 매치(match-v5) 폴백 감지. spectator 필터 우회.
+  match-fallback:
+    enabled: ${RIOT_MATCH_FALLBACK_ENABLED:false}
+    poll-interval-ms: ${RIOT_MATCH_FALLBACK_POLL_INTERVAL_MS:300000}
+    initial-delay-ms: ${RIOT_MATCH_FALLBACK_INITIAL_DELAY_MS:45000}
+    fetch-count: ${RIOT_MATCH_FALLBACK_FETCH_COUNT:5}
+    alert-freshness-minutes: ${RIOT_MATCH_FALLBACK_ALERT_FRESHNESS_MINUTES:60}
 
 player:
   profile-sync:

--- a/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackServiceTest.java
+++ b/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMatchFallbackServiceTest.java
@@ -1,0 +1,179 @@
+package com.toy.nar.app.riot;
+
+import com.toy.nar.app.data.source.ChampionDataService;
+import com.toy.nar.app.data.source.NotificationService;
+import com.toy.nar.app.mobile.push.PlayerSoloRankPushService;
+import com.toy.nar.app.monitor.SchedulerAlertService;
+import com.toy.nar.app.riot.dto.PlayerSoloRankMatchFallbackResult;
+import com.toy.nar.app.riot.dto.RiotMatchResponse;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.PlayerRiotAccount;
+import com.toy.nar.domain.participant.repository.PlayerRiotAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerSoloRankMatchFallbackServiceTest {
+
+	@Mock
+	private PlayerRiotAccountRepository playerRiotAccountRepository;
+
+	@Mock
+	private RiotApiClient riotApiClient;
+
+	@Mock
+	private ChampionDataService championDataService;
+
+	@Mock
+	private NotificationService notificationService;
+
+	@Mock
+	private PlayerSoloRankPushService playerSoloRankPushService;
+
+	@Mock
+	private SoloRankGameHistoryRecorder soloRankGameHistoryRecorder;
+
+	@Mock
+	private SchedulerAlertService schedulerAlertService;
+
+	private RiotMatchFallbackProperties properties;
+	private PlayerSoloRankMatchFallbackService service;
+
+	private PlayerRiotAccount account;
+
+	@BeforeEach
+	void setUp() {
+		properties = new RiotMatchFallbackProperties();
+		service = new PlayerSoloRankMatchFallbackService(
+				playerRiotAccountRepository,
+				riotApiClient,
+				properties,
+				championDataService,
+				notificationService,
+				playerSoloRankPushService,
+				soloRankGameHistoryRecorder,
+				schedulerAlertService);
+
+		Player player = Player.builder()
+				.name("SUPKING")
+				.imageUrl(null)
+				.build();
+		account = PlayerRiotAccount.builder()
+				.player(player)
+				.riotId("SUPKING#1015")
+				.gameName("SUPKING")
+				.tagLine("1015")
+				.platform("KR")
+				.puuid("puuid-supking")
+				.primaryAccount(true)
+				.enabled(true)
+				.build();
+	}
+
+	@Test
+	void stripsPlatformPrefixFromMatchId() {
+		assertThat(PlayerSoloRankMatchFallbackService.normalizeGameId("KR_8292488921"))
+				.isEqualTo("8292488921");
+		assertThat(PlayerSoloRankMatchFallbackService.normalizeGameId("8292488921"))
+				.isEqualTo("8292488921");
+	}
+
+	@Test
+	void alertsForFreshNewSoloRankGame() {
+		when(playerRiotAccountRepository.findAllTrackedAccounts()).thenReturn(List.of(account));
+		when(riotApiClient.getRecentSoloRankMatchIdsByPuuid(eq("puuid-supking"), anyInt(), eq("KR")))
+				.thenReturn(List.of("KR_100"));
+		when(soloRankGameHistoryRecorder.exists(any(), eq("100"))).thenReturn(false);
+		when(riotApiClient.getMatch(eq("KR_100"), eq("KR"))).thenReturn(match(
+				420, System.currentTimeMillis() - 60_000,
+				new RiotMatchResponse.Participant("puuid-supking", 902, true, 4, 2, 8)));
+		when(championDataService.findChampionByRiotKey(902)).thenReturn(Optional.empty());
+		when(soloRankGameHistoryRecorder.record(any(), eq("100"), any(), any())).thenReturn(true);
+
+		PlayerSoloRankMatchFallbackResult result = service.pollTrackedAccounts();
+
+		assertThat(result.newGameCount()).isEqualTo(1);
+		assertThat(result.alertsSentCount()).isEqualTo(1);
+		verify(playerSoloRankPushService).notifySubscribersPostGame(
+				any(), eq("100"), any(), any(), eq("솔로 랭크로 승리 · 4/2/8"), anyString());
+		verify(notificationService).sendPlayerGameNotification(
+				eq("SUPKING"), eq("SUPKING#1015"), eq("SUPKING"), eq("1015"),
+				eq("100"), eq("솔로 랭크 (경기 종료·폴백)"), any(), any());
+	}
+
+	@Test
+	void recordsButDoesNotAlertStaleGame() {
+		when(playerRiotAccountRepository.findAllTrackedAccounts()).thenReturn(List.of(account));
+		when(riotApiClient.getRecentSoloRankMatchIdsByPuuid(anyString(), anyInt(), anyString()))
+				.thenReturn(List.of("KR_100"));
+		when(soloRankGameHistoryRecorder.exists(any(), eq("100"))).thenReturn(false);
+		// 25시간 전 종료 — 신선도(기본 60분) 초과. 첫 가동 백필 시나리오.
+		when(riotApiClient.getMatch(eq("KR_100"), anyString())).thenReturn(match(
+				420, System.currentTimeMillis() - 25L * 60 * 60 * 1000,
+				new RiotMatchResponse.Participant("puuid-supking", 902, false, 1, 5, 9)));
+		when(soloRankGameHistoryRecorder.record(any(), eq("100"), any(), any())).thenReturn(true);
+
+		PlayerSoloRankMatchFallbackResult result = service.pollTrackedAccounts();
+
+		assertThat(result.newGameCount()).isEqualTo(1);
+		assertThat(result.alertsSentCount()).isZero();
+		verify(playerSoloRankPushService, never()).notifySubscribersPostGame(
+				any(), anyString(), any(), any(), anyString(), anyString());
+	}
+
+	@Test
+	void skipsAlreadyRecordedGameWithoutMatchDetailCall() {
+		when(playerRiotAccountRepository.findAllTrackedAccounts()).thenReturn(List.of(account));
+		when(riotApiClient.getRecentSoloRankMatchIdsByPuuid(anyString(), anyInt(), anyString()))
+				.thenReturn(List.of("KR_100"));
+		// 라이브 모니터가 이미 적재한 게임 — 상세 조회·알림 모두 없어야 한다.
+		when(soloRankGameHistoryRecorder.exists(any(), eq("100"))).thenReturn(true);
+
+		PlayerSoloRankMatchFallbackResult result = service.pollTrackedAccounts();
+
+		assertThat(result.newGameCount()).isZero();
+		assertThat(result.alertsSentCount()).isZero();
+		verify(riotApiClient, never()).getMatch(anyString(), anyString());
+	}
+
+	@Test
+	void skipsAlertWhenConcurrentPollAlreadyRecorded() {
+		when(playerRiotAccountRepository.findAllTrackedAccounts()).thenReturn(List.of(account));
+		when(riotApiClient.getRecentSoloRankMatchIdsByPuuid(anyString(), anyInt(), anyString()))
+				.thenReturn(List.of("KR_100"));
+		when(soloRankGameHistoryRecorder.exists(any(), eq("100"))).thenReturn(false);
+		when(riotApiClient.getMatch(eq("KR_100"), anyString())).thenReturn(match(
+				420, System.currentTimeMillis(),
+				new RiotMatchResponse.Participant("puuid-supking", 902, true, 4, 2, 8)));
+		// exists 통과 후 record 시점에 경쟁 폴링이 먼저 적재 — 알림 중복 방지.
+		when(soloRankGameHistoryRecorder.record(any(), eq("100"), any(), any())).thenReturn(false);
+
+		PlayerSoloRankMatchFallbackResult result = service.pollTrackedAccounts();
+
+		assertThat(result.alertsSentCount()).isZero();
+		verify(playerSoloRankPushService, never()).notifySubscribersPostGame(
+				any(), anyString(), any(), any(), anyString(), anyString());
+	}
+
+	private RiotMatchResponse match(int queueId, long gameEndTimestamp, RiotMatchResponse.Participant participant) {
+		return new RiotMatchResponse(
+				new RiotMatchResponse.Metadata("KR_100"),
+				new RiotMatchResponse.Info(queueId, gameEndTimestamp, List.of(participant)));
+	}
+}

--- a/src/test/java/com/toy/nar/common/util/KoreanParticleTest.java
+++ b/src/test/java/com/toy/nar/common/util/KoreanParticleTest.java
@@ -1,0 +1,40 @@
+package com.toy.nar.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KoreanParticleTest {
+
+	@Test
+	void noFinalConsonantTakesRo() {
+		assertThat(KoreanParticle.ro("티모")).isEqualTo("로");
+		assertThat(KoreanParticle.ro("아리")).isEqualTo("로");
+	}
+
+	@Test
+	void rieulFinalConsonantTakesRo() {
+		assertThat(KoreanParticle.ro("멜")).isEqualTo("로");
+		assertThat(KoreanParticle.ro("이즈리얼")).isEqualTo("로");
+	}
+
+	@Test
+	void otherFinalConsonantTakesEuro() {
+		assertThat(KoreanParticle.ro("가렌")).isEqualTo("으로");
+		assertThat(KoreanParticle.ro("갱플랭크")).isEqualTo("로"); // 크: 받침 없음
+		assertThat(KoreanParticle.ro("징크스")).isEqualTo("로"); // 스: 받침 없음
+		assertThat(KoreanParticle.ro("문도 박사")).isEqualTo("로");
+		assertThat(KoreanParticle.ro("코그모")).isEqualTo("로");
+		assertThat(KoreanParticle.ro("벨코즈")).isEqualTo("로");
+		assertThat(KoreanParticle.ro("자이라")).isEqualTo("로");
+		assertThat(KoreanParticle.ro("판테온")).isEqualTo("으로");
+		assertThat(KoreanParticle.ro("케이틀린")).isEqualTo("으로");
+	}
+
+	@Test
+	void nonHangulFallsBackToRo() {
+		assertThat(KoreanParticle.ro("Mel")).isEqualTo("로");
+		assertThat(KoreanParticle.ro(null)).isEqualTo("로");
+		assertThat(KoreanParticle.ro("")).isEqualTo("로");
+	}
+}


### PR DESCRIPTION
## 배경
Riot 2025-10 익명성 정책으로 스트리머 모드 계정은 spectator-v5에서 필터링(`"filtered"` 404)됨. 라이브 모니터가 해당 계정 게임을 영구 누락.

**실측 증거 (prod)**
- SUPKING#1015 (Career, 챌 2370LP): 7/10 18시부터 감지 0 — 이후 솔랭 7게임(33분 게임 포함) 전부 누락, 같은 시간대 타 선수 22게임/시 정상 감지
- PerfecT#132 (챌 2344LP): 7/20부터 동일 증상
- puuid·키·레이트리밋·폴링 전부 정상 확인 후 소거법으로 확정

## 동작
- 5분 주기(89계정 × ids 1콜, 새 게임만 상세 1콜)로 match-v5 최근 솔랭 조회
- 게임 ID 정규화(`KR_8292...` → `8292...`) → `player_solo_rank_game` 이력과 dedup — 라이브 모니터가 잡은 게임은 알림 중복 없음
- 알림: 신규 적재 + 종료 60분 이내만 (첫 가동 시 옛 게임은 이력만 백필)
- 문구: "○○ 선수가 솔랭 한 판을 마쳤어요 — 멜로 승리 · 4/2/8"

## 플래그
`RIOT_MATCH_FALLBACK_ENABLED` 기본 **false** (CLAUDE.md 규칙). 활성화 시 EC2 env에 true 추가.

## 테스트
- 신규 4케이스: prefix 정규화 / fresh 알림 / stale 이력만 / 동시성 중복 방지
- 전체 스위트 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)