### PR TITLE
fix: 커뮤니티 동기화 크롤링을 트랜잭션 밖으로 분리

### DIFF
--- a/src/main/java/com/toy/nar/app/community/CommunityService.java
+++ b/src/main/java/com/toy/nar/app/community/CommunityService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -25,79 +26,85 @@ public class CommunityService {
 	private final NaverNewsService naverNewsService;
 	private final CommunityPostRepository communityPostRepository;
 	private final NewsPostRepository newsPostRepository;
+	private final TransactionTemplate transactionTemplate;
 
 	/**
 	 * 모든 커뮤니티 및 뉴스를 동기화합니다.
+	 *
+	 * 크롤링(Jsoup)은 트랜잭션 밖에서 수행하고, DB 쓰기 구간만 짧게 트랜잭션으로 감싼다.
+	 * 예전엔 이 메서드 전체가 @Transactional 이라 외부 사이트 응답이 느리면
+	 * 커넥션 1개와 community/news 테이블 락을 최대 수십 초씩 붙잡아
+	 * 10분 주기로 서비스 전체 응답이 튀었다.
 	 */
-	@Transactional
 	public void syncAll(String sortType) {
 		syncAllCommunities(sortType);
 		syncNaverNews(sortType);
 	}
 
-	@Transactional
 	public void syncAllCommunities(String sortType) {
 		syncOpgg(sortType);
 		syncInven(sortType);
 		syncNaver(sortType);
 	}
 
-	@Transactional
 	public void syncNaverNews(String sortType) {
 		naverNewsService.syncNaverNews(sortType);
 	}
 
-	@Transactional
 	public void syncOpgg(String sortType) {
 		List<OpggPostDto> posts = opggParserService.parseEsportsPosts(sortType);
-		for (OpggPostDto dto : posts) {
-			saveOrUpdate(
-				CommunityType.OPGG,
-				dto.getTitle(),
-				dto.getAuthor(),
-				dto.getPostUrl(),
-				dto.getCreatedAt(),
-				dto.getViewCount(),
-				dto.getVoteCount(),
-				dto.getCommentCount()
-			);
-		}
+		transactionTemplate.executeWithoutResult(status -> {
+			for (OpggPostDto dto : posts) {
+				saveOrUpdate(
+					CommunityType.OPGG,
+					dto.getTitle(),
+					dto.getAuthor(),
+					dto.getPostUrl(),
+					dto.getCreatedAt(),
+					dto.getViewCount(),
+					dto.getVoteCount(),
+					dto.getCommentCount()
+				);
+			}
+		});
 		log.info("Synced {} OP.GG posts ({})", posts.size(), sortType);
 	}
 
-	@Transactional
 	public void syncInven(String sortType) {
 		List<InvenPostDto> posts = invenParserService.parseInvenPosts(sortType);
-		for (InvenPostDto dto : posts) {
-			saveOrUpdate(
-				CommunityType.INVEN,
-				dto.getTitle(),
-				dto.getAuthor(),
-				dto.getPostUrl(),
-				dto.getCreatedAt(),
-				dto.getViewCount(),
-				dto.getVoteCount(),
-				dto.getCommentCount()
-			);
-		}
+		transactionTemplate.executeWithoutResult(status -> {
+			for (InvenPostDto dto : posts) {
+				saveOrUpdate(
+					CommunityType.INVEN,
+					dto.getTitle(),
+					dto.getAuthor(),
+					dto.getPostUrl(),
+					dto.getCreatedAt(),
+					dto.getViewCount(),
+					dto.getVoteCount(),
+					dto.getCommentCount()
+				);
+			}
+		});
 		log.info("Synced {} Inven posts ({})", posts.size(), sortType);
 	}
 
-	@Transactional
 	public void syncNaver(String sortType) {
 		List<NaverPostDto> posts = naverParserService.parseNaverPosts(sortType);
-		for (NaverPostDto dto : posts) {
-			saveOrUpdate(
-				CommunityType.NAVER,
-				dto.getTitle(),
-				dto.getAuthor(),
-				dto.getPostUrl(),
-				dto.getCreatedAt(),
-				dto.getViewCount(),
-				dto.getVoteCount(),
-				dto.getCommentCount()
-			);
-		}
+		transactionTemplate.executeWithoutResult(status -> {
+			for (NaverPostDto dto : posts) {
+				saveOrUpdate(
+					CommunityType.NAVER,
+					dto.getTitle(),
+					dto.getAuthor(),
+					dto.getPostUrl(),
+					dto.getCreatedAt(),
+					dto.getViewCount(),
+					dto.getVoteCount(),
+					dto.getCommentCount()
+				);
+			}
+		});
 		log.info("Synced {} Naver posts ({})", posts.size(), sortType);
 	}
 

--- a/src/main/java/com/toy/nar/app/community/InvenParserService.java
+++ b/src/main/java/com/toy/nar/app/community/InvenParserService.java
@@ -13,6 +13,9 @@ import java.util.List;
 @Service
 public class InvenParserService {
 
+	// Jsoup 기본 타임아웃은 30초 — 외부 사이트가 멈추면 스케줄러가 그만큼 매달린다.
+	private static final int CRAWL_TIMEOUT_MS = 5000;
+
 	public List<InvenPostDto> parseInvenPosts(String sortType) {
 		List<InvenPostDto> postList = new ArrayList<>();
 		// 롤 인벤 e스포츠 게시판
@@ -27,6 +30,7 @@ public class InvenParserService {
 			Document doc = Jsoup.connect(url)
 				.userAgent(
 					"Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1")
+				.timeout(CRAWL_TIMEOUT_MS)
 				.get();
 
 			// 게시글 리스트 아이템 추출

--- a/src/main/java/com/toy/nar/app/community/NaverNewsService.java
+++ b/src/main/java/com/toy/nar/app/community/NaverNewsService.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -24,15 +24,20 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class NaverNewsService {
 
+	private static final int CRAWL_TIMEOUT_MS = 5000;
+
 	private final ObjectMapper objectMapper;
 	private final NewsPostRepository newsPostRepository;
+	private final TransactionTemplate transactionTemplate;
 
-	@Transactional
+	/** 네이버 API 호출은 트랜잭션 밖, DB 쓰기 루프만 트랜잭션 안. */
 	public void syncNaverNews(String sortType) {
 		List<NaverNewsDto> newsList = parseNaverNews(sortType);
-		for (NaverNewsDto dto : newsList) {
-			saveOrUpdate(dto);
-		}
+		transactionTemplate.executeWithoutResult(status -> {
+			for (NaverNewsDto dto : newsList) {
+				saveOrUpdate(dto);
+			}
+		});
 		log.info("Synced {} Naver news ({})", newsList.size(), sortType);
 	}
 
@@ -47,6 +52,8 @@ public class NaverNewsService {
 			String jsonResponse = Jsoup.connect(url)
 				.ignoreContentType(true)
 				.userAgent("Mozilla/5.0")
+				// Jsoup 기본 타임아웃은 30초 — 외부 사이트가 멈추면 스케줄러가 그만큼 매달린다.
+				.timeout(CRAWL_TIMEOUT_MS)
 				.execute()
 				.body();
 

--- a/src/main/java/com/toy/nar/app/community/NaverParserService.java
+++ b/src/main/java/com/toy/nar/app/community/NaverParserService.java
@@ -18,6 +18,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NaverParserService {
 
+	// Jsoup 기본 타임아웃은 30초 — 외부 사이트가 멈추면 스케줄러가 그만큼 매달린다.
+	private static final int CRAWL_TIMEOUT_MS = 5000;
+
 	private final ObjectMapper objectMapper;
 
 	public List<NaverPostDto> parseNaverPosts(String sortType) {
@@ -40,6 +43,7 @@ public class NaverParserService {
 			String jsonResponse = Jsoup.connect(url)
 				.ignoreContentType(true)
 				.userAgent("Mozilla/5.0")
+				.timeout(CRAWL_TIMEOUT_MS)
 				.execute()
 				.body();
 

--- a/src/main/java/com/toy/nar/app/community/OpggParserService.java
+++ b/src/main/java/com/toy/nar/app/community/OpggParserService.java
@@ -14,6 +14,9 @@ import java.util.List;
 @Service
 public class OpggParserService {
 
+	// Jsoup 기본 타임아웃은 30초 — 외부 사이트가 멈추면 스케줄러가 그만큼 매달린다.
+	private static final int CRAWL_TIMEOUT_MS = 5000;
+
 	private final ObjectMapper objectMapper;
 
 	public OpggParserService(ObjectMapper objectMapper) {
@@ -34,6 +37,7 @@ public class OpggParserService {
 			// 1. Jsoup으로 HTML 가져오기 (User-Agent 설정은 필수)
 			Document doc = Jsoup.connect(url)
 				.userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+				.timeout(CRAWL_TIMEOUT_MS)
 				.get();
 
 			// 2. __NEXT_DATA__ 스크립트 태그 찾기

--- a/src/test/java/com/toy/nar/app/community/CommunitySyncTransactionBoundaryTest.java
+++ b/src/test/java/com/toy/nar/app/community/CommunitySyncTransactionBoundaryTest.java
@@ -1,0 +1,68 @@
+package com.toy.nar.app.community;
+
+import com.toy.nar.app.community.repository.CommunityPostRepository;
+import com.toy.nar.app.community.repository.NewsPostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 크롤링이 트랜잭션 밖에서 일어나는지 지키는 회귀 테스트.
+ *
+ * 예전엔 syncAll 전체가 @Transactional 이라 외부 사이트 응답이 느리면
+ * DB 커넥션과 테이블 락을 최대 수십 초 붙잡아 서비스 응답이 튀었다.
+ */
+class CommunitySyncTransactionBoundaryTest {
+
+	private final OpggParserService opggParser = mock(OpggParserService.class);
+	private final InvenParserService invenParser = mock(InvenParserService.class);
+	private final NaverParserService naverParser = mock(NaverParserService.class);
+	private final NaverNewsService naverNewsService = mock(NaverNewsService.class);
+	private final CommunityPostRepository postRepository = mock(CommunityPostRepository.class);
+	private final NewsPostRepository newsPostRepository = mock(NewsPostRepository.class);
+	private final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+
+	private final CommunityService service = new CommunityService(
+			opggParser, invenParser, naverParser, naverNewsService,
+			postRepository, newsPostRepository, transactionTemplate);
+
+	@Test
+	@DisplayName("크롤링은 트랜잭션이 열리기 전에 끝난다")
+	void 크롤링은_트랜잭션_밖에서_수행된다() {
+		when(opggParser.parseEsportsPosts("latest")).thenReturn(List.of());
+
+		service.syncOpgg("latest");
+
+		// 파싱이 먼저, 그 다음에야 트랜잭션이 열려야 한다.
+		var order = inOrder(opggParser, transactionTemplate);
+		order.verify(opggParser).parseEsportsPosts("latest");
+		order.verify(transactionTemplate).executeWithoutResult(any());
+		order.verifyNoMoreInteractions();
+	}
+
+	@Test
+	@DisplayName("동기화 메서드에 @Transactional 이 다시 붙지 않았다")
+	void 동기화_메서드는_선언적_트랜잭션을_쓰지_않는다() throws NoSuchMethodException {
+		for (String methodName : List.of(
+				"syncAll", "syncAllCommunities", "syncNaverNews", "syncOpgg", "syncInven", "syncNaver")) {
+			assertThat(CommunityService.class.getMethod(methodName, String.class)
+					.getAnnotation(Transactional.class))
+					.as("CommunityService.%s 는 @Transactional 이면 크롤링이 트랜잭션에 갇힌다", methodName)
+					.isNull();
+		}
+
+		assertThat(NaverNewsService.class.getMethod("syncNaverNews", String.class)
+				.getAnnotation(Transactional.class))
+				.as("NaverNewsService.syncNaverNews 는 @Transactional 이면 API 호출이 트랜잭션에 갇힌다")
+				.isNull();
+	}
+}


### PR DESCRIPTION
## 문제

와탭 히트맵에서 응답시간 스파이크(최대 5s+, 평균 응답 봉우리 30s)가 반복 관측됨. CPU 19%, 힙 369MB로 자원 여유가 있는데도 동시 요청이 한꺼번에 느려지는 큐잉 패턴 — 커넥션/락 대기로 판단.

원인: `CommunityService.syncAll` 전체가 `@Transactional` 이고, 그 안에서 Jsoup 크롤링이 실행된다.

- `Jsoup.connect()` 타임아웃 미지정 → **기본 30초**
- `syncAll` 은 latest·popular 2회 × (opgg, 인벤, 네이버) + 네이버 뉴스를 순차 호출
- 최악의 경우 DB 커넥션 1개 + `community_post`/`news_post` 락을 **100초 이상** 점유
- 크론 `0 0/10 * * * *` → 매 10분 `:00`에 발사. 관측된 스파이크 시각과 일치
- prod `hikari.maximum-pool-size` 미설정(기본 10)이라 그 구간에 사용자 요청이 같이 대기

## 변경

- 동기화 메서드 6개에서 `@Transactional` 제거. 크롤링은 트랜잭션 밖, DB 쓰기 루프만 `TransactionTemplate` 으로 짧게 감쌈
  - `syncOpgg`/`syncInven`/`syncNaver` 는 `syncAllCommunities` 에서 자기 호출되므로 기존 내부 `@Transactional` 은 프록시를 안 타서 사실상 무의미했음. 실제로 트랜잭션을 여는 건 최외곽 `syncAll` 하나였다
- Jsoup 타임아웃 4개 크롤러 모두 `5000ms` 명시
- 회귀 테스트 추가
  - 파싱이 트랜잭션 개시보다 먼저 끝나는지 (`inOrder`)
  - 동기화 메서드에 `@Transactional` 이 다시 붙지 않았는지 (리플렉션)

`TransactionTemplate` 은 Spring Boot `TransactionAutoConfiguration` 이 제공하는 빈을 주입. 이 프로젝트엔 커스텀 `PlatformTransactionManager` 빈 정의가 없어 `@ConditionalOnSingleCandidate` 조건이 성립함(3.5.3 jar에서 확인).

## 검증

```
./gradlew test --tests "com.toy.nar.app.community.*"   # BUILD SUCCESSFUL
./gradlew build -x test                                 # BUILD SUCCESSFUL
```

역검증: `syncOpgg` 에 `@Transactional` 을 다시 붙이면 테스트가 FAILED 되는 것 확인 후 되돌림.

`NarApplicationTests`(풀 컨텍스트)는 로컬 gitignore 설정 의존이라 스킵됨 — 실제 기동 검증은 안 됐다. 배포 후 컨테이너 기동 로그 확인 필요.

## 후속 (별건)

- 워밍업 스크립트가 사실상 no-op — `DUMMY` gameId는 `requireState`에서 404로 즉시 탈출해 JPA/캐시 경로를 안 데운다
- `hikari.maximum-pool-size` 미설정 → 실측 후 판단. 이 PR로 압력이 사라지면 안 건드리는 게 맞음
- 블루/그린 겹침 구간에 양쪽 컨테이너가 스케줄러를 동시에 돈다 (리더 선출 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)