### PR TITLE
fix: 행 락 대기 상한을 커넥션마다 5초로 낮춤 (기본 50초)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,19 @@ spring:
         await-termination: true
         await-termination-period: 25s
 
+  datasource:
+    hikari:
+      # 행 락 대기 상한을 커넥션마다 5초로 낮춘다(MySQL 기본 50초).
+      #
+      # 50초 대기는 사용자 입장에서 실패와 같은데 스레드와 커넥션만 붙잡는다. 실측
+      # 2026-07-29 T1 vs KT 에서 세트 종료 푸시가 구독자마다 정확히 50초씩 락 대기 후
+      # 타임아웃돼(fan-out 이 순차라) 알림 하나가 6분 넘게 밀렸고, 세트 시작 푸시는 폴링
+      # 스레드를 17분간 세워 그 구간 라이브 이벤트가 통째로 누락됐다.
+      #
+      # 세션 변수라 DB 관리자 권한도 재시작도 필요 없고, 글로벌 값(50초)은 그대로 남아
+      # 백업·수동 작업 등 앱 밖 세션에는 영향이 없다.
+      connection-init-sql: "SET SESSION innodb_lock_wait_timeout = ${DB_LOCK_WAIT_TIMEOUT_SECONDS:5}"
+
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 왜

MySQL 기본 `innodb_lock_wait_timeout`은 **50초**다(프로덕션에서 확인). 그 50초는 사용자 입장에서 실패와 같은데 스레드와 커넥션만 붙잡는다.

2026-07-29 LCK T1 vs KT 실측 — 푸시 실패 로그 간격이 정확히 50초다.

```
SET_END set=1   19:53:45  19:58:03  19:58:53  19:59:44  20:03:09  20:03:59  20:04:49
                          └─ 50s ─┘└─ 51s ─┘          └─ 50s ─┘└─ 50s ─┘
SET_START set=2 20:16:24 ~ 20:30:07   (Scheduled-VT-2 = 폴링 스레드)
SET_END set=2   21:00:27  21:01:17  21:02:07
```

- 세트 종료 푸시는 fan-out이 순차라 구독자마다 50초씩 갈렸다. 1세트는 실패 7건 × 50초 = **6분 넘게** 밀렸다(19:50:57 종료 감지 → 20:04:49 마지막 실패)
- 세트 시작 푸시는 폴링 스레드에서 같은 대기에 걸려 **20:13~20:30 라이브 폴링을 세웠다**. 그 구간 프레임이 통째로 건너뛰어져 이벤트 알림이 누락됐다
- 그날 락 대기 타임아웃 80건, 전부 `member` 계열 INSERT

5초로 낮추면 점유 시간이 1/10이 된다. 어차피 실패할 대기라면 빨리 실패하고 스레드를 놓는 쪽이 낫다.

## 어떻게

Hikari `connection-init-sql`로 커넥션마다 세션 변수를 설정한다.

```yaml
spring:
  datasource:
    hikari:
      connection-init-sql: "SET SESSION innodb_lock_wait_timeout = ${DB_LOCK_WAIT_TIMEOUT_SECONDS:5}"
```

**DB 관리자 권한도, DB 재시작도, `my.cnf` 수정도 필요 없다.** 세션 변수라서다. 프로덕션에서 `nar_dev` 계정으로 직접 확인했다.

```
before_set: 50
after_set:  5      global_unchanged: 50
```

글로벌 값(50초)은 그대로 남아 백업·수동 작업 등 앱 밖 세션에는 영향이 없다. 적용 범위가 앱 커넥션으로만 한정되는 게 글로벌 변경보다 안전하다.

## Flyway 영향 없음

이 값은 **행 락**에만 적용된다. DDL이 기다리는 **메타데이터 락**은 `lock_wait_timeout`(기본 1년)이 별도로 관장한다. 따라서 스키마 변경 대기에는 영향이 없다.

행을 대량 갱신하는 마이그레이션을 돌릴 때만 `DB_LOCK_WAIT_TIMEOUT_SECONDS`를 일시 상향하면 된다. 그래서 상수 대신 env 오버라이드로 뒀다.

## 검증

```
./gradlew test    # BUILD SUCCESSFUL — 365건 실행(skip 21)
```

DataSource를 쓰는 테스트(Testcontainers MySQL·임베디드) 포함 전체 통과. `SET SESSION` 구문이 프로덕션 계정에서 통하는 것도 위와 같이 확인했다 — 이 구문이 거부되면 Hikari가 커넥션을 못 만들어 앱이 기동하지 않으므로, 배포 전에 확인해야 하는 유일한 지점이었다.

## 배포 후 확인할 것

락 대기 실패 로그 간격이 50초에서 **5초**로 바뀌는지 본다. 바뀌면 적용된 것이다.

```bash
aws logs filter-log-events --log-group-name /nar/app \
  --filter-pattern '"Lock wait timeout"' --region ap-northeast-2
```

## 한계

**락을 쥔 트랜잭션을 없애는 수정이 아니다.** 대기 시간만 줄인다. 근본 원인(홀더)은 아직 특정하지 못했고 `nar_dev`에 `PROCESS` 권한이 없어 `innodb_trx`를 읽을 수 없다.

관련 PR — #320(폴링 스레드 분리·Riot 모니터 트랜잭션 분해). 남은 후속은 fan-out 직렬화 해소, SET_END 스코어 재시도(최대 80초) 축소, `member_favorite_player` 삽입 멱등화다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)