### PR TITLE
fix: 해외 플랫폼(NA/EUW) 솔랭 계정 선수도 구독 목록에 노출

### DIFF
--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -121,6 +121,11 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	 *
 	 * <p>윈도우 함수와 파생 테이블을 쓰기 위해 네이티브 쿼리로 작성했다. 컬럼 별칭은
 	 * {@link LckPlayerOption} 프로젝션 게터명과 일치시킨다.
+	 *
+	 * <p>UNION ALL 분기(해당 리그 미출전 + 계정 보유)에는 플랫폼 조건을 걸지 않는다. 예전엔
+	 * {@code platform = 'KR'}이 있어 해외 리그 선수의 NA/EUW 계정이 목록에서 빠졌다
+	 * (라이브 감지는 플랫폼 무관인데 구독 자체가 불가능한 모순). 자격은 {@code enabled}·
+	 * {@code primary_account}만으로 판단한다.
 	 */
 	@Query(
 			value = """
@@ -162,7 +167,6 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 						JOIN player_riot_account pra ON pra.player_id = p.player_id
 						WHERE pra.enabled = true
 						  AND pra.primary_account = true
-						  AND pra.platform = 'KR'
 						  AND NOT EXISTS (
 							  SELECT 1 FROM game_participants gp2
 							  JOIN games g2 ON gp2.game_id = g2.game_id
@@ -212,7 +216,6 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 						JOIN player_riot_account pra ON pra.player_id = p.player_id
 						WHERE pra.enabled = true
 						  AND pra.primary_account = true
-						  AND pra.platform = 'KR'
 						  AND NOT EXISTS (
 							  SELECT 1 FROM game_participants gp2
 							  JOIN games g2 ON gp2.game_id = g2.game_id
@@ -316,7 +319,6 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			JOIN player_riot_account pra ON pra.player_id = p.player_id
 			WHERE pra.enabled = true
 			  AND pra.primary_account = true
-			  AND pra.platform = 'KR'
 			  AND p.player_id IN (:playerIds)
 			""", nativeQuery = true)
 	List<LckPlayerOption> findSoloRankPlayerOptionsByPlayerIds(@Param("playerIds") Set<Long> playerIds);

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -159,6 +161,28 @@ class PlayerRepositoryLckPlayerOptionsTest {
 				.orElseThrow();
 		assertThat(deft.getTeamId()).isNull();
 		assertThat(deft.getTeamName()).isNull();
+	}
+
+	@Test
+	@DisplayName("해외 플랫폼(NA1) 주계정 선수도 목록에 포함된다")
+	void includesNonKrPlatformSoloRankPlayer() {
+		// 해외 리그로 이적한 선수는 계정이 NA/EUW로 저장된다. 예전엔 platform='KR' 조건 때문에
+		// 라이브 감지는 되는데 구독 목록에는 안 뜨는 모순이 있었다.
+		exec(player(10, "Quad", "Mid"));
+		exec("INSERT INTO player_riot_account"
+				+ " (id, player_id, riot_id, game_name, tag_line, platform, puuid, primary_account, enabled,"
+				+ " live_status, created_at, updated_at)"
+				+ " VALUES (100, 10, 'FLY Quad#123', 'FLY Quad', '123', 'NA1', 'puuid-quad', true, true,"
+				+ " 'OFFLINE', '2026-01-01 00:00:00', '2026-01-01 00:00:00')");
+		em.flush();
+		em.clear();
+
+		Page<LckPlayerOption> page = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, null, PageRequest.of(0, 50));
+
+		assertThat(page.getContent()).extracting(LckPlayerOption::getPlayerName).contains("Quad");
+		assertThat(playerRepository.findSoloRankPlayerOptionsByPlayerIds(Set.of(10L)))
+				.extracting(LckPlayerOption::getPlayerName).containsExactly("Quad");
 	}
 
 	@Test


### PR DESCRIPTION
## 문제

`Quad`(Flyquest, `FLY Quad#123`, NA1) 계정을 부착했는데 앱 구독 검색에 안 뜬다.

구독 가능 선수 조회의 UNION ALL 분기(해당 리그 미출전 + 계정 보유)에 `pra.platform = 'KR'` 조건이 박혀 있어 해외 리그 이적 선수의 NA/EUW 계정이 전부 탈락했다. 실시간 라이브 감지는 `findAllTrackedAccounts`로 플랫폼 무관이라 **감지는 되는데 구독은 불가능한** 모순 상태였다.

## 변경

`PlayerRepository`에서 platform 조건 3곳 제거. 자격은 `enabled`·`primary_account`만으로 판단한다.

- `findLckPlayerOptions` 본쿼리
- `findLckPlayerOptions` countQuery
- `findSoloRankPlayerOptionsByPlayerIds` (구독 표시/검증 병합용)

`findSoloRankSyncTargets`의 `platform = 'KR'`은 **유지**했다. 일일 sync가 크롤링된 `game_accounts`를 `extractPrimaryKrAccount`로 재해석하는 경로라 기존 ⚠️ 주석(조건 없으면 비활성 계정이 되살아나는 버그)이 그대로 유효하다.

## 검증

```
./gradlew test --tests "...PlayerRepositoryLckPlayerOptionsTest"   → 9 tests, 0 fail
./gradlew test --tests "...mobile.subscription.*"                  → 17 tests, 0 fail
```

NA1 주계정 선수가 목록·병합 조회 양쪽에 뜨는 테스트를 추가했다.

로컬(프로덕션 데이터 사본)에서 비-KR 주계정 보유자 4명(Hype·Way·Paduck EUW1, Contractz NA1) 전부 LCK 2026 미출전 → 이 수정으로 UNION 분기에 편입되는 것을 확인했다.

## 프로덕션 영향

배포 후 구독 검색에 새로 노출되는 선수: **Quad(NA1) + Hype·Way·Paduck(EUW1) + Contractz(NA1)**. 기존 KR 계정 선수 노출은 변화 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)