### PR TITLE
feat: 다전제 규격(bestOf) 저장 + 미래 일정 페이지 추적

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -40,6 +40,8 @@ import java.util.stream.Collectors;
 public class LeagueMatchService {
 
 	private static final String LOLESPORTS_SOURCE = "LOLESPORTS";
+	/** 미래(newer) 페이지 추적 상한. 실측상 리그당 1홉이면 끝나지만 시즌 편성이 길어질 때를 대비한 안전장치다. */
+	private static final int MAX_NEWER_PAGE_HOPS = 5;
 	private static final Map<String, String> TEAM_ALIAS_TARGETS_BY_EXTERNAL_ID = Map.of(
 			"107700204561086446", "Deep Cross Gaming",
 			"99566406332987990", "Chiefs Esports Club",
@@ -209,6 +211,45 @@ public class LeagueMatchService {
 		log.info("Synced {} matches for league: {} (inserted={}, updated={}, skipped={})",
 				matches.size(), leagueSlug, upsertResult.insertedMatches(), upsertResult.updatedMatches(),
 				upsertResult.skippedMatches());
+
+		syncNewerPages(leagueSlug, response.getNewerPageToken());
+	}
+
+	/**
+	 * 기본 페이지 창 밖의 미래 경기를 따라간다.
+	 *
+	 * <p>기본 페이지는 과거~가까운 미래까지만 담는다. getSchedule 은 커서 페이지네이션이고 기존 sync 는 {@code pages.older} 만 따라갔다.
+	 * 그래서 창 밖 미래 일정(LCK 플레이오프·결승, LPL 정규 잔여+플레이오프 등)이 DB 에 아예 없었다.
+	 * 여기서는 upsert 만 한다 — 아직 시작도 안 한 경기에는 매핑할 게임이 없어
+	 * autoBackfill 을 태우면 매 sync 마다 헛된 getEventDetails 호출만 쌓인다.</p>
+	 */
+	private void syncNewerPages(String leagueSlug, String startToken) {
+		String token = startToken;
+		Set<String> visitedTokens = new java.util.LinkedHashSet<>();
+		int hops = 0;
+
+		while (token != null && !token.isBlank() && hops < MAX_NEWER_PAGE_HOPS && visitedTokens.add(token)) {
+			hops++;
+			try {
+				MatchResponseWrapper page = worldsService.getWorldsMatches(token, leagueSlug);
+				List<MatchResultDto> matches = page.getMatches();
+				if (matches == null || matches.isEmpty()) {
+					break;
+				}
+				MatchSyncUpsertResult result = upsertLeagueMatches(leagueSlug, matches);
+				log.info("Synced newer page {} for league: {} ({} matches, inserted={}, updated={}, skipped={})",
+						hops, leagueSlug, matches.size(), result.insertedMatches(), result.updatedMatches(),
+						result.skippedMatches());
+				token = page.getNewerPageToken();
+			} catch (Exception e) {
+				log.warn("Failed to sync newer page {} for league={}: {}", hops, leagueSlug, e.getMessage());
+				return;
+			}
+		}
+		if (hops >= MAX_NEWER_PAGE_HOPS) {
+			log.warn("Newer page hop limit reached for league={} (limit={}) — 남은 미래 페이지는 다음 sync 에서 따라간다.",
+					leagueSlug, MAX_NEWER_PAGE_HOPS);
+		}
 	}
 
 	public RecentMatchBackfillResult backfillRecentMatches(String leagueSlug, boolean includeTeamMetadataSync) {
@@ -812,12 +853,18 @@ public class LeagueMatchService {
 				}
 
 				if (!hasRealtimeRelevantChange(existing, incoming)) {
-					// 시즌만 비어 있으면 채운다 (dirtyMatchIds에는 넣지 않아 게임 ID 재동기화는 트리거하지 않음)
+					// 시즌·bestOf 만 비어 있으면 채운다 (dirtyMatchIds에는 넣지 않아 게임 ID 재동기화는 트리거하지 않음)
+					boolean filled = false;
 					if (existing.getSeasonYear() == null) {
 						applySeasonIfResolvable(existing);
-						if (existing.getSeasonYear() != null) {
-							dirtyMatches.add(existing);
-						}
+						filled = existing.getSeasonYear() != null;
+					}
+					if (existing.getBestOf() == null && incoming.getBestOf() != null) {
+						existing.applyBestOf(incoming.getBestOf());
+						filled = true;
+					}
+					if (filled) {
+						dirtyMatches.add(existing);
 					}
 					skipped++;
 					continue;
@@ -841,6 +888,7 @@ public class LeagueMatchService {
 						incoming.isHasVod(),
 						incoming.getMatchDetailsJson(),
 						incoming.getLastUpdated());
+				existing.applyBestOf(incoming.getBestOf());
 				applySeasonIfResolvable(existing);
 				dirtyMatches.add(existing);
 				dirtyMatchIds.add(existing.getId());
@@ -1103,6 +1151,7 @@ public class LeagueMatchService {
 				.redTeamCode(dto.getRedTeam().getCode()).redTeamName(dto.getRedTeam().getName())
 				.redExternalTeamId(dto.getRedTeam().getExternalTeamId())
 				.redTeamImageUrl(dto.getRedTeam().getImageUrl()).redScore(dto.getRedTeam().getWins()).hasVod(hasVod)
+				.bestOf(dto.getBestOf())
 				.matchDetailsJson(jsonDetails).lastUpdated(LocalDateTime.now()).build();
 	}
 
@@ -1134,6 +1183,7 @@ public class LeagueMatchService {
 																								// string
 				.state(entity.getState()) // [수정] Entity 상태 DTO로 전달
 				.score(entity.getBlueScore() + " : " + entity.getRedScore())
+				.bestOf(entity.getBestOf())
 				.blueTeam(
 						MatchResultDto.TeamInfo.builder()
 								.externalTeamId(entity.getBlueExternalTeamId())

--- a/src/main/java/com/toy/nar/app/lolesports/MatchResponseWrapper.java
+++ b/src/main/java/com/toy/nar/app/lolesports/MatchResponseWrapper.java
@@ -9,4 +9,5 @@ import java.util.List;
 public class MatchResponseWrapper {
 	private List<MatchResultDto> matches; // 경기 데이터 리스트
 	private String nextPageToken;         // 다음 페이지를 불러올 암호키 (older)
+	private String newerPageToken;        // 더 먼 미래 페이지 토큰 (newer). 없으면 null
 }

--- a/src/main/java/com/toy/nar/app/lolesports/MatchResultDto.java
+++ b/src/main/java/com/toy/nar/app/lolesports/MatchResultDto.java
@@ -13,6 +13,7 @@ public class MatchResultDto {
 	private String matchDate; // 경기 시간
 	private String state; // 경기 상태 (completed, unstarted, inProgress)
 	private String score; // 3 : 1
+	private Integer bestOf; // 다전제 규격 (1/3/5). 업스트림 match.strategy.count. 모르면 null
 	private TeamInfo blueTeam;
 	private TeamInfo redTeam;
 	private List<SetVod> sets; // 세트별 VOD 리스트

--- a/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/WorldsService.java
@@ -50,6 +50,7 @@ public class WorldsService {
 		JsonNode dataNode = scheduleRoot.path("data").path("schedule");
 		JsonNode eventsNode = dataNode.path("events");
 		String nextToken = dataNode.path("pages").path("older").asText(null);
+		String newerToken = dataNode.path("pages").path("newer").asText(null);
 
 		List<JsonNode> targetEvents = new ArrayList<>();
 		if (eventsNode.isArray()) {
@@ -84,6 +85,7 @@ public class WorldsService {
 		return MatchResponseWrapper.builder()
 				.matches(matchResults)
 				.nextPageToken(nextToken)
+				.newerPageToken(newerToken)
 				.build();
 	}
 
@@ -206,6 +208,7 @@ public class WorldsService {
 					.matchDate(matchDate)
 					.state(finalState)
 					.score(winsA + " : " + winsB)
+					.bestOf(parseBestOf(match))
 					.blueTeam(MatchResultDto.TeamInfo.builder()
 							.externalTeamId(teamA.path("id").asText(null))
 							.code(teamA.path("code").asText())
@@ -698,6 +701,15 @@ public class WorldsService {
 			log.error("API Call Failed: {}", path, e);
 			return null;
 		}
+	}
+
+	/**
+	 * 다전제 규격(match.strategy.count). 대진이 TBD 인 미래 경기도 값이 확정돼서 온다(실측).
+	 * 없거나 0 이면 null — 리그명으로 대체 추정하지 않는다(KeSPA Cup 은 한 리그에 Bo1·Bo3·Bo5 가 섞인다).
+	 */
+	static Integer parseBestOf(JsonNode match) {
+		int count = match.path("strategy").path("count").asInt(0);
+		return count > 0 ? count : null;
 	}
 
 	private List<String> extractTrackedGameIds(JsonNode games) {

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatch.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatch.java
@@ -44,6 +44,9 @@ public class LeagueMatch {
 
 	private boolean hasVod;
 
+	/** 다전제 규격(1/3/5). 업스트림 match.strategy.count. 과거 데이터는 완료 스코어로 역산됐다. */
+	private Integer bestOf;
+
 	@Column(columnDefinition = "TEXT")
 	private String matchDetailsJson;
 
@@ -75,6 +78,13 @@ public class LeagueMatch {
 		this.hasVod = hasVod;
 		this.matchDetailsJson = matchDetailsJson;
 		this.lastUpdated = lastUpdated;
+	}
+
+	/** 업스트림이 준 다전제 규격을 반영한다. null 이면(업스트림 공백) 기존 값을 유지한다. */
+	public void applyBestOf(Integer bestOf) {
+		if (bestOf != null) {
+			this.bestOf = bestOf;
+		}
 	}
 
 	public void applySeason(Integer seasonYear, String seasonSplit) {

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -92,17 +92,25 @@ public class TeamLiveEventPushService {
 		// SET_END 는 매치 스코어를 함께 보여준다. 세트 N 종료 시점의 스코어 합은 반드시 N —
 		// DB 가 아직 이번 세트를 반영 못 했으면(업스트림 지연·EWC unstarted 방치) 업스트림을
 		// 직접 재조회하고, 그래도 stale 이면 틀린 스코어 대신 생략한다.
-		String matchScoreLine = TYPE_SET_END.equals(eventType) ? buildMatchScoreLine(matchId, setNumber) : null;
+		// SET_START 에서도 매치를 한 번 읽어 bestOf 를 payload 에 실는다(앱이 마지막 세트를 판정한다).
+		ResolvedMatchScore resolved = TYPE_SET_END.equals(eventType)
+				? resolveMatchScore(matchId, setNumber)
+				: resolveMatchScore(matchId, 0);
+		String matchScoreLine = TYPE_SET_END.equals(eventType) ? scoreLineOf(resolved) : null;
+		Integer bestOf = resolved.bestOf();
 		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
-				blueEsportsTeamId, blueTeamName, redTeamName, true, matchScoreLine);
+				blueEsportsTeamId, blueTeamName, redTeamName, true, matchScoreLine, resolved);
 		notifyTeamSide(eventType, matchId, setNumber, NO_EVENT_ORDER,
-				redEsportsTeamId, redTeamName, blueTeamName, false, matchScoreLine);
+				redEsportsTeamId, redTeamName, blueTeamName, false, matchScoreLine, resolved);
 
 		// 경기 예약 구독자(팀 무관)에게도 발송. 매치 중립 문구를 1회 만들어 fan-out 한다.
 		// dedup 키가 (member, matchId, ...) 라 팀+매치 양쪽 구독자여도 1회만 나간다.
-		MobilePushMessage matchMessage =
-				buildMatchScopedMessage(eventType, matchId, setNumber, blueTeamName, redTeamName, matchScoreLine);
+		MobilePushMessage matchMessage = buildMatchScopedMessage(
+				eventType, matchId, setNumber, blueTeamName, redTeamName, matchScoreLine, resolved);
 		fanOutToMatchSubscribers(eventType, matchId, setNumber, NO_EVENT_ORDER, matchMessage);
+		if (bestOf == null) {
+			log.debug("bestOf 미확정 매치의 세트 이벤트. matchId={} eventType={}", matchId, eventType);
+		}
 	}
 
 	/** 경기 예약 구독자용 중립 문구. 특정 팀 관점이 아니라 대진 기준으로 표기한다. */
@@ -112,18 +120,26 @@ public class TeamLiveEventPushService {
 			int setNumber,
 			String blueTeamName,
 			String redTeamName,
-			String matchScoreLine) {
+			String matchScoreLine,
+			ResolvedMatchScore resolved) {
 		String matchup = matchup(blueTeamName, redTeamName);
+		// 단판(Bo1)에는 세트 개념이 없다 — KeSPA Cup 그룹 스테이지가 전부 Bo1 이다.
+		String phase = setPhase(resolved.bestOf(), setNumber);
 		String title;
 		String body;
 		if (TYPE_SET_END.equals(eventType)) {
-			title = matchup + " " + setNumber + "세트 종료";
-			body = (matchScoreLine != null ? matchScoreLine : matchup) + " · " + setNumber + "세트 종료";
+			title = matchup + " " + phase + " 종료";
+			body = (matchScoreLine != null ? matchScoreLine : matchup) + " · " + phase + " 종료";
 		} else {
-			title = matchup + " " + setNumber + "세트 시작";
-			body = matchup + " · " + setNumber + "세트 시작";
+			title = matchup + " " + phase + " 시작";
+			body = matchup + " · " + phase + " 시작";
 		}
-		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber));
+		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber, resolved));
+	}
+
+	/** 단판이면 "경기", 다전제면 "N세트". */
+	private String setPhase(Integer bestOf, int setNumber) {
+		return bestOf != null && bestOf == 1 ? "경기" : setNumber + "세트";
 	}
 
 	/** 경기 예약 구독자 fan-out. 팀 구독 fanOut 과 동일하게 sendToMember(dedup) 를 태운다. */
@@ -151,22 +167,41 @@ public class TeamLiveEventPushService {
 	 * 돌려 스코어 없이 발송한다. 세트 번호를 모르면(0 이하) 기존처럼 합>0 인 DB 값을 쓴다.</p>
 	 */
 	String buildMatchScoreLine(String matchId, int endedSetNumber) {
+		return scoreLineOf(resolveMatchScore(matchId, endedSetNumber));
+	}
+
+	private String scoreLineOf(ResolvedMatchScore resolved) {
+		if (resolved.match() == null || resolved.score() == null) {
+			return null;
+		}
+		return scoreLine(resolved.match().getBlueTeamName(), resolved.score()[0], resolved.score()[1],
+				resolved.match().getRedTeamName());
+	}
+
+	/**
+	 * 매치와 (가능하면) 방금 끝난 세트가 반영된 스코어를 함께 돌려준다.
+	 * 푸시 payload 에 bestOf·스코어를 실어야 하므로 스코어를 문자열로만 만들지 않는다.
+	 */
+	private ResolvedMatchScore resolveMatchScore(String matchId, int endedSetNumber) {
 		try {
 			var match = leagueMatchRepository.findById(matchId).orElse(null);
 			if (match == null) {
-				return null;
+				return ResolvedMatchScore.EMPTY;
 			}
 			Integer blueScore = match.getBlueScore();
 			Integer redScore = match.getRedScore();
 			int dbSum = (blueScore == null ? 0 : blueScore) + (redScore == null ? 0 : redScore);
 
 			if (endedSetNumber <= 0) {
-				return dbSum > 0 ? scoreLine(match.getBlueTeamName(), blueScore, redScore, match.getRedTeamName()) : null;
+				return dbSum > 0
+						? new ResolvedMatchScore(match,
+								new int[] { blueScore == null ? 0 : blueScore, redScore == null ? 0 : redScore })
+						: new ResolvedMatchScore(match, null);
 			}
-			String dbLine = lineIfFresh(new int[] { blueScore == null ? 0 : blueScore, redScore == null ? 0 : redScore },
-					match, endedSetNumber);
-			if (dbLine != null) {
-				return dbLine;
+			int[] dbScore = freshOrNull(new int[] { blueScore == null ? 0 : blueScore, redScore == null ? 0 : redScore },
+					endedSetNumber);
+			if (dbScore != null) {
+				return new ResolvedMatchScore(match, dbScore);
 			}
 
 			// DB stale — 업스트림이 방금 끝난 세트를 반영할 때까지 짧게 재시도.
@@ -182,34 +217,47 @@ public class TeamLiveEventPushService {
 					int[] naver = naverEsportsScoreClient.fetchScore(
 							match.getBlueTeamCode(), match.getRedTeamCode(), match.getMatchDate());
 					naverUsable = naver != null;
-					String line = lineIfFresh(naver, match, endedSetNumber);
-					if (line != null) {
-						return line;
+					int[] fresh = freshOrNull(naver, endedSetNumber);
+					if (fresh != null) {
+						return new ResolvedMatchScore(match, fresh);
 					}
 				}
-				String line = lineIfFresh(worldsService.fetchMatchGameWins(matchId), match, endedSetNumber);
-				if (line != null) {
-					return line;
+				int[] fresh = freshOrNull(worldsService.fetchMatchGameWins(matchId), endedSetNumber);
+				if (fresh != null) {
+					return new ResolvedMatchScore(match, fresh);
 				}
 			}
 			log.warn("Set-end score still stale after retries. matchId={} endedSet={} dbScore={}:{}",
 					matchId, endedSetNumber, blueScore, redScore);
-			return null;
+			return new ResolvedMatchScore(match, null);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			return null;
+			return ResolvedMatchScore.EMPTY;
 		} catch (Exception e) {
 			log.warn("Failed to load match score for set-end push matchId={}", matchId, e);
-			return null;
+			return ResolvedMatchScore.EMPTY;
 		}
 	}
 
-	/** 스코어 합이 방금 끝난 세트 수 이상(=신선)일 때만 스코어 라인, 아니면 null. */
-	private String lineIfFresh(int[] score, com.toy.nar.app.lolesports.repository.LeagueMatch match, int endedSetNumber) {
+	/** 스코어 합이 방금 끝난 세트 수 이상(=신선)일 때만 그 스코어, 아니면 null. */
+	private int[] freshOrNull(int[] score, int endedSetNumber) {
 		if (score == null || score[0] + score[1] < endedSetNumber) {
 			return null;
 		}
-		return scoreLine(match.getBlueTeamName(), score[0], score[1], match.getRedTeamName());
+		return score;
+	}
+
+	/**
+	 * 스코어 해석 결과. {@code match} 가 null 이면 매치를 못 찾은 것이고,
+	 * {@code score} 가 null 이면 방금 끝난 세트를 반영한 스코어를 못 구한 것(stale)이다.
+	 */
+	private record ResolvedMatchScore(com.toy.nar.app.lolesports.repository.LeagueMatch match, int[] score) {
+
+		private static final ResolvedMatchScore EMPTY = new ResolvedMatchScore(null, null);
+
+		Integer bestOf() {
+			return match == null ? null : match.getBestOf();
+		}
 	}
 
 	private String scoreLine(String blueTeamName, Integer blueScore, Integer redScore, String redTeamName) {
@@ -251,7 +299,8 @@ public class TeamLiveEventPushService {
 			String teamName,
 			String opponentTeamName,
 			boolean blueSide,
-			String matchScoreLine) {
+			String matchScoreLine,
+			ResolvedMatchScore resolvedScore) {
 		Optional<Team> team = resolveLckTeam(esportsTeamId);
 		if (team.isEmpty()) {
 			return;
@@ -262,7 +311,7 @@ public class TeamLiveEventPushService {
 		String blue = blueSide ? displayName : opponent;
 		String red = blueSide ? opponent : displayName;
 		MobilePushMessage message = buildMatchEventMessage(
-				eventType, matchId, setNumber, displayName, blue, red, matchScoreLine);
+				eventType, matchId, setNumber, displayName, blue, red, matchScoreLine, resolvedScore);
 		fanOut(eventType, matchId, setNumber, eventOrder, resolved.getId(), message);
 	}
 
@@ -466,21 +515,23 @@ public class TeamLiveEventPushService {
 			String teamName,
 			String blueTeamName,
 			String redTeamName,
-			String matchScoreLine) {
+			String matchScoreLine,
+			ResolvedMatchScore resolved) {
 		String matchup = matchup(blueTeamName, redTeamName);
+		String phase = setPhase(resolved.bestOf(), setNumber);
 		String title;
 		String body;
 		if (TYPE_SET_END.equals(eventType)) {
-			title = teamName + " " + setNumber + "세트 종료";
+			title = teamName + " " + phase + " 종료";
 			// 매치 스코어를 알면 "T1 1 vs 2 HLE" 로 경기 흐름을 보여준다.
 			body = matchScoreLine != null
-					? matchScoreLine + " · " + setNumber + "세트 종료"
-					: matchup + " · " + setNumber + "세트 종료";
+					? matchScoreLine + " · " + phase + " 종료"
+					: matchup + " · " + phase + " 종료";
 		} else {
-			title = teamName + " 세트 시작";
-			body = matchup + " · " + setNumber + "세트 시작";
+			title = teamName + " " + (resolved.bestOf() != null && resolved.bestOf() == 1 ? "경기" : "세트") + " 시작";
+			body = matchup + " · " + phase + " 시작";
 		}
-		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber));
+		return new MobilePushMessage(title, body, baseData(eventType, matchId, setNumber, resolved));
 	}
 
 	/** 모바일 계약: data.type / data.matchId / data.setNumber 는 모두 String. */
@@ -489,6 +540,24 @@ public class TeamLiveEventPushService {
 		data.put("type", eventType);
 		data.put("matchId", matchId);
 		data.put("setNumber", String.valueOf(setNumber));
+		return Map.copyOf(data);
+	}
+
+	/**
+	 * 세트 이벤트 payload. 기본 필드에 {@code bestOf} 와 스코어를 더한다.
+	 * 앱은 이 셋으로 마지막 세트(= max(score) 가 승리 조건 도달)와 다음 세트 존재 여부를 판정해
+	 * Live Activity 를 갱신한다. 모르는 값은 키를 넣지 않는다(구버전 앱은 무시).
+	 */
+	private Map<String, String> baseData(
+			String eventType, String matchId, int setNumber, ResolvedMatchScore resolved) {
+		Map<String, String> data = new LinkedHashMap<>(baseData(eventType, matchId, setNumber));
+		if (resolved.bestOf() != null) {
+			data.put("bestOf", String.valueOf(resolved.bestOf()));
+		}
+		if (resolved.score() != null) {
+			data.put("blueScore", String.valueOf(resolved.score()[0]));
+			data.put("redScore", String.valueOf(resolved.score()[1]));
+		}
 		return Map.copyOf(data);
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -324,6 +324,7 @@ public class MobileScheduleService {
 						match.getRedScore()),
 				liveStreamUrl(match),
 				streamLinks(match),
+				match.getBestOf(),
 				gamesByMatchId.getOrDefault(match.getId(), List.of()));
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/dto/MobileScheduleListResponse.java
@@ -24,6 +24,9 @@ public record MobileScheduleListResponse(
 			@Schema(description = "라이브 중계 채널 목록. 진행 중 경기에서만 채워지며, 복수면 앱이 선택 시트를 띄운다. "
 					+ "liveStreamUrl 은 하위호환용(첫 번째 링크와 동일)")
 			List<MobileStreamLink> streamLinks,
+			@Schema(description = "다전제 규격(1=단판, 3=3전 2선승, 5=5전 3선승). 같은 리그 안에서도 스테이지별로 다르다. "
+					+ "업스트림에 값이 없으면 null", example = "3", nullable = true)
+			Integer bestOf,
 			@Schema(description = "매치에 속한 세트(게임) 목록. 아직 세트가 생성되지 않은 매치는 빈 배열")
 			List<MobileGameSummary> games) {
 	}

--- a/src/main/resources/db/migration/V57__Add_best_of_to_league_match.sql
+++ b/src/main/resources/db/migration/V57__Add_best_of_to_league_match.sql
@@ -1,0 +1,14 @@
+-- 매치의 다전제 규격(Bo1/Bo3/Bo5). lolesports getSchedule/getEventDetails 의 match.strategy.count 값이다.
+-- 마지막 세트·매치포인트 판정에 필요하다. 같은 리그 안에 Bo 가 섞이므로(KeSPA Cup: 그룹 Bo1 25 / 플레이-인 Bo3 10 / 토너먼트·결승 Bo5 3,
+-- LCK: 정규 Bo3 / 플레이오프 Bo5) 리그명으로는 판정할 수 없다.
+ALTER TABLE league_match ADD COLUMN best_of INT NULL;
+
+-- 완료 경기 역산 백필. 승자는 정확히 ceil(bo/2) 세트를 따고 끝나므로 bo = 2 * max(score) - 1 이다.
+-- 프로덕션 completed 3,274건 전수 점검: max 값이 1/2/3 만 존재(동점·max>3·NULL 0건),
+-- API strategy.count 와 대조한 65건 전수 일치. 미완료 경기는 다음 sync 가 업스트림 값으로 채운다.
+UPDATE league_match
+   SET best_of = 2 * GREATEST(blue_score, red_score) - 1
+ WHERE state = 'completed'
+   AND blue_score IS NOT NULL
+   AND red_score IS NOT NULL
+   AND GREATEST(blue_score, red_score) > 0;

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -48,6 +48,7 @@ class MobileMatchControllerTest {
 						"https://chzzk.naver.com/abc",
 						List.of(new MobileScheduleListResponse.MobileStreamLink(
 								"chzzk", "치지직", "LCK 공식 채널 · 한국어", "https://chzzk.naver.com/abc")),
+						3,
 						List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", null, "LIVE", null))));
 
 		mockMvc.perform(get("/api/mobile/matches/match-1"))
@@ -76,6 +77,7 @@ class MobileMatchControllerTest {
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 1),
 								null,
 								List.of(),
+								3,
 								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, "ENDED", null)))),
 						"cursor-token",
 						true));

--- a/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/schedule/MobileScheduleControllerTest.java
@@ -106,6 +106,7 @@ class MobileScheduleControllerTest {
 								new MobileScheduleListResponse.MobileTeamResult("Gen.G", "GEN", "https://example.com/gen.png", 0),
 								null,
 								List.of(),
+								3,
 								List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-1", 100L, null, null))))));
 
 		mockMvc.perform(get("/api/mobile/schedules")

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceNewerPageTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceNewerPageTest.java
@@ -1,0 +1,146 @@
+package com.toy.nar.app.lolesports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.domain.game.repository.GameExternalIdentityRepository;
+import com.toy.nar.domain.game.repository.GameRepository;
+import com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+
+/**
+ * getSchedule 미래(newer) 페이지 추적 검증.
+ * 기본 페이지 창 밖의 미래 일정(LCK 플레이오프·결승, LPL 정규 잔여분)은 newer 토큰을 따라가야만 DB 에 들어온다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LeagueMatchServiceNewerPageTest {
+
+	@Mock
+	private LeagueMatchRepository leagueMatchRepository;
+	@Mock
+	private LeagueMatchGameRepository leagueMatchGameRepository;
+	@Mock
+	private com.toy.nar.app.lolesports.season.LeagueSeasonResolver leagueSeasonResolver;
+	@Mock
+	private TeamRepository teamRepository;
+	@Mock
+	private TeamExternalIdentityRepository teamExternalIdentityRepository;
+	@Mock
+	private GameExternalIdentityRepository gameExternalIdentityRepository;
+	@Mock
+	private WorldsService worldsService;
+	@Mock
+	private TransactionTemplate transactionTemplate;
+	@Mock
+	private GameRepository gameRepository;
+
+	private LeagueMatchService leagueMatchService;
+
+	@BeforeEach
+	void setUp() {
+		leagueMatchService = new LeagueMatchService(
+				leagueMatchRepository,
+				leagueMatchGameRepository,
+				leagueSeasonResolver,
+				teamRepository,
+				teamExternalIdentityRepository,
+				gameExternalIdentityRepository,
+				worldsService,
+				new ObjectMapper(),
+				transactionTemplate,
+				gameRepository,
+				null);
+		when(leagueMatchRepository.findAllById(anyList())).thenReturn(List.of());
+		when(leagueMatchGameRepository.findMappedGameRowsByMatchIds(anyList(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of());
+	}
+
+	@Test
+	@DisplayName("기본 페이지의 newer 토큰을 따라 미래 경기까지 저장한다")
+	void syncMatches_followsNewerPage() {
+		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(page(match("base-1"), "newer-1", null));
+		when(worldsService.getWorldsMatches("newer-1", "LCK")).thenReturn(page(match("playoff-1"), null, null));
+
+		leagueMatchService.syncMatchesWithoutTeamMetadata("LCK");
+
+		verify(worldsService).getWorldsMatches("newer-1", "LCK");
+		// 기본 페이지 1건 + 미래 페이지 1건이 각각 저장된다.
+		verify(leagueMatchRepository, times(2)).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("newer 토큰이 없으면 추가 페이지를 조회하지 않는다")
+	void syncMatches_stopsWithoutNewerToken() {
+		when(worldsService.getWorldsMatches(null, "KESPA")).thenReturn(page(match("base-1"), null, null));
+
+		leagueMatchService.syncMatchesWithoutTeamMetadata("KESPA");
+
+		verify(worldsService, times(1)).getWorldsMatches(null, "KESPA");
+		verify(worldsService, org.mockito.Mockito.never())
+				.getWorldsMatches(org.mockito.ArgumentMatchers.argThat(token -> token != null), org.mockito.ArgumentMatchers.eq("KESPA"));
+	}
+
+	@Test
+	@DisplayName("newer 토큰이 같은 값을 반복해도 무한 루프에 빠지지 않는다")
+	void syncMatches_stopsOnRepeatedToken() {
+		when(worldsService.getWorldsMatches(null, "LPL")).thenReturn(page(match("base-1"), "loop", null));
+		when(worldsService.getWorldsMatches("loop", "LPL")).thenReturn(page(match("future-1"), "loop", null));
+
+		leagueMatchService.syncMatchesWithoutTeamMetadata("LPL");
+
+		verify(worldsService, times(1)).getWorldsMatches("loop", "LPL");
+	}
+
+	@Test
+	@DisplayName("업스트림 bestOf 가 DTO→엔티티로 이어진다")
+	void convertToEntity_carriesBestOf() {
+		MatchResultDto dto = match("m1");
+		dto.setBestOf(5);
+
+		var entity = org.springframework.test.util.ReflectionTestUtils.invokeMethod(
+				leagueMatchService, "convertToEntity", dto, "LCK");
+
+		assertThat(entity).isNotNull();
+		assertThat(((com.toy.nar.app.lolesports.repository.LeagueMatch) entity).getBestOf()).isEqualTo(5);
+	}
+
+	private MatchResponseWrapper page(MatchResultDto match, String newerToken, String olderToken) {
+		return MatchResponseWrapper.builder()
+				.matches(List.of(match))
+				.nextPageToken(olderToken)
+				.newerPageToken(newerToken)
+				.build();
+	}
+
+	private MatchResultDto match(String id) {
+		return MatchResultDto.builder()
+				.matchId(id)
+				.leagueName("LCK")
+				.matchTitle("플레이오프 | T1 vs GEN")
+				.matchDate("2026-09-13T08:00:00Z")
+				.state("unstarted")
+				.blueTeam(MatchResultDto.TeamInfo.builder().code("T1").name("T1").wins(0).build())
+				.redTeam(MatchResultDto.TeamInfo.builder().code("GEN").name("Gen.G").wins(0).build())
+				.sets(List.of())
+				.build();
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/WorldsServiceBestOfTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/WorldsServiceBestOfTest.java
@@ -1,0 +1,42 @@
+package com.toy.nar.app.lolesports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * match.strategy.count 파싱 검증.
+ * 실측 응답 형태 — getSchedule 은 {"type":"bestOf","count":3}, getEventDetails 는 {"count":3} 을 준다.
+ */
+class WorldsServiceBestOfTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@DisplayName("strategy.count 를 그대로 읽는다")
+	void readsStrategyCount() {
+		ObjectNode match = objectMapper.createObjectNode();
+		match.putObject("strategy").put("type", "bestOf").put("count", 5);
+
+		assertThat(WorldsService.parseBestOf(match)).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("strategy 가 없으면 null — 리그명으로 추정하지 않는다")
+	void missingStrategyIsNull() {
+		assertThat(WorldsService.parseBestOf(objectMapper.createObjectNode())).isNull();
+	}
+
+	@Test
+	@DisplayName("count 가 0 이면 null 로 본다")
+	void zeroCountIsNull() {
+		ObjectNode match = objectMapper.createObjectNode();
+		match.putObject("strategy").put("count", 0);
+
+		assertThat(WorldsService.parseBestOf(match)).isNull();
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceBestOfTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceBestOfTest.java
@@ -1,0 +1,164 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.NaverEsportsScoreClient;
+import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberDevice;
+import com.toy.nar.domain.member.repository.MemberDeviceRepository;
+import com.toy.nar.domain.member.repository.MemberTeamEventPushDeliveryRepository;
+import com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * 세트 이벤트 푸시의 bestOf 반영 검증.
+ * Bo1(KeSPA Cup 그룹 스테이지 전체)은 세트 개념이 없어 "1세트 종료" 가 아니라 "경기 종료" 여야 하고,
+ * payload 의 bestOf·스코어로 앱이 마지막 세트를 판정한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TeamLiveEventPushServiceBestOfTest {
+
+	@Mock
+	private MemberDeviceRepository deviceRepository;
+	@Mock
+	private MemberTeamEventPushDeliveryRepository deliveryRepository;
+	@Mock
+	private TeamExternalIdentityRepository teamExternalIdentityRepository;
+	@Mock
+	private LeagueMatchRepository leagueMatchRepository;
+	@Mock
+	private MobilePushGateway pushGateway;
+	@Mock
+	private MemberNotificationService notificationService;
+	@Mock
+	private WorldsService worldsService;
+	@Mock
+	private NaverEsportsScoreClient naverEsportsScoreClient;
+
+	private TeamLiveEventPushService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new TeamLiveEventPushService(
+				deviceRepository, deliveryRepository, teamExternalIdentityRepository,
+				leagueMatchRepository, pushGateway, notificationService, worldsService,
+				naverEsportsScoreClient);
+		ReflectionTestUtils.setField(service, "fcmNotificationEnabled", true);
+		ReflectionTestUtils.setField(service, "scoreRetryAttempts", 1);
+		ReflectionTestUtils.setField(service, "scoreRetryDelayMs", 0L);
+
+		Member member = Member.builder().build();
+		ReflectionTestUtils.setField(member, "id", 1L);
+		MemberDevice device = MemberDevice.builder()
+				.member(member)
+				.fcmToken("token-1")
+				.platform(com.toy.nar.domain.member.entity.MobileDevicePlatform.IOS)
+				.build();
+		when(deviceRepository.findActiveDevicesBySubscribedMatchId(anyString(), anyString()))
+				.thenReturn(List.of(device));
+		when(deliveryRepository.reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+		when(pushGateway.isAvailable()).thenReturn(true);
+		when(pushGateway.send(any(), any())).thenReturn(new MobilePushResult(1, 0, List.of()));
+	}
+
+	private LeagueMatch match(Integer bestOf, int blueScore, int redScore) {
+		return LeagueMatch.builder()
+				.id("m1")
+				.leagueName("KESPA")
+				.blueTeamCode("BRO")
+				.blueTeamName("OK저축은행 브리온")
+				.redTeamCode("DNS")
+				.redTeamName("DN SOOPers")
+				.blueScore(blueScore)
+				.redScore(redScore)
+				.bestOf(bestOf)
+				.matchDate(java.time.LocalDateTime.of(2026, 7, 20, 8, 15))
+				.build();
+	}
+
+	private MobilePushMessage captureSentMessage() {
+		ArgumentCaptor<MobilePushMessage> captor = ArgumentCaptor.forClass(MobilePushMessage.class);
+		org.mockito.Mockito.verify(pushGateway).send(any(), captor.capture());
+		return captor.getValue();
+	}
+
+	@Test
+	@DisplayName("Bo1 세트 종료는 '경기 종료' 로 표기한다")
+	void bo1SetEndReadsAsMatchEnd() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(1, 1, 0)));
+
+		service.notifyMatchEvent("SET_END", "m1", 1, null, null, "OK저축은행 브리온", "DN SOOPers");
+
+		MobilePushMessage message = captureSentMessage();
+		assertThat(message.title()).isEqualTo("OK저축은행 브리온 vs DN SOOPers 경기 종료");
+		assertThat(message.body()).contains("경기 종료").doesNotContain("세트");
+	}
+
+	@Test
+	@DisplayName("Bo3 세트 종료는 기존처럼 'N세트 종료' 로 표기한다")
+	void bo3SetEndKeepsSetWording() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(3, 1, 1)));
+
+		service.notifyMatchEvent("SET_END", "m1", 2, null, null, "OK저축은행 브리온", "DN SOOPers");
+
+		assertThat(captureSentMessage().title()).isEqualTo("OK저축은행 브리온 vs DN SOOPers 2세트 종료");
+	}
+
+	@Test
+	@DisplayName("payload 에 bestOf 와 스코어를 실어 앱이 마지막 세트를 판정할 수 있게 한다")
+	void payloadCarriesBestOfAndScore() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(3, 1, 1)));
+
+		service.notifyMatchEvent("SET_END", "m1", 2, null, null, "OK저축은행 브리온", "DN SOOPers");
+
+		assertThat(captureSentMessage().data())
+				.containsEntry("bestOf", "3")
+				.containsEntry("blueScore", "1")
+				.containsEntry("redScore", "1")
+				.containsEntry("setNumber", "2");
+	}
+
+	@Test
+	@DisplayName("bestOf 를 모르면 관련 키를 넣지 않고 기존 세트 문구를 유지한다")
+	void unknownBestOfKeepsLegacyWording() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(null, 1, 1)));
+
+		service.notifyMatchEvent("SET_END", "m1", 2, null, null, "OK저축은행 브리온", "DN SOOPers");
+
+		MobilePushMessage message = captureSentMessage();
+		assertThat(message.title()).isEqualTo("OK저축은행 브리온 vs DN SOOPers 2세트 종료");
+		assertThat(message.data()).doesNotContainKey("bestOf");
+	}
+
+	@Test
+	@DisplayName("SET_START 도 bestOf 를 payload 에 싣는다")
+	void setStartCarriesBestOf() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(5, 2, 1)));
+
+		service.notifyMatchEvent("SET_START", "m1", 4, null, null, "OK저축은행 브리온", "DN SOOPers");
+
+		assertThat(captureSentMessage().data()).containsEntry("bestOf", "5");
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceBestOfTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceBestOfTest.java
@@ -78,9 +78,11 @@ class TeamLiveEventPushServiceBestOfTest {
 				.build();
 		when(deviceRepository.findActiveDevicesBySubscribedMatchId(anyString(), anyString()))
 				.thenReturn(List.of(device));
-		when(deliveryRepository.reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+		when(deliveryRepository.reserveAll(any(), anyString(), anyInt(), anyString(), anyLong()))
+				.thenReturn(List.of(1L));
 		when(pushGateway.isAvailable()).thenReturn(true);
-		when(pushGateway.send(any(), any())).thenReturn(new MobilePushResult(1, 0, List.of()));
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(1, 0, List.of(), List.of("token-1")));
 	}
 
 	private LeagueMatch match(Integer bestOf, int blueScore, int redScore) {

--- a/src/test/resources/db/pre_v31_schema.sql
+++ b/src/test/resources/db/pre_v31_schema.sql
@@ -23,10 +23,14 @@ CREATE TABLE games (
     actual_game_start_time DATETIME
 );
 
+-- state/blue_score/red_score: 프로드에는 V6(베이스라인 이전)부터 존재. V57 best_of 역산 백필이 참조한다.
 CREATE TABLE league_match (
     id VARCHAR(50) PRIMARY KEY,
     league_name VARCHAR(20) NOT NULL,
-    match_date DATETIME
+    match_date DATETIME,
+    state VARCHAR(50),
+    blue_score INT DEFAULT 0,
+    red_score INT DEFAULT 0
 );
 
 CREATE INDEX idx_league_match_name_date ON league_match (league_name, match_date DESC);


### PR DESCRIPTION
## 배경

Live Activity 에 세트 진행/종료 UI 를 붙이려면 "이 세트가 마지막인가"를 서버가 알아야 한다. 지금은 판정 근거가 없다.

lolesports 는 `match.strategy.count` 로 Bo 규격을 **항상** 준다(실측 — 대진이 TBD 인 미래 경기도 확정값). 그런데 파싱하지 않고 버렸다. `LolesportsResponse.Strategy` 클래스는 존재하지만 그 파일 전체가 dead code 다.

리그명으로 대체 추정도 불가능하다:

| 리그 | 구성 |
|---|---|
| KeSPA Cup | 그룹 Bo1 25경기 · 플레이-인 Bo3 10경기 · 토너먼트·결승 Bo5 3경기 |
| LCK | 정규 Bo3 · 플레이오프/결승 Bo5 (프로덕션 completed 기준 Bo3 139 / Bo5 36) |

그래서 KeSPA 그룹 25경기(단판)에서도 `"1세트 종료"` 로 알림이 나갔고, Live Activity 가 다음 세트 카운트다운을 붙이면 존재하지 않는 2세트를 기다린다.

별개로, `getSchedule` 커서 페이지네이션에서 `pages.older` 만 따라가고 있었다. 기본 페이지 창 밖 미래 일정이 DB 에 아예 없다 — 46경기 ID 를 프로덕션에서 조회한 결과 **0건**.

```
LCK  newer 1홉 → 13경기 (2026-08-26~09-13)  플레이오프 9 · 플레이-인 3 · 결승 1
LPL  newer 1홉 → 33경기 (2026-08-16~09-19)  정규 4주차 1 · 5주차 13 · 플레이오프 13 · 선발전 3 · 결승 1
그 외 9리그: newer 토큰 null (이미 커버)
```

## 변경

- **`league_match.best_of` 추가 + 완료 경기 역산 백필** (`V57`). 승자는 정확히 `ceil(bo/2)` 세트를 따고 끝나므로 `bo = 2 * max(score) - 1`.
- **세트 이벤트 푸시 payload 에 `bestOf` / `blueScore` / `redScore` 추가.** 앱이 이 값으로 마지막 세트·다음 세트 존재 여부를 판정해 Live Activity 를 갱신한다. 모르는 값은 키를 넣지 않아 구버전 앱은 그대로 동작한다.
- **Bo1 문구 분기.** `"N세트 종료/시작"` → `"경기 종료/시작"`.
- **`pages.newer` 추적.** 미래 페이지는 upsert 만 한다 — 시작도 안 한 경기에는 매핑할 게임이 없어 `autoBackfill` 을 태우면 매 sync 마다 헛된 `getEventDetails` 호출만 쌓인다. 토큰 방문 집합 + 5홉 상한.
- **모바일 일정 응답에 `bestOf` 노출.** 리스트에서 단판/3전 2선승/5전 3선승 배지 표기용.

### `MATCH_END` 푸시 타입을 새로 만들지 않은 이유

`eventType` 은 문구 분기용 문자열이 아니라 구독 토글 키다(`MemberDeviceRepository:74-78`). 새 타입은 구독 스키마 마이그레이션 + 앱 토글 UI + 배포 대기를 부르고, `SET_END` 만 켠 사용자가 **마지막 세트 알림만 못 받는** 상태를 만든다. `SET_END` + `bestOf` 로 앱이 판정하는 쪽이 계약 변경이 없다.

## 검증

**역산 공식 — API `strategy.count` 대조 65건 전수 일치**
```
LCK   ok 40  bad 0
KESPA ok 25  bad 0
```

**프로덕션 completed 3,274건 이상치 스캔 — 전부 0**
```
동점 0 · blue+red>5 0 · max>3 0 · score NULL 0 · 논리 불가 조합 0
```

**마이그레이션 실제 적용** (로컬 = 프로덕션 데이터 사본)
```
Successfully applied 1 migration to schema `lol_esports_analysis`, now at version v57
Started NarApplication in 14.679 seconds

completed 중 best_of NULL: 0건
KESPA: Bo1 25 / Bo3 1     LCK: Bo3 158 / Bo5 36
```

**테스트** — `./gradlew test` 전체 통과. 신규 3개 파일:
- `WorldsServiceBestOfTest` — `strategy.count` 파싱, 부재 시 null
- `LeagueMatchServiceNewerPageTest` — newer 추적, 토큰 없을 때 정지, 토큰 반복 시 루프 방지, bestOf DTO→엔티티 전달
- `TeamLiveEventPushServiceBestOfTest` — Bo1 "경기 종료", Bo3 기존 문구 유지, payload 필드, bestOf 미확정 시 기존 동작

## 남긴 것

- 미완료 경기 230건은 별도 백필 스크립트 없이 다음 sync(30분)가 채운다.
- `getRecent3Matches` / 4-arg `fetchMatchDetails` 는 호출자가 없는 dead code라 손대지 않았다.
- `best_of` NULL 방어는 앱에서 세트 카운트다운 문구 생략으로 처리하면 된다(현재 completed 기준 0건).

🤖 Generated with [Claude Code](https://claude.com/claude-code)