### PR TITLE
fix: 무중단 배포 중 라이브 알림 유실 수정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -293,27 +293,32 @@ public class LiveObjectEventRecorder {
 			int valueAfter,
 			int opponentCurrentValue,
 			LocalDateTime frameTimestampUtc) {
-		boolean exists = objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
-				activeGame.gameId(), teamSide, eventType, eventOrder);
-		if (exists) {
-			return;
+		// 이미 저장된 이벤트라도 FCM 푸시는 다시 시도한다. 저장 직후 푸시 전에 프로세스가 죽으면
+		// (배포 중 컨테이너 교체) 다음 컨테이너가 exists 로 조기 return 해 그 알림이 영구 유실됐다.
+		// 발송 멱등은 delivery 테이블(reserve/reactivateStale)이 보장하므로 이미 SENT 인 건은 다시 안 나간다.
+		// 디스코드 알림은 멱등 장치가 없으므로 신규 저장 시에만 보낸다.
+		LiveGameObjectEvent event = objectEventRepository
+				.findByGameIdAndTeamSideAndEventTypeAndEventOrder(
+						activeGame.gameId(), teamSide, eventType, eventOrder)
+				.orElse(null);
+		boolean newlySaved = event == null;
+
+		if (newlySaved) {
+			event = objectEventRepository.save(new LiveGameObjectEvent(
+					activeGame.gameId(),
+					activeGame.matchId(),
+					activeGame.leagueName(),
+					teamSide,
+					eventType,
+					eventSubType,
+					eventOrder,
+					valueAfter,
+					frameTimestampUtc));
+			log.info("[live-notify] event saved type={} team={} order={} gameId={} notify={}",
+					eventType, teamSide, eventOrder, activeGame.gameId(), eventNotificationEnabled);
 		}
 
-		LiveGameObjectEvent event = new LiveGameObjectEvent(
-				activeGame.gameId(),
-				activeGame.matchId(),
-				activeGame.leagueName(),
-				teamSide,
-				eventType,
-				eventSubType,
-				eventOrder,
-				valueAfter,
-				frameTimestampUtc);
-		event = objectEventRepository.save(event);
-		log.info("[live-notify] event saved type={} team={} order={} gameId={} notify={}",
-				eventType, teamSide, eventOrder, activeGame.gameId(), eventNotificationEnabled);
-
-		if (eventNotificationEnabled && isNotifiableLeague(activeGame.leagueName())) {
+		if (newlySaved && eventNotificationEnabled && isNotifiableLeague(activeGame.leagueName())) {
 			notificationService.sendLiveObjectEventNotification(
 					activeGame.leagueName(),
 					teamNameOf(activeGame, teamSide),
@@ -345,38 +350,40 @@ public class LiveObjectEventRecorder {
 			Integer victimId,
 			Map<Integer, ParticipantMeta> metadata,
 			LocalDateTime frameTimestampUtc) {
-		boolean exists = objectEventRepository.existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
-				activeGame.gameId(), killerSide, EVENT_KILL, eventOrder);
-		if (exists) {
-			return;
-		}
-
 		ParticipantMeta killer = killerId == null ? null : metadata.get(killerId);
 		ParticipantMeta victim = victimId == null ? null : metadata.get(victimId);
 		String killerChampion = killer == null ? null : killer.champion();
 
-		// event_sub_type 은 하위호환을 위해 킬러 챔피언을 유지하고, 킬러/피해자 선수명과 피해자 챔피언을 신규 컬럼에 함께 저장한다.
-		LiveGameObjectEvent event = new LiveGameObjectEvent(
-				activeGame.gameId(),
-				activeGame.matchId(),
-				activeGame.leagueName(),
-				killerSide,
-				EVENT_KILL,
-				killerChampion,
-				eventOrder,
-				teamKillsAfter,
-				killer == null ? null : killer.summonerName(),
-				victim == null ? null : victim.champion(),
-				victim == null ? null : victim.summonerName(),
-				frameTimestampUtc);
-		event = objectEventRepository.save(event);
-		log.info("[live-notify] kill saved order={} team={} killer={} victim={} gameId={} notify={}",
-				eventOrder, killerSide,
-				killer == null ? "?" : killer.summonerName(),
-				victim == null ? "?" : victim.summonerName(),
-				activeGame.gameId(), eventNotificationEnabled);
+		// 오브젝트 이벤트와 같은 이유로, 이미 저장된 킬이라도 FCM 푸시는 다시 시도한다(saveEventIfAbsent 주석 참고).
+		LiveGameObjectEvent event = objectEventRepository
+				.findByGameIdAndTeamSideAndEventTypeAndEventOrder(
+						activeGame.gameId(), killerSide, EVENT_KILL, eventOrder)
+				.orElse(null);
+		boolean newlySaved = event == null;
 
-		if (eventNotificationEnabled && isNotifiableLeague(activeGame.leagueName())) {
+		if (newlySaved) {
+			// event_sub_type 은 하위호환을 위해 킬러 챔피언을 유지하고, 킬러/피해자 선수명과 피해자 챔피언을 신규 컬럼에 함께 저장한다.
+			event = objectEventRepository.save(new LiveGameObjectEvent(
+					activeGame.gameId(),
+					activeGame.matchId(),
+					activeGame.leagueName(),
+					killerSide,
+					EVENT_KILL,
+					killerChampion,
+					eventOrder,
+					teamKillsAfter,
+					killer == null ? null : killer.summonerName(),
+					victim == null ? null : victim.champion(),
+					victim == null ? null : victim.summonerName(),
+					frameTimestampUtc));
+			log.info("[live-notify] kill saved order={} team={} killer={} victim={} gameId={} notify={}",
+					eventOrder, killerSide,
+					killer == null ? "?" : killer.summonerName(),
+					victim == null ? "?" : victim.summonerName(),
+					activeGame.gameId(), eventNotificationEnabled);
+		}
+
+		if (newlySaved && eventNotificationEnabled && isNotifiableLeague(activeGame.leagueName())) {
 			notificationService.sendLiveKillNotification(
 					activeGame.leagueName(),
 					teamNameOf(activeGame, killerSide),

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePersistenceQueue.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePersistenceQueue.java
@@ -33,6 +33,10 @@ public class LivePersistenceQueue {
 	@Value("${lolesports.live.queue.object-capacity:1200}")
 	private int objectCapacity;
 
+	/** 종료 시 남은 큐를 비우는 데 쓸 최대 시간. graceful shutdown 예산(30초) 안에 들어가야 한다. */
+	@Value("${lolesports.live.queue.drain-timeout-ms:10000}")
+	private long drainTimeoutMs;
+
 	private BlockingQueue<LiveGameState> snapshotQueue;
 	private BlockingQueue<ObjectEventTask> objectQueue;
 	private final AtomicBoolean running = new AtomicBoolean(false);
@@ -51,6 +55,57 @@ public class LivePersistenceQueue {
 	@PreDestroy
 	void stop() {
 		running.set(false);
+		drainRemaining();
+	}
+
+	/**
+	 * 종료 시 남은 큐를 마감 시한 안에서 비운다.
+	 *
+	 * 예전에는 running=false 만 세팅해 큐에 쌓인 오브젝트 태스크(최대 1200)와 스냅샷(최대 600)을
+	 * 그대로 버렸다. 오브젝트 태스크에는 LIVE_EVENT FCM 푸시가 실려 있어, 무중단 배포로 구 컨테이너가
+	 * 내려갈 때 그 알림이 통째로 유실됐다(배포 중 "알림이 한동안 안 오다가 몰아서 옴"의 원인).
+	 *
+	 * 오브젝트 태스크를 먼저 비운다 — 알림이 걸려 있어 사용자 체감에 직접 영향을 준다.
+	 */
+	void drainRemaining() {
+		long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(drainTimeoutMs);
+		int objects = 0;
+		int snapshots = 0;
+
+		while (System.nanoTime() < deadline) {
+			ObjectEventTask task = objectQueue.poll();
+			if (task != null) {
+				if (drainOne(() -> objectEventRecorder.record(task.activeGame(), task.windowResponse()))) {
+					objects++;
+				}
+				continue;
+			}
+			LiveGameState state = snapshotQueue.poll();
+			if (state != null) {
+				if (drainOne(() -> snapshotWriter.write(state))) {
+					snapshots++;
+				}
+				continue;
+			}
+			break;
+		}
+
+		int remaining = objectQueue.size() + snapshotQueue.size();
+		if (objects > 0 || snapshots > 0 || remaining > 0) {
+			log.info("Live queue drained on shutdown. objects={} snapshots={} remaining={}",
+					objects, snapshots, remaining);
+		}
+	}
+
+	/** 한 건 실패가 나머지 drain 을 막지 않게 삼킨다. */
+	private boolean drainOne(Runnable action) {
+		try {
+			action.run();
+			return true;
+		} catch (Exception e) {
+			log.warn("Live queue drain item failed: {}", e.getMessage());
+			return false;
+		}
 	}
 
 	public void enqueueSnapshot(LiveGameState state) {

--- a/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameObjectEventRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/repository/LiveGameObjectEventRepository.java
@@ -5,10 +5,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface LiveGameObjectEventRepository extends JpaRepository<LiveGameObjectEvent, Long> {
 
 	boolean existsByGameIdAndTeamSideAndEventTypeAndEventOrder(
+			String gameId,
+			String teamSide,
+			String eventType,
+			Integer eventOrder);
+
+	/**
+	 * 이미 저장된 이벤트를 집어 온다. 저장 여부와 무관하게 FCM 푸시를 재시도해야 하므로
+	 * exists 판정만으로는 부족하고(푸시 멱등 키가 이 행의 id 다) 행 자체가 필요하다.
+	 */
+	Optional<LiveGameObjectEvent> findByGameIdAndTeamSideAndEventTypeAndEventOrder(
 			String gameId,
 			String teamSide,
 			String eventType,

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
@@ -43,7 +43,13 @@ public interface MemberTeamEventPushDeliveryRepository
 			@Param("eventType") String eventType,
 			@Param("eventOrder") long eventOrder);
 
-	/** 재예약. 실패했거나 5분 넘게 PENDING 으로 방치된 건만 되살린다. SENT 는 절대 재예약되지 않는다. */
+	/**
+	 * 재예약. 실패했거나 1분 넘게 PENDING 으로 방치된 건만 되살린다. SENT 는 절대 재예약되지 않는다.
+	 *
+	 * 방치 기준이 5분이었으나 라이브 경기 알림은 5분 늦으면 의미가 없어 1분으로 줄였다.
+	 * PENDING 은 reserve 직후 FCM 발송까지의 짧은 구간이라(스코어 재조회는 reserve 이전에 끝난다)
+	 * 1분이면 정상 발송 중인 건을 중복 발송할 위험은 없다.
+	 */
 	@Modifying
 	@Transactional
 	@Query(value = """
@@ -55,7 +61,7 @@ public interface MemberTeamEventPushDeliveryRepository
 			  AND event_type = :eventType
 			  AND event_order = :eventOrder
 			  AND (status = 'FAILED'
-					OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)))
+					OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 1 MINUTE)))
 			""", nativeQuery = true)
 	int reactivateStale(
 			@Param("memberId") Long memberId,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,22 @@
+server:
+  # 무중단 배포에서 구 컨테이너는 nginx 전환 후 docker stop -t 35 로 내려간다.
+  # 그 35초 안에 진행 중인 요청과 라이브 이벤트 저장·FCM 발송을 끝내고 죽어야 알림이 유실되지 않는다.
+  shutdown: graceful
+
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
+
+  # docker stop 의 35초보다 짧게 잡아, 강제 SIGKILL 전에 정상 종료가 끝나도록 한다.
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
+  task:
+    execution:
+      shutdown:
+        # SET_END 푸시처럼 executor 에서 도는 알림 작업을 기다린다(스코어 재조회로 수십 초 걸릴 수 있음).
+        await-termination: true
+        await-termination-period: 25s
 
   jpa:
     properties:

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePersistenceQueueDrainTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePersistenceQueueDrainTest.java
@@ -1,0 +1,85 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.toy.nar.app.lolesports.live.dto.LiveGameState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 종료 시 큐를 버리지 않고 비우는지 지키는 회귀 테스트.
+ *
+ * 예전에는 stop() 이 running=false 만 세팅해 큐에 쌓인 오브젝트 태스크(LIVE_EVENT FCM 푸시 포함)를
+ * 그대로 버렸고, 무중단 배포 중 구 컨테이너가 내려갈 때 그 알림이 유실됐다.
+ */
+class LivePersistenceQueueDrainTest {
+
+	private final LiveMinuteSnapshotWriter snapshotWriter = mock(LiveMinuteSnapshotWriter.class);
+	private final LiveObjectEventRecorder objectEventRecorder = mock(LiveObjectEventRecorder.class);
+	/** 워커를 띄우지 않는 executor — drain 동작만 검증하고 워커와의 경쟁을 배제한다. */
+	private final AsyncTaskExecutor noopExecutor = mock(AsyncTaskExecutor.class);
+
+	private LivePersistenceQueue queue;
+
+	@BeforeEach
+	void setUp() {
+		queue = new LivePersistenceQueue(snapshotWriter, objectEventRecorder, noopExecutor);
+		ReflectionTestUtils.setField(queue, "snapshotCapacity", 10);
+		ReflectionTestUtils.setField(queue, "objectCapacity", 10);
+		ReflectionTestUtils.setField(queue, "drainTimeoutMs", 5000L);
+		ReflectionTestUtils.invokeMethod(queue, "start");
+	}
+
+	@Test
+	@DisplayName("종료 시 큐에 남은 오브젝트 태스크와 스냅샷을 모두 처리한다")
+	void 종료_시_큐를_비운다() {
+		queue.enqueueObjectEvents(activeGame("GAME-1"), windowResponse());
+		queue.enqueueObjectEvents(activeGame("GAME-2"), windowResponse());
+		queue.enqueueSnapshot(state("GAME-1"));
+
+		ReflectionTestUtils.invokeMethod(queue, "stop");
+
+		verify(objectEventRecorder, times(2)).record(any(), any());
+		verify(snapshotWriter).write(any());
+		org.assertj.core.api.Assertions.assertThat(queue.stats().objectQueueSize()).isZero();
+		org.assertj.core.api.Assertions.assertThat(queue.stats().snapshotQueueSize()).isZero();
+	}
+
+	@Test
+	@DisplayName("한 건이 실패해도 나머지 drain 은 계속된다")
+	void 실패한_건이_drain을_막지_않는다() {
+		doThrow(new RuntimeException("boom")).when(objectEventRecorder).record(any(), any());
+		queue.enqueueObjectEvents(activeGame("GAME-1"), windowResponse());
+		queue.enqueueSnapshot(state("GAME-1"));
+
+		ReflectionTestUtils.invokeMethod(queue, "stop");
+
+		verify(snapshotWriter).write(any());
+	}
+
+	private ActiveLiveGame activeGame(String gameId) {
+		return new ActiveLiveGame(gameId, "MATCH-1", "LCK", "T1", "GEN",
+				LocalDateTime.now(), 0, 1, "blue-esports-id", "red-esports-id");
+	}
+
+	private ObjectNode windowResponse() {
+		return JsonNodeFactory.instance.objectNode();
+	}
+
+	private LiveGameState state(String gameId) {
+		return new LiveGameState(gameId, "MATCH-1", "LCK", "T1", "GEN",
+				LocalDateTime.now(), LocalDateTime.now(), List.of(), List.of());
+	}
+}


### PR DESCRIPTION
## 제보

> dns vs bro 2세트까진 잘 오다가 마지막 세트에서 앱 알림 오류로 한동안 알림이 안 오다가 끝날 때쯤 쭈르륵 알림이 오고 몇 개는 씹히네요

배포와 연관 확인됨. CloudWatch 로그 스트림 메타데이터 기준 오늘 경기 시간대 배포 4회:

| 배포 | KST |
|---|---|
#310 | 20:52:29 → 20:55:43 |
(중간) | 21:12:54 → 21:16:05 |
#311 | 21:29:53 → 21:33:28 |
#314 | 22:17:15 → 22:20:31 |

커뮤니티 글 "케스파컵 든숲이 브리온 이겼네"가 22:18:56 — 마지막 세트가 21:30~22:18 구간이고 배포 2회가 겹쳤다. 1·2세트 정상, 3세트만 깨진 것과 일치.

## 원인

**1. 종료 시 큐를 버린다** — `LivePersistenceQueue.stop()`이 `running=false`만 세팅. 오브젝트 태스크(최대 1200)·스냅샷(최대 600)을 폐기. 오브젝트 태스크에 `LIVE_EVENT` FCM 푸시가 실려 있어 통째로 유실 → **"한동안 안 옴"**

**2. graceful shutdown 미설정** — SIGTERM에 즉시 컨텍스트 종료. `docker stop -t 35`가 35초를 주는데도 진행 중 발송이 중단. SET_END 푸시는 스코어 재조회(`retry-attempts:6` × `retry-delay-ms:10000`)로 최대 ~80초라 거의 항상 잘렸다 → **SET_END 유실**

**3. save-then-push 비원자성** — `saveEventIfAbsent`/`saveKillEventIfAbsent`가 이미 저장된 이벤트를 만나면 조기 return. "저장은 됐지만 푸시 전에 죽은" 이벤트는 다음 컨테이너에서도 영구히 안 나감 → **"몇 개 씹힘"**

버스트("쭈르륵")는 1번의 결과다. 구 컨테이너가 버린 이벤트를 새 컨테이너가 window 프레임에서 재유도해 한꺼번에 저장·발송했다.

## 변경

- `LivePersistenceQueue`: `@PreDestroy`에서 남은 큐를 마감 시한(`drain-timeout-ms`, 기본 10초) 안에 비운다. 알림이 걸린 오브젝트 태스크를 스냅샷보다 먼저 처리. 한 건 실패가 나머지 drain을 막지 않음
- `application.yml`: `server.shutdown=graceful`, `spring.lifecycle.timeout-per-shutdown-phase=30s`, `spring.task.execution.shutdown.await-termination=true`(25s). 모두 `docker stop -t 35`의 35초 예산 안
- `LiveObjectEventRecorder`: `existsBy...` → `findBy...`. 이미 저장된 이벤트라도 FCM 푸시는 재시도. 발송 멱등은 delivery 테이블의 `reserve`/`reactivateStale`이 보장하므로 SENT는 재발송 안 됨. 멱등 장치 없는 디스코드 알림은 신규 저장 시에만
- `MemberTeamEventPushDeliveryRepository`: PENDING 방치 재활성 5분 → 1분. 라이브 알림은 5분 늦으면 무의미. `reserve`→발송 구간은 FCM 호출뿐이라(스코어 재조회는 `reserve` 이전에 끝난다) 중복 발송 위험 없음

## 효과

| 증상 | 결과 |
|---|---|
몇 개 씹힘 | 해결 |
한동안 안 옴 | 유실 차단. 배포 중 **~30초 지연**은 남음 |
쭈르륵 버스트 | 버릴 이벤트가 없어져 재유도분이 사라짐 |

## 검증

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

회귀 테스트: 종료 시 큐가 비워지는지, 한 건 실패가 drain을 막지 않는지. `stop()`에서 `drainRemaining()`을 빼면 두 테스트 모두 FAILED 되는 것 확인 후 되돌림.

graceful shutdown은 실제 SIGTERM 경로라 단위 테스트로 못 잡는다. 배포 후 구 컨테이너 종료 로그에서 `Live queue drained on shutdown. objects=N` 확인 필요.

## 안 한 것

**in-memory 상태를 DB에서 복원**(`lastObservedByGame`)은 넣지 않았다. 검토해보니 위 3개를 고치면 불필요해진다 — 버스트는 큐 유실로 생긴 미발송분의 재유도였고, 유실이 없으면 재유도 대상이 SENT여서 dedup에 걸러진다. 남는 이득은 window 프레임 재파싱 비용 절감뿐(정확성 무관).

**RESERVED 스윕**도 뺐다. graceful shutdown이 진행 중 발송을 마치게 하므로 stuck PENDING 자체가 안 생긴다. 남는 갭은 SIGKILL/OOM으로 죽는 경우뿐 — 필요해지면 별도 PR.

Redis 등 외부 저장소는 도입하지 않았다. 인스턴스가 2개인 시간은 배포 겹침 40초뿐이어서, 상시 인프라 추가와 새 장애 모드(Redis 다운 시 라이브 파이프라인 정지) 대비 이득이 없다. 수평 확장 시 재검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)