### PR TITLE
feat: 스케줄러 전역 스위치 추가 — 로컬은 기본 OFF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ RIOT_MONITOR_ENABLED, RIOT_API_ENABLED   # feature flags for scheduling
 JWT_SECRET
 ```
 
+### 스케줄러 전역 스위치
+
+`app.scheduling.enabled` (env `APP_SCHEDULING_ENABLED`)가 모든 `@Scheduled` 등록을 좌우한다(`SchedulerConfig`).
+**prod 프로파일만 ON**이고, 로컬(`dev`)은 값이 없으므로 OFF다. 로컬 DB가 prod 데이터 사본이고
+YouTube/Riot API 키, Discord 웹훅, FCM 자격증명을 prod와 공유하기 때문에 로컬 폴링이 prod의
+API 쿼터를 태우거나 prod 채널·실유저에게 알림을 보낼 수 있다.
+
+로컬에서 스케줄 로직을 확인해야 하면 개별 잡은 백오피스 수동 트리거 API를 쓰고,
+스케줄러 자체를 검증할 때만 `app.scheduling.enabled=true`로 켠다(공유 자원 영향 확인 후).
+
 ## CI/CD
 
 GitHub Actions (`.github/workflows/deploy.yml`): Gradle build → Docker image → push to Docker Hub → SSH deploy to EC2 → health check against `/v3/api-docs`. Production logs viewable via Dozzle at `https://api.nar.kr/dozzle`.

--- a/src/main/java/com/toy/nar/app/youtube/YoutubeSubscriptionManager.java
+++ b/src/main/java/com/toy/nar/app/youtube/YoutubeSubscriptionManager.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.youtube;
 
 import com.toy.nar.app.monitor.SchedulerAlertService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
@@ -11,9 +12,15 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 구독 갱신은 {@code @Scheduled} 외에 기동 직후 {@link ApplicationReadyEvent} 로도 돈다.
+ * 스케줄러 전역 스위치({@code app.scheduling.enabled})만으로는 기동 시점 호출을 막을 수 없어 빈 자체를 같은 조건으로 묶는다.
+ * 로컬에서는 콜백 URL이 로컬/터널 주소라 등록해도 쓸모없는 구독만 남는다.
+ */
 @Slf4j
 @Component
 @Profile("!benchmark")
