### PR TITLE
ci: 프로덕션 DB 일일 백업 워크플로 추가

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,102 @@
+name: DB Backup
+
+# 프로덕션 MySQL(Oracle Cloud VM의 도커 컨테이너)을 매일 논리 백업한다.
+#
+# 왜 러너에서 도는가: DB가 앱 서버(AWS EC2)와 다른 호스트에 있고 그 VM의 SSH 키가 유실돼
+# 서버 cron을 걸 수 없었다. 3306이 외부에서 접속 가능하고 DB 접속 정보가 이미 secrets에
+# 있으므로, 러너에서 원격 덤프하는 쪽이 서버 접근 복구를 기다리지 않는 가장 빠른 경로다.
+# (3306 노출 자체는 EC2 IP로 좁히는 별도 작업이 필요하다. 좁히는 순간 이 워크플로는
+#  GitHub 러너 IP가 막혀 실패하므로, 그때는 EC2에서 돌리도록 옮겨야 한다.)
+#
+# 보관: 업로드 대상 버킷의 라이프사이클 규칙으로 관리한다(30일 만료 권장).
+
+on:
+  schedule:
+    - cron: '10 19 * * *'   # 매일 04:10 KST (19:10 UTC)
+  workflow_dispatch:         # 수동 실행 — 최초 검증·임시 백업용
+
+concurrency:
+  group: db-backup
+  cancel-in-progress: false
+
+jobs:
+  dump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: 덤프 생성
+        env:
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          # jdbc:mysql://host:port/db?params → host / port / db 분해
+          stripped="${DB_URL#jdbc:mysql://}"
+          hostport="${stripped%%/*}"
+          dbpart="${stripped#*/}"
+          DB_HOST="${hostport%%:*}"
+          DB_PORT="${hostport##*:}"
+          [ "$DB_PORT" = "$DB_HOST" ] && DB_PORT=3306
+          DB_NAME="${dbpart%%\?*}"
+          echo "host=${DB_HOST} port=${DB_PORT} db=${DB_NAME}"
+
+          FILE="nar-$(TZ=Asia/Seoul date +%F).sql.gz"
+          echo "FILE=${FILE}" >> "$GITHUB_ENV"
+
+          # 서버와 같은 메이저 버전(8.0) 클라이언트를 도커로 쓴다 — 러너의 mysqldump 버전에
+          # 좌우되지 않는다. --single-transaction: InnoDB를 락 없이 일관 스냅샷으로.
+          # --no-tablespaces: PROCESS 권한 없는 계정에서도 되게. --set-gtid-purged=OFF: 복원 시
+          # GTID 구문이 걸리지 않게.
+          docker run --rm -e MYSQL_PWD="${DB_PASSWORD}" mysql:8.0 \
+            mysqldump \
+              -h "${DB_HOST}" -P "${DB_PORT}" -u "${DB_USERNAME}" \
+              --single-transaction --quick --routines --events \
+              --no-tablespaces --set-gtid-purged=OFF \
+              --default-character-set=utf8mb4 \
+              "${DB_NAME}" | gzip -6 > "${FILE}"
+
+          ls -lh "${FILE}"
+
+      - name: 덤프 검증
+        run: |
+          set -euo pipefail
+          SIZE=$(stat -c%s "${FILE}")
+          echo "size=${SIZE} bytes"
+          # 정상 덤프는 20MB 이상(2026-07 기준 27MB). 인증 실패·빈 응답이 gzip 헤더만 남기고
+          # 조용히 성공하는 것을 막는 최소 가드다.
+          if [ "${SIZE}" -lt 5000000 ]; then
+            echo "덤프가 비정상적으로 작다 — 인증 실패나 접속 차단 의심" >&2
+            gunzip -c "${FILE}" | head -20 >&2 || true
+            exit 1
+          fi
+          # 마지막 줄에 완료 주석이 있어야 잘리지 않은 덤프다.
+          gunzip -c "${FILE}" | tail -1 | grep -q "Dump completed"
+          echo "검증 통과"
+
+      - name: 오브젝트 스토리지 업로드
+        env:
+          PAR_URL: ${{ secrets.OCI_BACKUP_PAR_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PAR_URL}" ]; then
+            echo "OCI_BACKUP_PAR_URL secret이 없다" >&2
+            exit 1
+          fi
+          # PAR은 쓰기 전용 URL이고, 뒤에 오브젝트 이름을 붙여 PUT 한다.
+          curl -sS --fail-with-body -X PUT \
+            --data-binary "@${FILE}" \
+            "${PAR_URL%/}/${FILE}"
+          echo "업로드 완료: ${FILE}"
+
+      - name: 실패 알림
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          # 백업은 조용히 실패하면 백업이 없는 것과 같다 — 실패는 반드시 알린다.
+          [ -z "${WEBHOOK}" ] && exit 0
+          curl -sS -X POST -H 'Content-Type: application/json' \
+            -d "{\"content\":\"🔴 DB 백업 실패 — <https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}>\"}" \
+            "${WEBHOOK}" || true


### PR DESCRIPTION
## 문제

**프로덕션 DB에 백업이 전혀 없다.** MySQL은 Oracle Cloud VM의 도커 컨테이너로 돌고, 레포·서버 어디에도 백업 자동화가 없다(`scripts/`엔 백필 스크립트 2개뿐).

유실 시 경기·선수 데이터는 lolesports 재싱크로 복원 가능하지만 **회원·구독·리뷰·솔랭 알림 이력은 외부에 원본이 없어 영구 손실**이다.

## 왜 서버 cron이 아니라 GH Actions인가

정석은 DB 호스트의 cron이다. 그런데 그 VM의 **SSH 키가 유실**돼 접근이 막혀 있다(메타데이터 등록 공개키 `SHA256:mkt8Tam…`와 짝인 개인키가 로컬에 없음, Run Command 플러그인은 에이전트 미지원, Bastion 플러그인 활성화 시도 중).

한편 **3306이 외부에서 접속 가능**하고 `DB_URL`·`DB_USERNAME`·`DB_PASSWORD`가 이미 secrets에 있다. 러너에서 원격 덤프하면 접근 복구를 기다리지 않고 지금 백업을 세울 수 있다. 백업 없는 기간을 늘리지 않는 게 우선이다.

## 구성

```
매일 04:10 KST (+ workflow_dispatch)
  → docker mysql:8.0 mysqldump (원격)
  → gzip -6  (현재 약 27MB)
  → 검증
  → OCI Object Storage PAR 업로드
  → 실패 시 Discord 알림
```

**mysqldump 플래그 근거**

| 플래그 | 이유 |
|---|---|
| `--single-transaction` | InnoDB를 **락 없이** 일관 스냅샷으로 — 서비스 중단 없음 |
| `--quick` | 결과를 메모리에 버퍼링하지 않음 |
| `--no-tablespaces` | `PROCESS` 권한 없는 계정에서도 동작 |
| `--set-gtid-purged=OFF` | 복원 시 GTID 구문이 걸리지 않게 |
| `--default-character-set=utf8mb4` | 한글 데이터 보존 |

도커 `mysql:8.0` 클라이언트를 쓰는 이유는 러너 이미지의 mysqldump 버전 변화에 백업이 좌우되지 않게 하기 위함이다.

**검증 단계** — 인증 실패·접속 차단이 빈 gzip으로 *조용히 성공*하는 것을 막는다:
- 5MB 미만이면 실패 처리(현재 정상값 27MB)
- 마지막 줄에 `Dump completed` 있는지 확인(잘린 덤프 탐지)

**실패 알림** — 백업은 조용히 실패하면 백업이 없는 것과 같다. `if: failure()`로 Discord 웹훅 전송.

## 로컬 검증

DB_URL 파싱 3케이스(포트 있음/없음/쿼리 파라미터 있음) 통과.

로컬 MySQL 8.0(프로덕션 데이터 사본)에 실제 덤프 실행:

```
exit=0   size=28,217,401 bytes   stderr 없음
마지막 줄: -- Dump completed on 2026-07-28 13:52:13
CREATE TABLE 44개 (DB 테이블 수와 일치)   INSERT 127문
```

## 머지 전 준비 (secret 1개)

`OCI_BACKUP_PAR_URL` 이 필요하다. OCI 콘솔에서:

1. **Storage → Buckets → Create Bucket** — 이름 `nar-backups`, Standard
2. 그 버킷 → **Pre-Authenticated Requests → Create** — 대상 *Bucket*, 권한 **Object write 만**, 만료 1년
3. 생성 직후 나오는 URL(다시 못 봄)을 레포 secret `OCI_BACKUP_PAR_URL` 로 저장
4. 버킷에 **라이프사이클 규칙 30일 만료** 추가 → 27MB × 30일 = 0.8GB (Always Free 20GB 내)

쓰기 전용 URL이라 유출 시에도 기존 백업을 읽거나 지울 수 없다.

머지 후 `workflow_dispatch`로 1회 수동 실행해 검증하고, **복원 리허설**(덤프를 로컬 도커에 넣어보기)도 한 번 하는 것을 권한다.

## 알려진 한계 / 후속

- ⚠️ **3306 인터넷 노출** — 지금 어디서든 TCP 접속이 된다. 실서비스 DB이므로 OCI 시큐리티 리스트에서 **EC2 IP `/32`만** 허용으로 좁혀야 한다. 좁히는 순간 이 워크플로는 러너 IP가 막혀 실패하므로, 그때 백업을 EC2 또는 서버 cron으로 옮긴다.
- SSH 접근 복구는 별개로 진행 중(Bastion 관리형 SSH).
- 이미지 백업(`/srv/nar/images`)은 #313 배포 후 별도 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)