### PR TITLE
fix: API 인증 실패를 302 로그인 리다이렉트에서 401로 변경

### DIFF
--- a/src/main/java/com/toy/nar/config/SecurityConfig.java
+++ b/src/main/java/com/toy/nar/config/SecurityConfig.java
@@ -10,13 +10,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -70,6 +75,22 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                // API 는 인증 실패 시 401 을 준다. 기본 진입점(oauth2Login 이 등록하는
+                // LoginUrlAuthenticationEntryPoint)은 /login 으로 302 리다이렉트를 보내는데,
+                // 모바일 클라이언트는 리다이렉트를 따라가 로그인 HTML 을 200 으로 받는다.
+                // 그러면 토큰 만료가 "빈 응답"으로 보여 화면이 조용히 비고, 401 기반 토큰
+                // 리프레시도 트리거되지 않는다(마이구독 알림 목록 미갱신 원인).
+                // 브라우저 OAuth 로그인 흐름(/oauth2/**, /login/**)은 기존 302 를 유지해야 하므로
+                // /api/** 에만 401 진입점을 적용한다.
+                // 두 번째 매핑(AnyRequest → /login)은 생략하면 안 된다. 매핑이 하나뿐이면
+                // 그 진입점이 전역 기본값이 되어 웹 경로까지 401 이 나간다.
+                .exceptionHandling(exception -> exception
+                        .defaultAuthenticationEntryPointFor(
+                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+                                PathPatternRequestMatcher.withDefaults().matcher("/api/**"))
+                        .defaultAuthenticationEntryPointFor(
+                                new LoginUrlAuthenticationEntryPoint("/login"),
+                                AnyRequestMatcher.INSTANCE))
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(a -> a
                                 .authorizationRequestRepository(authorizationRequestRepository))