+@ConditionalOnProperty(prefix = "app.scheduling", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class YoutubeSubscriptionManager {
 

--- a/src/main/java/com/toy/nar/config/SchedulerConfig.java
+++ b/src/main/java/com/toy/nar/config/SchedulerConfig.java
@@ -1,5 +1,6 @@
 package com.toy.nar.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -9,8 +10,18 @@ import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
+/**
+ * 스케줄러 전역 스위치. 이 설정이 안 뜨면 애플리케이션의 모든 {@code @Scheduled} 가 등록되지 않는다.
+ *
+ * <p>기본값 OFF. prod 프로파일(application-prod.yml)에서만 app.scheduling.enabled=true 로 켠다.
+ * 로컬은 DB가 prod 데이터 사본이고 YouTube/Riot API 키·Discord 웹훅·FCM 자격증명을 prod와 공유하기 때문에,
+ * 로컬에서 스케줄러가 돌면 prod의 API 쿼터를 태우거나 prod 채널·실유저에게 알림이 나갈 수 있다.
+ * 로컬에서 스케줄러를 검증해야 하면 app.scheduling.enabled=true 로 켠다(공유 자원 영향 확인 후).
+ * 개별 잡 단위 검증은 백오피스 수동 트리거 API를 쓰면 스케줄러를 켜지 않아도 된다.
+ */
 @Configuration
 @Profile("!benchmark")
+@ConditionalOnProperty(prefix = "app.scheduling", name = "enabled", havingValue = "true")
 @EnableScheduling
 public class SchedulerConfig implements SchedulingConfigurer {
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -98,6 +98,10 @@ app:
     url: "https://api.nar.kr"
   frontend-url: ${FRONTEND_URL:https://nar.kr}
   mobile-redirect-url: ${MOBILE_REDIRECT_URL:nar://oauth/callback}
+  scheduling:
+    # 스케줄러 전역 스위치(SchedulerConfig). prod 만 ON, 그 외 프로파일은 값이 없으므로 OFF.
+    # 로컬에서 끄는 이유: API 키·웹훅·FCM 자격증명을 prod와 공유해서 로컬 폴링이 prod 쿼터/알림에 그대로 반영된다.
+    enabled: ${APP_SCHEDULING_ENABLED:true}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/com/toy/nar/config/SchedulerConfigTest.java
+++ b/src/test/java/com/toy/nar/config/SchedulerConfigTest.java
@@ -1,0 +1,46 @@
+package com.toy.nar.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+/**
+ * 스케줄러 전역 스위치가 실제로 스케줄링 등록을 좌우하는지 검증.
+ * app.scheduling.enabled 가 없으면(로컬 기본) SchedulerConfig 자체가 뜨지 않아야 한다.
+ */
+class SchedulerConfigTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(SchedulerConfig.class);
+
+	@Test
+	@DisplayName("app.scheduling.enabled 미설정이면 스케줄러 설정이 로드되지 않는다")
+	void schedulingDisabledByDefault() {
+		contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean(SchedulerConfig.class);
+			assertThat(context).doesNotHaveBean(ScheduledTaskRegistrar.class);
+		});
+	}
+
+	@Test
+	@DisplayName("app.scheduling.enabled=false 면 스케줄러 설정이 로드되지 않는다")
+	void schedulingDisabledExplicitly() {
+		contextRunner
+				.withPropertyValues("app.scheduling.enabled=false")
+				.run(context -> assertThat(context).doesNotHaveBean(SchedulerConfig.class));
+	}
+
+	@Test
+	@DisplayName("app.scheduling.enabled=true 면 스케줄러 설정과 TaskScheduler 가 로드된다")
+	void schedulingEnabled() {
+		contextRunner
+				.withPropertyValues("app.scheduling.enabled=true")
+				.run(context -> {
+					assertThat(context).hasSingleBean(SchedulerConfig.class);
+					assertThat(context).hasBean("taskScheduler");
+				});
+	}
+}


### PR DESCRIPTION
## 문제

`dev` 프로파일의 스케줄러 플래그가 prod와 동일하게 전부 ON이라, 로컬 서버를 띄우는 동안 prod에 직접 영향이 갔다. 로컬 부팅만으로 라이브 폴링(10초), 솔랭 모니터·디스커버리·유저 활동(60초), gol.gg 스크래핑(5분), 유튜브/커뮤니티 동기화(10분·1시간)가 전부 돌았다.

공유 자원 경로:

| 자원 | 영향 |
|---|---|
| YouTube API 키 (prod와 동일) | 일일 쿼터 10,000 units 공유. 로컬이 동일 스케줄을 중복 소비 → prod 유튜브 동기화가 쿼터 소진으로 **조용히 실패** |
| Riot 키 | 로컬에 prod 키 주입 시 60초 폴링이 rate limit 공유 → prod 429 |
| Discord 웹훅 | prod 채널에 로컬 실패 알림 + 09시 데일리 요약 중복 발송 |
| FCM + 로컬 DB(prod 사본) | `member_device`에 실기기 토큰. `FIREBASE_MESSAGING_ENABLED=true` 한 번이면 실유저 푸시 |
| YouTube PubSub | 기동마다 터널 콜백으로 쓸모없는 구독 등록 |

기존에는 전역 스위치가 없어 플래그를 6~8개 개별로 꺼야 했고, `@EnableScheduling`은 `@Profile("!benchmark")` 외에 조건이 없었다.

## 변경

- `SchedulerConfig`에 `@ConditionalOnProperty(prefix = "app.scheduling", name = "enabled", havingValue = "true")`. 이 설정이 안 뜨면 `@Scheduled` 등록 자체가 없다.
- 기본값 OFF로 잡았다(`matchIfMissing` 없음). prod 프로파일만 `app.scheduling.enabled: \${APP_SCHEDULING_ENABLED:true}`로 ON이라, 새 개발 환경도 별도 설정 없이 안전하다. `application-dev.yml`이 gitignore 대상이라 로컬 파일에 의존하는 방식은 머신마다 재발한다.
- `YoutubeSubscriptionManager`는 `@Scheduled`가 아닌 `ApplicationReadyEvent`로도 돌아서 빈 자체를 같은 조건으로 묶었다.
- `CLAUDE.md`에 스위치 설명 추가.

## prod 영향

없음. `application-prod.yml`에서 `true`이므로 스케줄 동작 동일. 배포 env 변경 불필요(`APP_SCHEDULING_ENABLED`로 끌 수는 있음).

## 검증

- `SchedulerConfigTest` 3케이스 통과 — 미설정/false면 `SchedulerConfig`·`ScheduledTaskRegistrar` 미생성, true면 `taskScheduler` 생성.
- 로컬 `bootRun`(dev, MySQL 3308) 기동 후 95초 관찰: 기동 완료 이후 로그 라인 증가 0, `[Scheduler]`/`PubSub`/폴링 로그 0건. 기동 자체는 정상(`Started NarApplication in 19.6s`).
- 개별 잡 검증 경로는 `BackofficeController` 수동 트리거로 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)