### PR TITLE
fix: 라이브 이벤트 뭉침·중복 저장 수정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveObjectEventRecorder.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -31,6 +32,18 @@ public class LiveObjectEventRecorder {
 	private static final String EVENT_TOWER = "TOWER";
 	private static final String EVENT_INHIBITOR = "INHIBITOR";
 	private static final String EVENT_KILL = "KILL";
+
+	/*
+	 * 관측 연속성 한계값. 프레임은 정상적으로 10초 간격으로 도착하고, 한 프레임 안에서
+	 * 현실적으로 가능한 증가분은 제한적이다(에이스가 5킬, 넥서스 앞 연쇄가 타워 2개).
+	 * 이 한계를 넘는 diff 는 "그 사이 프레임을 놓쳤다"는 신호이므로 이벤트를 유도하지 않는다.
+	 */
+	private static final long MAX_FRAME_GAP_SECONDS = 60L;
+	private static final int MAX_KILL_JUMP = 5;
+	private static final int MAX_TOWER_JUMP = 2;
+	private static final int MAX_BARON_JUMP = 1;
+	private static final int MAX_INHIBITOR_JUMP = 2;
+	private static final int MAX_DRAGON_JUMP = 1;
 
 	private final LiveGameObjectEventRepository objectEventRepository;
 	private final NotificationService notificationService;
@@ -73,6 +86,20 @@ public class LiveObjectEventRecorder {
 			if (previous != null && !snapshot.frameTimestampUtc().isAfter(previous.frameTimestampUtc())) {
 				continue;
 			}
+			if (previous != null && !isContinuousObservation(previous, snapshot)) {
+				// 공백 구간의 이벤트는 복구하지 않는다. 유도하면 전부 이 프레임에서 발생한 것으로 뭉친다.
+				log.warn("[live-notify] 관측 공백 감지 — 이벤트 유도 생략, 상태만 동기화 "
+								+ "gameId={} prevFrame={} frame={} killΔ={}/{} towerΔ={}/{}",
+						activeGame.gameId(), previous.frameTimestampUtc(), snapshot.frameTimestampUtc(),
+						snapshot.blue().kills() - previous.blue().kills(),
+						snapshot.red().kills() - previous.red().kills(),
+						snapshot.blue().towers() - previous.blue().towers(),
+						snapshot.red().towers() - previous.red().towers());
+				previous = new ObservedObjectState(snapshot.frameTimestampUtc(), snapshot.blue(), snapshot.red(),
+						snapshot.blueParticipants(), snapshot.redParticipants());
+				continue;
+			}
+
 			if (previous != null) {
 				int gameTotalPrevKills = previous.blue().kills() + previous.red().kills();
 				recordObjectDiff(activeGame, "Blue", previous.blue(), snapshot.blue(), snapshot.red(),
@@ -96,6 +123,35 @@ public class LiveObjectEventRecorder {
 		}
 
 		lastObservedByGame.put(activeGame.gameId(), previous);
+	}
+
+	/**
+	 * previous → snapshot 이 "연속된 관측"인지 판정한다.
+	 *
+	 * <p>추적이 끊겼다가 재개되면(업스트림 liveGameIds 가 늦게 도착해 디스커버리가 진행 중 게임을
+	 * 놓치는 케이스 — 실측 15~16분) previous 는 끊기기 전 상태다. 그 상태와 현재 프레임을 그대로
+	 * diff 하면 공백 구간 이벤트 전부가 "이 프레임에서 발생"한 것으로 뭉치고, 뭉친 킬 델타를
+	 * 그리디 페어링하면 같은 킬이 서로 다른 event_order 로 3~4개 복제된다.
+	 * (2026-07-27 KESPA DNS vs T1: 같은 킬러·피해자 조합 3회 저장,
+	 *  2026-07-28 KESPA DNS vs BRO 3세트: 19개 이벤트가 단일 프레임에 뭉침)</p>
+	 *
+	 * <p>공백 구간 이벤트는 복구하지 않는다. 놓친 알림보다 가짜 이벤트 3배 저장과 알림 폭탄이 나쁘다.</p>
+	 */
+	private boolean isContinuousObservation(ObservedObjectState previous, FrameSnapshot snapshot) {
+		long gapSeconds = Duration.between(previous.frameTimestampUtc(), snapshot.frameTimestampUtc()).getSeconds();
+		if (gapSeconds > MAX_FRAME_GAP_SECONDS) {
+			return false;
+		}
+		return withinJumpLimit(previous.blue(), snapshot.blue())
+				&& withinJumpLimit(previous.red(), snapshot.red());
+	}
+
+	private boolean withinJumpLimit(TeamObjectState previous, TeamObjectState current) {
+		return current.kills() - previous.kills() <= MAX_KILL_JUMP
+				&& current.towers() - previous.towers() <= MAX_TOWER_JUMP
+				&& current.barons() - previous.barons() <= MAX_BARON_JUMP
+				&& current.inhibitors() - previous.inhibitors() <= MAX_INHIBITOR_JUMP
+				&& current.dragons().size() - previous.dragons().size() <= MAX_DRAGON_JUMP;
 	}
 
 	private List<FrameSnapshot> toSnapshots(JsonNode frames) {
@@ -159,10 +215,18 @@ public class LiveObjectEventRecorder {
 		List<Integer> victims = expandByDelta(victimPrevKd, victimCurKd, false);
 
 		int newKills = currentTeamKills - previousTeamKills;
+		// 같은 (킬러, 피해자) 조합이 한 프레임에서 반복되면 페어링 결과가 잘못된 것이다 —
+		// 피해자는 한 프레임에 한 번만 죽는다. order 는 소비하되 저장·발송은 건너뛴다.
+		java.util.Set<String> pairsSeen = new java.util.HashSet<>();
 		for (int i = 0; i < newKills; i++) {
 			int order = previousTeamKills + 1 + i;
 			Integer killerId = i < killers.size() ? killers.get(i) : null;
 			Integer victimId = i < victims.size() ? victims.get(i) : null;
+			if (killerId != null && victimId != null && !pairsSeen.add(killerId + ">" + victimId)) {
+				log.warn("[live-notify] 킬 페어링 중복 — 저장 생략 gameId={} team={} order={} killer={} victim={}",
+						activeGame.gameId(), killerSide, order, killerId, victimId);
+				continue;
+			}
 			// 선취점: 이 프레임 이전까지 양팀 킬 합이 0이고, 이 팀의 첫 킬일 때.
 			boolean firstBlood = gameTotalPrevKills == 0 && order == 1 && i == 0;
 			saveKillEventIfAbsent(activeGame, killerSide, order, currentTeamKills, opponentCurrentKills,

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -125,13 +125,22 @@ public class LivePollingScheduler {
 					// 진행 중 게임을 찾는다. 피드가 라이브면 state 를 inProgress 로 올린다.
 					// 매 사이클 재판정해야 한다 — 이미 추적 중(activeMatchIds)이어도 여기서 다시 올리지 않으면
 					// 아래 syncRealtimeMatchStatus 가 Riot 원본 unstarted 로 DB 를 되돌린다.
+					// 업스트림이 진행 중 게임을 못 알려주는 경우를 피드 실측으로 우회한다. 두 가지가 있다:
+					//  (1) state 를 unstarted 로 방치 (EWC 등)
+					//  (2) state 는 넘어갔는데 liveGameIds 가 비어서 도착 — 실측 15~16분 지연
+					//      (2026-07-27 KESPA T1 vs DNS, 2026-07-28 KESPA DNS vs BRO 3세트)
+					// (2)는 예전에 unstarted 게이트에 걸려 우회로를 못 탔고, 그 사이 세트 하나가
+					// 통째로 추적되지 않았다. 그래서 게이트를 "업스트림이 라이브 게임을 모를 때"로 넓힌다.
+					// completed 는 디스커버리 대상이 아니므로 제외해 불필요한 외부 호출을 막는다.
 					List<String> feedLiveGameIds = List.of();
-					if ("unstarted".equalsIgnoreCase(match.getState())) {
+					boolean upstreamKnowsLiveGames =
+							match.getLiveGameIds() != null && !match.getLiveGameIds().isEmpty();
+					if (!upstreamKnowsLiveGames && !"completed".equalsIgnoreCase(match.getState())) {
 						FeedProbe probe = probeFeed(match);
 						feedLiveGameIds = probe.liveGameIds();
 						if (!feedLiveGameIds.isEmpty()) {
 							match.setState("inProgress");
-						} else if (probe.sawFinished()) {
+						} else if ("unstarted".equalsIgnoreCase(match.getState()) && probe.sawFinished()) {
 							// 세트 사이/경기 종료 직후: 피드는 finished 잔상인데 업스트림 state 는 여전히 unstarted.
 							// 업스트림 원본(unstarted)으로 sync 하면 DB 의 inProgress 가 되돌아가므로 쓸 수 없다.
 							// 대신 네이버가 매치 종료(RESULT)를 확인해주면 completed 를 직접 확정한다 —
@@ -259,7 +268,8 @@ public class LivePollingScheduler {
 	 * 창 밖이거나 게임 id 가 없거나 피드가 비면 EMPTY — 기존 inProgress 경로에는 영향 없다.
 	 */
 	private FeedProbe probeFeed(MatchResultDto match) {
-		if (!"unstarted".equalsIgnoreCase(match.getState()) || !withinFeedProbeWindow(match.getMatchDate())) {
+		// state 조건은 호출부가 판단한다(unstarted 방치 + liveGameIds 지연 둘 다 대상).
+		if (!withinFeedProbeWindow(match.getMatchDate())) {
 			return FeedProbe.EMPTY;
 		}
 		List<String> gameIds = match.getGameIds();

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventClumpGuardTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveObjectEventClumpGuardTest.java
@@ -1,0 +1,119 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.toy.nar.app.data.source.NotificationService;
+import com.toy.nar.app.lolesports.LeagueConfigService;
+import com.toy.nar.app.lolesports.live.entity.LiveGameObjectEvent;
+import com.toy.nar.app.lolesports.live.repository.LiveGameObjectEventRepository;
+import com.toy.nar.app.mobile.push.TeamLiveEventPushService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 관측 공백 뒤 재개될 때 이벤트가 한 프레임에 뭉쳐 저장되는 것을 막는지 지키는 회귀 테스트.
+ *
+ * 실제 사고: 업스트림 liveGameIds 지연으로 15~16분간 추적이 끊긴 뒤 재개되자,
+ * 끊기기 전 상태와 현재 프레임을 한 번에 diff 해 그 구간 이벤트 전부가 단일 프레임으로 뭉쳤다.
+ * 뭉친 킬 델타를 그리디 페어링하면서 같은 킬이 3~4개로 복제돼 저장·발송됐다.
+ */
+class LiveObjectEventClumpGuardTest {
+
+	private static final DateTimeFormatter FEED_FORMAT =
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SS'Z'");
+
+	private final LiveGameObjectEventRepository repository = mock(LiveGameObjectEventRepository.class);
+	private final NotificationService notificationService = mock(NotificationService.class);
+	private final TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+	private final LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+
+	private final LiveObjectEventRecorder recorder =
+			new LiveObjectEventRecorder(repository, notificationService, pushService, leagueConfigService);
+
+	@Test
+	@DisplayName("정상 간격 프레임은 이벤트를 유도한다")
+	void 연속_관측이면_이벤트를_저장한다() {
+		when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+		LocalDateTime base = LocalDateTime.of(2026, 7, 28, 13, 0, 0);
+
+		// 첫 프레임으로 기준을 잡고, 10초 뒤 프레임에서 타워 1개가 늘어난다.
+		recorder.record(activeGame(), window(
+				frame(base, 2, 0),
+				frame(base.plusSeconds(10), 3, 0)));
+
+		verify(repository, atLeastOnce()).save(any(LiveGameObjectEvent.class));
+	}
+
+	@Test
+	@DisplayName("프레임 간 점프가 비정상이면 이벤트를 유도하지 않는다")
+	void 비정상_점프면_저장하지_않는다() {
+		LocalDateTime base = LocalDateTime.of(2026, 7, 28, 13, 0, 0);
+
+		// 10초 사이에 타워 6개 + 킬 9개 — 현실적으로 불가능한 증가분(실제 사고 재현).
+		recorder.record(activeGame(), window(
+				frame(base, 2, 0),
+				frame(base.plusSeconds(10), 8, 9)));
+
+		verify(repository, never()).save(any(LiveGameObjectEvent.class));
+	}
+
+	@Test
+	@DisplayName("프레임 시각 간격이 크게 벌어지면 이벤트를 유도하지 않는다")
+	void 프레임_공백이_크면_저장하지_않는다() {
+		LocalDateTime base = LocalDateTime.of(2026, 7, 28, 13, 0, 0);
+
+		// 15분 공백 뒤 재개 — 증가분 자체는 작아도 그 사이 프레임을 놓쳤다.
+		recorder.record(activeGame(), window(
+				frame(base, 2, 0),
+				frame(base.plusMinutes(15), 3, 1)));
+
+		verify(repository, never()).save(any(LiveGameObjectEvent.class));
+	}
+
+	private ActiveLiveGame activeGame() {
+		return new ActiveLiveGame("GAME-1", "MATCH-1", "KESPA", "DNS", "BRO",
+				LocalDateTime.now(ZoneOffset.UTC), 0, 3, "blue-id", "red-id");
+	}
+
+	private ObjectNode window(ObjectNode... frames) {
+		ObjectNode root = JsonNodeFactory.instance.objectNode();
+		root.putObject("gameMetadata");
+		ArrayNode array = root.putArray("frames");
+		for (ObjectNode frame : frames) {
+			array.add(frame);
+		}
+		return root;
+	}
+
+	/** blueTeam 에만 타워·킬을 채운 최소 프레임. redTeam 은 전부 0 으로 고정한다. */
+	private ObjectNode frame(LocalDateTime timestampUtc, int blueTowers, int blueKills) {
+		ObjectNode frame = JsonNodeFactory.instance.objectNode();
+		frame.put("rfc460Timestamp", timestampUtc.format(FEED_FORMAT));
+		frame.put("gameState", "in_game");
+		team(frame.putObject("blueTeam"), blueTowers, blueKills);
+		team(frame.putObject("redTeam"), 0, 0);
+		return frame;
+	}
+
+	private void team(ObjectNode team, int towers, int kills) {
+		team.put("towers", towers);
+		team.put("barons", 0);
+		team.put("inhibitors", 0);
+		team.put("totalKills", kills);
+		team.putArray("dragons");
+		team.putArray("participants");
+	}
+}


### PR DESCRIPTION
## 제보 2건

- **07-27** KESPA T1 vs DNS — 이벤트가 3개씩 저장됨
- **07-28** KESPA DNS vs BRO 3세트 — 알림이 한동안 안 오다가 끝날 때쯤 쭈르륵, 몇 개는 누락

같은 뿌리다. 배포와는 무관하다 — **07-27은 배포가 0건**이었다(07-26 15:02 → 07-28 00:06 사이 없음).

## 실측 데이터

프로덕션 이벤트 API로 확인한 게임별 분포:

| 게임 | 이벤트 | 프레임 | 같은 킬 중복 |
|---|---|---|---|
DNS vs T1 (07-27) | 41 | **10** | **3회** (1389초, T1A Cypher→DNS Peter 등) |
GEN vs BFX (07-27) | 44 | **17** | **4회** (1634초, GEN Ruler→BFX Kellin 등) |
DNS vs BRO 3세트 (07-28) | 19 | **1** | 0 (뭉침만) |
DRX vs HLE | 82 | 80 | 0 |
NS vs T1 | 81 | 78 | 0 |
T1 vs DK | 63 | 59 | 0 |

정상 게임은 이벤트 수 ≈ 프레임 수. 문제 게임만 프레임이 1/4로 줄고 같은 킬이 3~4회 저장됐다.

07-28 3세트는 19건 전부 `gameTime 421초` 한 점 — 타워 6개·억제기 2개·바론·드래곤·킬 9개가 같은 순간으로 기록됐다.

livestats 피드를 직접 조회해 추적 공백도 확정했다:

```
startingTime(KST)  HTTP  프레임
21:35              204   없음        ← 세트3 아직 시작 안 함
21:50              200   27개 in_game ← 피드는 이미 라이브
22:00              200   25개 in_game
22:06:23           앱이 뒤늦게 세트 발견 (16분 지연)
```

## 원인 사슬

1. **업스트림 `liveGameIds` 지연** (실측 15~16분) → 디스커버리가 진행 중 게임을 놓친다. 기존 우회로(피드 직접 프로브)는 `state=unstarted`에만 걸려 있어, state는 넘어갔는데 `liveGameIds`만 비어 오는 이번 케이스를 못 잡았다. 같은 파일 주석에 이미 `"업스트림 flip 은 실측 17분+ 늦게 온다(2026-07-27 KESPA T1 vs DNS)"` 기록이 있다 — 어제 그 경기다.
2. **재개 시 단일 diff** → `lastObservedByGame`(끊기기 전 상태)과 현재 프레임을 그대로 비교해 공백 구간 이벤트가 전부 현재 프레임에서 발생한 것으로 뭉친다.
3. **그리디 페어링 복제** → `recordKills`가 뭉친 팀 킬 델타만큼 킬러·피해자를 펼쳐 페어링하므로 같은 `(킬러, 피해자)` 조합이 서로 다른 `event_order`로 여러 건 생성된다. 멱등 키가 `(gameId, teamSide, eventType, eventOrder)`라 order가 다르면 DB dedup을 통과 → 3~4건 저장, 푸시도 그만큼.

## 변경

- **관측 연속성 검사** (`LiveObjectEventRecorder`) — 프레임 시각 간격이 60초를 넘거나 증가분이 현실적 한계(킬 5·타워 2·바론 1·억제기 2·드래곤 1)를 넘으면 이벤트를 유도하지 않고 상태만 동기화. 공백 구간 이벤트는 복구하지 못하지만 가짜 이벤트 복제와 알림 폭탄을 막는다
- **킬 페어링 중복 방지** — 한 프레임에서 같은 `(킬러, 피해자)`가 반복되면 페어링 오류이므로 저장 생략. 피해자는 한 프레임에 한 번만 죽는다
- **피드 프로브 게이트 확장** (`LivePollingScheduler`) — `state=unstarted` → "업스트림이 라이브 게임을 모를 때(`liveGameIds` 비어 있음)". `completed`는 디스커버리 대상이 아니라 제외해 외부 호출 증가를 막았다

## 검증

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

회귀 테스트 3개 — 정상 간격은 유도하고, 비정상 점프(10초에 타워 6개+킬 9개)와 프레임 공백(15분)은 유도하지 않는다. 가드 조건을 `if (false)`로 무력화하면 뒤 2개가 FAILED 되는 것 확인 후 되돌렸다.

## 한계·후속

- **공백 구간 이벤트는 못 살린다.** 가드는 가짜 이벤트를 막을 뿐이다. 공백 자체를 줄이는 게 피드 프로브 게이트 확장의 몫이고, 그게 얼마나 잡는지는 다음 경기에서 확인해야 한다
- **오염 데이터 정리 필요** — 07-27 DNS vs T1·GEN vs BFX에 중복 행이 남아 있어 앱 타임라인에 킬이 3~4번 보인다. 별도 정리 쿼리 필요
- **디스커버리 로그 부재** — 이번 조사에서 로그로 못 좁혀 피드를 수동 조회해야 했다. `discoverLiveGames`에 후보/선정 게임 INFO 로그 추가 권장
- **`record()`의 FCM 동기 발송** — 이벤트당 2.09초, 그 트랜잭션이 `member`·`member_device`·`member_notification` 락을 쥐어 07-28 21:30~22:03에 Lock wait timeout 22건 발생(21:50에 8건 집중). 별 트랙이지만 실측된 문제다
- PR #318(큐 drain·graceful shutdown)은 같은 메서드를 건드려 리베이스가 필요하다. 이 PR이 먼저 머지되는 게 맞다

🤖 Generated with [Claude Code](https://claude.com/claude-code)