--- a/src/test/java/com/toy/nar/config/ApiAuthenticationEntryPointTest.java
+++ b/src/test/java/com/toy/nar/config/ApiAuthenticationEntryPointTest.java
@@ -1,0 +1,109 @@
+package com.toy.nar.config;
+
+import com.toy.nar.app.auth.CookieOAuth2AuthorizationRequestRepository;
+import com.toy.nar.app.auth.CustomOAuth2UserService;
+import com.toy.nar.app.auth.JwtTokenProvider;
+import com.toy.nar.app.auth.OAuth2AuthenticationFailureHandler;
+import com.toy.nar.app.auth.OAuth2AuthenticationSuccessHandler;
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 인증 실패 응답 규약 검증.
+ *
+ * <p>/api/** 가 302 로그인 리다이렉트를 주면 모바일 클라이언트는 리다이렉트를 따라가
+ * 로그인 HTML 을 200 으로 받는다. 그러면 토큰 만료가 "빈 응답"으로 보여 화면이 조용히 비고
+ * 401 기반 토큰 리프레시도 트리거되지 않는다(마이구독 알림 목록 미갱신 원인). 반드시 401 이어야 한다.
+ *
+ * <p>JPA/DB 없이 시큐리티 필터 체인만 띄운다. {@code @WebMvcTest} 는 메인 클래스의
+ * {@code @EnableJpaRepositories} 때문에 EntityManagerFactory 를 요구해서 쓰지 않는다.
+ */
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = {SecurityConfig.class, ApiAuthenticationEntryPointTest.Mocks.class})
+class ApiAuthenticationEntryPointTest {
+
+	@Configuration
+	@EnableWebMvc // requestMatchers(String...) 가 MvcRequestMatcher 를 쓰므로 HandlerMappingIntrospector 필요
+	static class Mocks {
+
+		@Bean
+		JwtTokenProvider jwtTokenProvider() {
+			// 어떤 토큰도 유효하지 않다고 본다(만료·위조 토큰 상황).
+			return mock(JwtTokenProvider.class);
+		}
+
+		@Bean
+		CustomOAuth2UserService customOAuth2UserService() {
+			return mock(CustomOAuth2UserService.class);
+		}
+
+		@Bean
+		OAuth2AuthenticationSuccessHandler successHandler() {
+			return mock(OAuth2AuthenticationSuccessHandler.class);
+		}
+
+		@Bean
+		OAuth2AuthenticationFailureHandler failureHandler() {
+			return mock(OAuth2AuthenticationFailureHandler.class);
+		}
+
+		@Bean
+		CookieOAuth2AuthorizationRequestRepository authorizationRequestRepository() {
+			return mock(CookieOAuth2AuthorizationRequestRepository.class);
+		}
+
+		@Bean
+		ClientRegistrationRepository clientRegistrationRepository() {
+			return mock(ClientRegistrationRepository.class);
+		}
+	}
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp(WebApplicationContext context) {
+		mockMvc = MockMvcBuilders.webAppContextSetup(context)
+				.addFilters(context.getBean("springSecurityFilterChain", Filter.class))
+				.build();
+	}
+
+	@Test
+	@DisplayName("토큰 없이 API 를 호출하면 302 리다이렉트가 아니라 401 이다")
+	void apiWithoutTokenReturnsUnauthorized() throws Exception {
+		mockMvc.perform(get("/api/mobile/me/notifications"))
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("만료·위조 토큰도 401 이다")
+	void apiWithInvalidTokenReturnsUnauthorized() throws Exception {
+		mockMvc.perform(get("/api/mobile/me/notifications")
+						.header("Authorization", "Bearer expired.or.forged"))
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("브라우저 웹 경로는 기존 로그인 리다이렉트(302)를 유지한다")
+	void nonApiPathStillRedirectsToLogin() throws Exception {
+		mockMvc.perform(get("/some-web-page"))
+				.andExpect(status().is3xxRedirection());
+	}
+}


### PR DESCRIPTION
## 제보

> 업데이트 후에 마이 구독 창에서 선수들 솔랭 목록이 업데이트 되지 않는 오류가 있는 것 같습니다! 갤럭시 쓰고 있고 팝업 알림은 오는데 마이 구독창에는 알림이 안 오네요

내부에서도 동일 증상 재현됨.

## 원인

`SecurityConfig`에 `exceptionHandling(authenticationEntryPoint)` 설정이 없어서, `oauth2Login`이 등록하는 `LoginUrlAuthenticationEntryPoint`가 기본 진입점이 됐다. 그래서 `/api/**`도 인증 실패 시 `/login`으로 **302**를 보낸다.

모바일 클라이언트 관점:
1. 액세스 토큰 수명 30분 (`JwtTokenProvider.java:18`)
2. 만료 후 목록 조회 → 302 → HTTP 클라이언트가 리다이렉트 자동 추적 → 로그인 HTML을 200으로 수신
3. JSON 파싱 실패 → 빈 목록. **401이 아니므로 토큰 리프레시도 트리거되지 않는다**
4. FCM 팝업은 서버 인증과 무관 → 계속 도착

→ "팝업은 오는데 마이구독 목록은 갱신 안 됨"

동일 증상이 과거에 이미지 경로에서 한 번 터진 이력 있음: `72ef7a1 fix: 정적 리소스(/images 등) permitAll — 선수 이미지 302 로그인 리다이렉트 수정`. 당시엔 경로만 permitAll로 우회하고 진입점은 그대로 뒀다.

## 데이터는 정상이었다

제보 회원(id 1426) 프로덕션 실측:

| 항목 | 값 |
|---|---|
| 개별 구독 | 9명 |
| 기기 | ANDROID 1건, `active=1`, 토큰 회전 없음 |
| 푸시 SENT | 55건 |
| 피드 `member_notification` | **55건 (1:1 일치, 누락 0)** |
| 최신 피드 | 제보 시각 직전까지 정상 적재 |

기록·조회 로직 문제가 아니라 인증 실패 응답 규약 문제였다.

## 변경

`/api/**`만 401, 브라우저 OAuth 로그인 흐름은 `/login` 302 유지.

매핑을 하나만 등록하면 그 진입점이 **전역 기본값**이 되어 웹 경로까지 401이 나간다(테스트로 잡았다). 그래서 `AnyRequest → /login` 매핑을 함께 등록했다.

## 검증

`ApiAuthenticationEntryPointTest` 3케이스 통과 (JPA/DB 없이 시큐리티 필터 체인만 로드).

로컬 실제 기동 후 응답 매트릭스:

| 요청 | 변경 후 |
|---|---|
| 유효 토큰 → `me/notifications` | `200` + 피드 JSON 정상 |
| 만료 토큰 | `401` (이전 302 → /login) |
| 위조 토큰 | `401` |
| 토큰 없음 (`me/notifications`, `player-subscriptions`, `auth/me`) | `401` |
| USER 토큰 → `/api/admin/**` | `403` (유지) |
| 공개 API `/api/live/games` | `200` (유지) |
| `/v3/api-docs` | `200` (유지) |
| 웹 경로 | `302 → /login` (유지) |
| `/oauth2/authorization/google` | `302 → accounts.google.com` (유지) |

## 앱 쪽 확인 필요

앱이 401을 받고 `POST /api/auth/refresh`를 호출해야 실제 복구가 끝난다. 401 핸들링이 없으면 여전히 빈 목록이므로 재로그인 유도가 필요하다. 배포 후 앱에서 로그아웃 → 재로그인으로 목록이 채워지는지 확인 요청.

## 별건 (이 PR에 미포함)

`PlayerSoloRankPushService.java:77` 토픽 푸시 경로는 피드를 기록하지 않는다. '전체 선수 솔랭 알림'만 켠 사용자는 팝업만 오고 피드가 영구히 0건이다 (2026-06-24부터). 서버만으로는 수신자를 알 수 없어 앱과 합의 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)