### PR TITLE
feat: 백오피스 선수 리뷰 조회·삭제 API

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -156,12 +156,15 @@ public class BackofficeController {
 
     // 회원이 모바일에서 작성한 선수 리뷰(별점 + 한줄평). 부적절한 한줄평 삭제용.
     // 경기 정보(리그·팀·일시)는 rating.matchId = league_match.id 로 페이지 단위 배치 조회해 붙인다.
+    // field(player|member|comment|all)+q 로 검색. field 없이 q만 오면 전체 대상(all).
     @GetMapping("/ratings")
     public Page<RatingRow> ratings(@RequestParam(required = false) String q,
+                                   @RequestParam(required = false) String field,
                                    @RequestParam(required = false) Integer rating,
                                    Pageable pageable) {
+        String fieldParam = blankToNull(field);
         Page<LivePlayerRating> page = livePlayerRatingRepository.searchForBackoffice(
-                blankToNull(q), rating, pageable);
+                blankToNull(q), fieldParam == null ? "all" : fieldParam, rating, pageable);
         Set<String> matchIds = page.getContent().stream()
                 .map(LivePlayerRating::getMatchId)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -13,6 +13,8 @@ import com.toy.nar.domain.participant.LckTeamCatalog;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
 import com.toy.nar.domain.participant.repository.TeamRepository;
+import com.toy.nar.domain.rating.entity.LivePlayerRating;
+import com.toy.nar.domain.rating.repository.LivePlayerRatingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
@@ -54,6 +56,7 @@ public class BackofficeController {
     private final LeagueConfigService leagueConfigService;
     private final PlayerAdminService playerAdminService;
     private final MemberDeleteService memberDeleteService;
+    private final LivePlayerRatingRepository livePlayerRatingRepository;
     private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
     private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
 
@@ -142,6 +145,24 @@ public class BackofficeController {
     // 빈 문자열/공백은 null 로 정규화 → 검색 쿼리의 ":q IS NULL" 분기가 전체 조회로 동작.
     private static String blankToNull(String q) {
         return (q == null || q.isBlank()) ? null : q.trim();
+    }
+
+    // 회원이 모바일에서 작성한 선수 리뷰(별점 + 한줄평). 부적절한 한줄평 삭제용.
+    @GetMapping("/ratings")
+    public Page<RatingRow> ratings(@RequestParam(required = false) String q,
+                                   @RequestParam(required = false) Integer rating,
+                                   Pageable pageable) {
+        return livePlayerRatingRepository.searchForBackoffice(blankToNull(q), rating, pageable)
+                .map(RatingRow::from);
+    }
+
+    @DeleteMapping("/ratings/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteRating(@PathVariable Long id) {
+        if (!livePlayerRatingRepository.existsById(id)) {
+            throw new NoSuchElementException("리뷰를 찾을 수 없습니다: " + id);
+        }
+        livePlayerRatingRepository.deleteById(id);
     }
 
     @GetMapping("/cron-jobs")
@@ -286,6 +307,16 @@ public class BackofficeController {
     public record SoloRankAccountRequest(String riotId, String region, String imageUrl) {}
 
     public record TeamRow(Long id, String name, String code) {}
+
+    public record RatingRow(Long id, String matchId, String playerName, String championName,
+                            String role, String memberNickname, Integer rating, String comment,
+                            LocalDateTime createdAt) {
+        static RatingRow from(LivePlayerRating r) {
+            return new RatingRow(r.getId(), r.getMatchId(), r.getPlayerName(), r.getChampionName(),
+                    r.getRole(), r.getMember().getNickname(), r.getRating(), r.getComment(),
+                    r.getCreatedAt());
+        }
+    }
 
     public record LeagueConfigRow(String leagueName, boolean liveEnabled,
                                   boolean notificationEnabled, boolean syncEnabled) {

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -1,6 +1,8 @@
 package com.toy.nar.api.admin;
 
 import com.toy.nar.app.lolesports.LeagueConfigService;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
 import com.toy.nar.app.lolesports.repository.LeagueConfig;
 import com.toy.nar.app.member.service.MemberDeleteService;
 import com.toy.nar.app.participant.service.PlayerAdminService;
@@ -35,9 +37,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 백오피스 API. {@code /api/admin/**} 는 SecurityConfig 에서 ROLE_ADMIN 으로 보호된다.
@@ -57,6 +63,7 @@ public class BackofficeController {
     private final PlayerAdminService playerAdminService;
     private final MemberDeleteService memberDeleteService;
     private final LivePlayerRatingRepository livePlayerRatingRepository;
+    private final LeagueMatchRepository leagueMatchRepository;
     private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
     private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
 
@@ -148,12 +155,19 @@ public class BackofficeController {
     }
 
     // 회원이 모바일에서 작성한 선수 리뷰(별점 + 한줄평). 부적절한 한줄평 삭제용.
+    // 경기 정보(리그·팀·일시)는 rating.matchId = league_match.id 로 페이지 단위 배치 조회해 붙인다.
     @GetMapping("/ratings")
     public Page<RatingRow> ratings(@RequestParam(required = false) String q,
                                    @RequestParam(required = false) Integer rating,
                                    Pageable pageable) {
-        return livePlayerRatingRepository.searchForBackoffice(blankToNull(q), rating, pageable)
-                .map(RatingRow::from);
+        Page<LivePlayerRating> page = livePlayerRatingRepository.searchForBackoffice(
+                blankToNull(q), rating, pageable);
+        Set<String> matchIds = page.getContent().stream()
+                .map(LivePlayerRating::getMatchId)
+                .collect(Collectors.toSet());
+        Map<String, LeagueMatch> matches = leagueMatchRepository.findAllById(matchIds).stream()
+                .collect(Collectors.toMap(LeagueMatch::getId, m -> m));
+        return page.map(r -> RatingRow.from(r, matches.get(r.getMatchId())));
     }
 
     @DeleteMapping("/ratings/{id}")
@@ -308,13 +322,30 @@ public class BackofficeController {
 
     public record TeamRow(Long id, String name, String code) {}
 
-    public record RatingRow(Long id, String matchId, String playerName, String championName,
-                            String role, String memberNickname, Integer rating, String comment,
+    /**
+     * @param matchDate 경기 일시. league_match 는 UTC 로 저장하므로 모바일 응답과 동일하게 KST 로 변환해 내린다.
+     *                  매치 정보를 못 찾으면(동기화 전/삭제) 경기 관련 필드는 null.
+     */
+    public record RatingRow(Long id, String matchId, String leagueName, String matchTitle,
+                            String blueTeamCode, String redTeamCode, LocalDateTime matchDate,
+                            String playerName, String championName, String role,
+                            String memberNickname, Integer rating, String comment,
                             LocalDateTime createdAt) {
-        static RatingRow from(LivePlayerRating r) {
-            return new RatingRow(r.getId(), r.getMatchId(), r.getPlayerName(), r.getChampionName(),
-                    r.getRole(), r.getMember().getNickname(), r.getRating(), r.getComment(),
+        static RatingRow from(LivePlayerRating r, LeagueMatch match) {
+            return new RatingRow(r.getId(), r.getMatchId(),
+                    match != null ? match.getLeagueName() : null,
+                    match != null ? match.getMatchTitle() : null,
+                    match != null ? match.getBlueTeamCode() : null,
+                    match != null ? match.getRedTeamCode() : null,
+                    match != null ? toKst(match.getMatchDate()) : null,
+                    r.getPlayerName(), r.getChampionName(), r.getRole(),
+                    r.getMember().getNickname(), r.getRating(), r.getComment(),
                     r.getCreatedAt());
+        }
+
+        private static LocalDateTime toKst(LocalDateTime utc) {
+            return utc == null ? null
+                    : utc.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         }
     }
 

--- a/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
+++ b/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
@@ -29,6 +29,27 @@ public interface LivePlayerRatingRepository extends JpaRepository<LivePlayerRati
 			String playerRef,
 			Pageable pageable);
 
+	/**
+	 * 백오피스 리뷰 목록. q = 선수명·회원명·한줄평 부분일치, rating = 별점 정확일치(둘 다 optional).
+	 * member 는 join fetch(행마다 닉네임 필요) — count 쿼리는 fetch 없이 별도 지정.
+	 */
+	@Query(value = """
+			SELECT r FROM LivePlayerRating r
+			JOIN FETCH r.member m
+			WHERE (:q IS NULL OR r.playerName LIKE %:q% OR m.name LIKE %:q% OR r.comment LIKE %:q%)
+			  AND (:rating IS NULL OR r.rating = :rating)
+			""",
+			countQuery = """
+			SELECT COUNT(r) FROM LivePlayerRating r
+			JOIN r.member m
+			WHERE (:q IS NULL OR r.playerName LIKE %:q% OR m.name LIKE %:q% OR r.comment LIKE %:q%)
+			  AND (:rating IS NULL OR r.rating = :rating)
+			""")
+	Page<LivePlayerRating> searchForBackoffice(
+			@Param("q") String q,
+			@Param("rating") Integer rating,
+			Pageable pageable);
+
 	@Query("""
 			SELECT r.playerRef AS playerRef,
 			       AVG(r.rating) AS averageRating,

--- a/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
+++ b/src/main/java/com/toy/nar/domain/rating/repository/LivePlayerRatingRepository.java
@@ -30,23 +30,36 @@ public interface LivePlayerRatingRepository extends JpaRepository<LivePlayerRati
 			Pageable pageable);
 
 	/**
-	 * 백오피스 리뷰 목록. q = 선수명·회원명·한줄평 부분일치, rating = 별점 정확일치(둘 다 optional).
+	 * 백오피스 리뷰 목록. field(player|member|comment|all) + q 로 검색, rating = 별점 정확일치(모두 optional).
 	 * member 는 join fetch(행마다 닉네임 필요) — count 쿼리는 fetch 없이 별도 지정.
 	 */
 	@Query(value = """
 			SELECT r FROM LivePlayerRating r
 			JOIN FETCH r.member m
-			WHERE (:q IS NULL OR r.playerName LIKE %:q% OR m.name LIKE %:q% OR r.comment LIKE %:q%)
+			WHERE (:q IS NULL
+			       OR (:field = 'player' AND LOWER(r.playerName) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'member' AND LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'comment' AND LOWER(r.comment) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'all' AND (LOWER(r.playerName) LIKE LOWER(CONCAT('%', :q, '%'))
+			                               OR LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%'))
+			                               OR LOWER(r.comment) LIKE LOWER(CONCAT('%', :q, '%')))))
 			  AND (:rating IS NULL OR r.rating = :rating)
 			""",
 			countQuery = """
 			SELECT COUNT(r) FROM LivePlayerRating r
 			JOIN r.member m
-			WHERE (:q IS NULL OR r.playerName LIKE %:q% OR m.name LIKE %:q% OR r.comment LIKE %:q%)
+			WHERE (:q IS NULL
+			       OR (:field = 'player' AND LOWER(r.playerName) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'member' AND LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'comment' AND LOWER(r.comment) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'all' AND (LOWER(r.playerName) LIKE LOWER(CONCAT('%', :q, '%'))
+			                               OR LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%'))
+			                               OR LOWER(r.comment) LIKE LOWER(CONCAT('%', :q, '%')))))
 			  AND (:rating IS NULL OR r.rating = :rating)
 			""")
 	Page<LivePlayerRating> searchForBackoffice(
 			@Param("q") String q,
+			@Param("field") String field,
 			@Param("rating") Integer rating,
 			Pageable pageable);
 

--- a/src/test/java/com/toy/nar/domain/rating/repository/LivePlayerRatingSearchTest.java
+++ b/src/test/java/com/toy/nar/domain/rating/repository/LivePlayerRatingSearchTest.java
@@ -1,0 +1,112 @@
+package com.toy.nar.domain.rating.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.rating.entity.LivePlayerRating;
+
+/**
+ * 백오피스 리뷰 검색 쿼리({@link LivePlayerRatingRepository#searchForBackoffice})를 검증한다.
+ *
+ * <p>마이그레이션은 MySQL 전용 문법이라 H2에서는 엔티티 기반 스키마(create-drop)를 사용한다.
+ */
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class LivePlayerRatingSearchTest {
+
+	@Autowired
+	private LivePlayerRatingRepository ratingRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@BeforeEach
+	void setUp() {
+		Member faker = new Member("페이커팬", "1234", "fan1@nar.kr");
+		Member other = new Member("구마유시팬", "5678", "fan2@nar.kr");
+		em.persist(faker);
+		em.persist(other);
+
+		ratingRepository.save(rating("m1", "Faker", faker, 5, "캐리했다"));
+		ratingRepository.save(rating("m1", "Gumayusi", other, 2, "던짐"));
+		ratingRepository.save(rating("m2", "Faker", other, 5, null));
+	}
+
+	@Test
+	@DisplayName("q가 null이면 전체, 값이 있으면 선수명·회원명·한줄평 부분일치로 검색한다")
+	void searchForBackoffice_matchesPlayerOrMemberOrComment() {
+		assertThat(ratingRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
+				.isEqualTo(3);
+
+		// 선수명 부분일치
+		assertThat(names(ratingRepository.searchForBackoffice("Faker", null, PageRequest.of(0, 10)).getContent()))
+				.containsExactly("Faker", "Faker");
+
+		// 회원명 부분일치 — 그 회원이 쓴 리뷰 전부
+		assertThat(names(ratingRepository.searchForBackoffice("구마유시팬", null, PageRequest.of(0, 10)).getContent()))
+				.containsExactlyInAnyOrder("Gumayusi", "Faker");
+
+		// 한줄평 부분일치
+		assertThat(names(ratingRepository.searchForBackoffice("던짐", null, PageRequest.of(0, 10)).getContent()))
+				.containsExactly("Gumayusi");
+
+		// 매칭 없음
+		assertThat(ratingRepository.searchForBackoffice("zzz", null, PageRequest.of(0, 10)).getTotalElements())
+				.isZero();
+	}
+
+	@Test
+	@DisplayName("rating을 주면 해당 별점만, q와 함께도 동작한다")
+	void searchForBackoffice_filtersByRating() {
+		assertThat(ratingRepository.searchForBackoffice(null, 5, PageRequest.of(0, 10)).getTotalElements())
+				.isEqualTo(2);
+		assertThat(names(ratingRepository.searchForBackoffice("던짐", 2, PageRequest.of(0, 10)).getContent()))
+				.containsExactly("Gumayusi");
+		// q와 rating이 서로 다른 행을 가리키면 결과 없음
+		assertThat(ratingRepository.searchForBackoffice("던짐", 5, PageRequest.of(0, 10)).getTotalElements())
+				.isZero();
+	}
+
+	private static List<String> names(List<LivePlayerRating> rows) {
+		return rows.stream().map(LivePlayerRating::getPlayerName).toList();
+	}
+
+	private static LivePlayerRating rating(String matchId, String playerName, Member member, int rating, String comment) {
+		return new LivePlayerRating(matchId, matchId + "-1", 1, playerName, member, null,
+				"blue", "MID", playerName, playerName, "Ahri", rating, comment);
+	}
+
+	/**
+	 * 컨텍스트를 rating·member·participant 도메인으로 한정한다. (전체 앱을 띄우면 Elasticsearch 빈을
+	 * 요구해 슬라이스 테스트가 실패하므로, 저장소의 다른 리포지토리 테스트와 동일하게 범위를 좁힌다.)
+	 */
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@EntityScan(basePackages = {
+			"com.toy.nar.domain.rating.entity",
+			"com.toy.nar.domain.member.entity",
+			"com.toy.nar.domain.participant.entity",
+			"com.toy.nar.domain.game.entity"
+	})
+	@EnableJpaRepositories(basePackageClasses = LivePlayerRatingRepository.class)
+	static class TestJpaConfiguration {
+	}
+}

--- a/src/test/java/com/toy/nar/domain/rating/repository/LivePlayerRatingSearchTest.java
+++ b/src/test/java/com/toy/nar/domain/rating/repository/LivePlayerRatingSearchTest.java
@@ -53,36 +53,60 @@ class LivePlayerRatingSearchTest {
 	@Test
 	@DisplayName("q가 null이면 전체, 값이 있으면 선수명·회원명·한줄평 부분일치로 검색한다")
 	void searchForBackoffice_matchesPlayerOrMemberOrComment() {
-		assertThat(ratingRepository.searchForBackoffice(null, null, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(ratingRepository.searchForBackoffice(null, "all", null, PageRequest.of(0, 10)).getTotalElements())
 				.isEqualTo(3);
 
 		// 선수명 부분일치
-		assertThat(names(ratingRepository.searchForBackoffice("Faker", null, PageRequest.of(0, 10)).getContent()))
+		assertThat(names(ratingRepository.searchForBackoffice("Faker", "all", null, PageRequest.of(0, 10)).getContent()))
 				.containsExactly("Faker", "Faker");
 
 		// 회원명 부분일치 — 그 회원이 쓴 리뷰 전부
-		assertThat(names(ratingRepository.searchForBackoffice("구마유시팬", null, PageRequest.of(0, 10)).getContent()))
+		assertThat(names(ratingRepository.searchForBackoffice("구마유시팬", "all", null, PageRequest.of(0, 10)).getContent()))
 				.containsExactlyInAnyOrder("Gumayusi", "Faker");
 
 		// 한줄평 부분일치
-		assertThat(names(ratingRepository.searchForBackoffice("던짐", null, PageRequest.of(0, 10)).getContent()))
+		assertThat(names(ratingRepository.searchForBackoffice("던짐", "all", null, PageRequest.of(0, 10)).getContent()))
 				.containsExactly("Gumayusi");
 
 		// 매칭 없음
-		assertThat(ratingRepository.searchForBackoffice("zzz", null, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(ratingRepository.searchForBackoffice("zzz", "all", null, PageRequest.of(0, 10)).getTotalElements())
 				.isZero();
 	}
 
 	@Test
 	@DisplayName("rating을 주면 해당 별점만, q와 함께도 동작한다")
 	void searchForBackoffice_filtersByRating() {
-		assertThat(ratingRepository.searchForBackoffice(null, 5, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(ratingRepository.searchForBackoffice(null, "all", 5, PageRequest.of(0, 10)).getTotalElements())
 				.isEqualTo(2);
-		assertThat(names(ratingRepository.searchForBackoffice("던짐", 2, PageRequest.of(0, 10)).getContent()))
+		assertThat(names(ratingRepository.searchForBackoffice("던짐", "all", 2, PageRequest.of(0, 10)).getContent()))
 				.containsExactly("Gumayusi");
 		// q와 rating이 서로 다른 행을 가리키면 결과 없음
-		assertThat(ratingRepository.searchForBackoffice("던짐", 5, PageRequest.of(0, 10)).getTotalElements())
+		assertThat(ratingRepository.searchForBackoffice("던짐", "all", 5, PageRequest.of(0, 10)).getTotalElements())
 				.isZero();
+	}
+
+	@Test
+	@DisplayName("field 로 검색 대상을 좁힌다 (player|member|comment)")
+	void searchForBackoffice_scopesByField() {
+		// "Faker" 는 선수명에만 있다 → member/comment 스코프면 0건
+		assertThat(ratingRepository.searchForBackoffice("Faker", "player", null, PageRequest.of(0, 10))
+				.getTotalElements()).isEqualTo(2);
+		assertThat(ratingRepository.searchForBackoffice("Faker", "member", null, PageRequest.of(0, 10))
+				.getTotalElements()).isZero();
+		assertThat(ratingRepository.searchForBackoffice("Faker", "comment", null, PageRequest.of(0, 10))
+				.getTotalElements()).isZero();
+
+		// "팬" 은 작성자 닉네임에만 있다
+		assertThat(ratingRepository.searchForBackoffice("팬", "member", null, PageRequest.of(0, 10))
+				.getTotalElements()).isEqualTo(3);
+		assertThat(ratingRepository.searchForBackoffice("팬", "player", null, PageRequest.of(0, 10))
+				.getTotalElements()).isZero();
+
+		// 한줄평 스코프 + 닉네임 태그(#) 검색
+		assertThat(names(ratingRepository.searchForBackoffice("캐리", "comment", null, PageRequest.of(0, 10))
+				.getContent())).containsExactly("Faker");
+		assertThat(ratingRepository.searchForBackoffice("#5678", "member", null, PageRequest.of(0, 10))
+				.getTotalElements()).isEqualTo(2);
 	}
 
 	private static List<String> names(List<LivePlayerRating> rows) {


### PR DESCRIPTION
## 무엇을

모바일에서 작성된 선수 리뷰(`live_player_rating` — 별점 1~5 + 한줄평 150자)를 운영자가 백오피스에서 확인하고 부적절한 한줄평을 삭제할 수 있도록 admin API를 추가한다.

- `GET /api/admin/ratings` — `q`(선수명·회원명·한줄평 부분일치), `rating`(별점 정확일치) 필터, Spring `Page` 반환
- `DELETE /api/admin/ratings/{id}` — 없는 id는 404(기존 `NoSuchElementException` 핸들러 재사용)

## 구현 메모

- `member` 는 join fetch(행마다 닉네임 필요), count 는 fetch 없이 별도 쿼리로 지정
- 스키마 변경 없음 (마이그레이션 없음)

## 검증

- `./gradlew test --tests "com.toy.nar.domain.rating.repository.LivePlayerRatingSearchTest"` 통과 (q null/부분일치 3종·별점 필터·q+별점 조합)
- 로컬 부팅 후 실제 호출은 미검증

프론트: warding-backoffice-fe `feat/ratings-page`

🤖 Generated with [Claude Code](https://claude.com/claude-code)