### PR TITLE
perf: 라이브 푸시 팬아웃을 멀티캐스트 1회로 묶음

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/FirebaseMobilePushGateway.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/FirebaseMobilePushGateway.java
@@ -41,6 +41,7 @@ public class FirebaseMobilePushGateway implements MobilePushGateway {
 		int successCount = 0;
 		int failureCount = 0;
 		List<String> invalidTokens = new ArrayList<>();
+		List<String> successTokens = new ArrayList<>();
 		for (int start = 0; start < tokens.size(); start += MAX_MULTICAST_TOKENS) {
 			List<String> batchTokens = tokens.subList(
 					start,
@@ -49,8 +50,10 @@ public class FirebaseMobilePushGateway implements MobilePushGateway {
 			successCount += response.getSuccessCount();
 			failureCount += response.getFailureCount();
 			collectInvalidTokens(batchTokens, response.getResponses(), invalidTokens);
+			collectSuccessTokens(batchTokens, response.getResponses(), successTokens);
 		}
-		return new MobilePushResult(successCount, failureCount, List.copyOf(invalidTokens));
+		return new MobilePushResult(
+				successCount, failureCount, List.copyOf(invalidTokens), List.copyOf(successTokens));
 	}
 
 	@Override
@@ -106,6 +109,18 @@ public class FirebaseMobilePushGateway implements MobilePushGateway {
 			return firebaseMessaging.sendEachForMulticast(multicastMessage);
 		} catch (FirebaseMessagingException e) {
 			throw new IllegalStateException("FCM 멀티캐스트 발송에 실패했습니다.", e);
+		}
+	}
+
+	/** 여러 구독자의 토큰을 한 번에 보낼 때, 누가 받았는지 되돌리려면 성공 토큰이 필요하다. */
+	private void collectSuccessTokens(
+			List<String> tokens,
+			List<SendResponse> responses,
+			List<String> successTokens) {
+		for (int index = 0; index < responses.size(); index++) {
+			if (responses.get(index).isSuccessful()) {
+				successTokens.add(tokens.get(index));
+			}
 		}
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/push/MobilePushResult.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/MobilePushResult.java
@@ -2,8 +2,20 @@ package com.toy.nar.app.mobile.push;
 
 import java.util.List;
 
+/**
+ * FCM 발송 결과.
+ *
+ * @param successTokens 발송에 성공한 토큰. 여러 구독자의 토큰을 한 번에 보낼 때
+ *                      "누가 받았는지"를 되돌리려면 집계값만으로는 부족해 토큰별 결과가 필요하다.
+ */
 public record MobilePushResult(
 		int successCount,
 		int failureCount,
-		List<String> invalidTokens) {
+		List<String> invalidTokens,
+		List<String> successTokens) {
+
+	/** 토큰별 결과가 필요 없는 호출부(단일 구독자 발송 등)를 위한 생성자. */
+	public MobilePushResult(int successCount, int failureCount, List<String> invalidTokens) {
+		this(successCount, failureCount, invalidTokens, List.of());
+	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -14,10 +14,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -130,15 +132,8 @@ public class TeamLiveEventPushService {
 			long eventOrder,
 			MobilePushMessage message) {
 		try {
-			List<MemberDevice> devices = deviceRepository.findActiveDevicesBySubscribedMatchId(matchId, eventType);
-			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
-					.collect(Collectors.groupingBy(
-							device -> device.getMember().getId(),
-							LinkedHashMap::new,
-							Collectors.toList()));
-			for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
-				sendToMember(entry.getKey(), entry.getValue(), eventType, matchId, setNumber, eventOrder, message);
-			}
+			fanOutBatched(deviceRepository.findActiveDevicesBySubscribedMatchId(matchId, eventType),
+					eventType, matchId, setNumber, eventOrder, message);
 		} catch (Exception e) {
 			log.warn("Failed to prepare match-subscription pushes eventType={} matchId={} setNumber={}",
 					eventType, matchId, setNumber, e);
@@ -277,51 +272,87 @@ public class TeamLiveEventPushService {
 			Long teamId,
 			MobilePushMessage message) {
 		try {
-			List<MemberDevice> devices =
-					deviceRepository.findActiveDevicesBySubscribedTeamId(teamId, eventType);
-			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
-					.collect(Collectors.groupingBy(
-							device -> device.getMember().getId(),
-							LinkedHashMap::new,
-							Collectors.toList()));
-			for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
-				sendToMember(entry.getKey(), entry.getValue(), eventType, matchId, setNumber, eventOrder, message);
-			}
+			fanOutBatched(deviceRepository.findActiveDevicesBySubscribedTeamId(teamId, eventType),
+					eventType, matchId, setNumber, eventOrder, message);
 		} catch (Exception e) {
 			log.warn("Failed to prepare team live event pushes eventType={} matchId={} setNumber={} teamId={}",
 					eventType, matchId, setNumber, teamId, e);
 		}
 	}
 
-	private void sendToMember(
-			Long memberId,
+	/**
+	 * 구독자 전원에게 한 번의 발송 호출로 보낸다.
+	 *
+	 * <p>예전엔 구독자마다 {@code pushGateway.send} 를 호출해 FCM 왕복이 구독자 수만큼 났다.
+	 * 실측 2026-07-29 LCK T1 vs KT 에서 구독자 약 1,500명 팬아웃이 이벤트당 8~18분 걸려
+	 * (1명당 0.3~0.7초) 마지막 구독자는 세트가 끝난 뒤에 세트 시작 알림을 받았다. 게다가 세트 시작
+	 * 팬아웃은 폴링 스레드에서 돌아 그 시간 동안 라이브 관측까지 멈췄다.</p>
+	 *
+	 * <p>게이트웨이가 500토큰씩 멀티캐스트하므로 토큰을 모아 한 번에 넘기면 왕복이 구독자 수에서
+	 * 500토큰 단위로 줄어든다(1,500명이면 3회). 발송 후 토큰별 성공 여부로 구독자를 되돌려 기록한다.</p>
+	 *
+	 * <p>dedup 예약과 발송 기록은 아직 구독자 단위 쿼리다 — 배치화는 후속 작업으로 남긴다.</p>
+	 */
+	private void fanOutBatched(
 			List<MemberDevice> devices,
 			String eventType,
 			String matchId,
 			int setNumber,
 			long eventOrder,
 			MobilePushMessage message) {
+		Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
+				.collect(Collectors.groupingBy(
+						device -> device.getMember().getId(),
+						LinkedHashMap::new,
+						Collectors.toList()));
+
+		// dedup: 양 팀 구독자라도 (member, matchId, setNumber, eventType, eventOrder) 1회만 통과한다.
+		Map<Long, List<String>> tokensByMember = new LinkedHashMap<>();
+		for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
+			if (!deliveryRepository.reserve(entry.getKey(), matchId, setNumber, eventType, eventOrder)) {
+				continue;
+			}
+			tokensByMember.put(entry.getKey(),
+					entry.getValue().stream().map(MemberDevice::getFcmToken).toList());
+		}
+		if (tokensByMember.isEmpty()) {
+			return;
+		}
+
+		List<String> allTokens = tokensByMember.values().stream().flatMap(List::stream).toList();
+		MobilePushResult result;
 		try {
-			// dedup: 양 팀 구독자라도 (member, matchId, setNumber, eventType, eventOrder) 1회만 통과한다.
-			if (!deliveryRepository.reserve(memberId, matchId, setNumber, eventType, eventOrder)) {
-				return;
-			}
-			List<String> tokens = devices.stream().map(MemberDevice::getFcmToken).toList();
-			MobilePushResult result = pushGateway.send(tokens, message);
-			if (!result.invalidTokens().isEmpty()) {
-				deactivateInvalidTokens(result.invalidTokens(), matchId, eventType);
-			}
-			if (result.successCount() > 0) {
-				deliveryRepository.markSent(memberId, matchId, setNumber, eventType, eventOrder);
-				recordFeed(memberId, eventType, message);
-			} else {
-				deliveryRepository.markFailed(memberId, matchId, setNumber, eventType, eventOrder,
-						"FCM 전송 성공 기기가 없습니다.");
-			}
+			result = pushGateway.send(allTokens, message);
 		} catch (Exception e) {
-			markFailed(memberId, matchId, setNumber, eventType, eventOrder, truncate(e.getMessage()));
-			log.warn("Team live event push failed memberId={} eventType={} matchId={} setNumber={} eventOrder={}",
-					memberId, eventType, matchId, setNumber, eventOrder, e);
+			// 발송 자체가 실패하면 예약한 구독자 전원을 FAILED 로 남긴다(재예약 대상이 된다).
+			tokensByMember.keySet().forEach(memberId ->
+					markFailed(memberId, matchId, setNumber, eventType, eventOrder, truncate(e.getMessage())));
+			log.warn("Team live event multicast failed eventType={} matchId={} setNumber={} members={} tokens={}",
+					eventType, matchId, setNumber, tokensByMember.size(), allTokens.size(), e);
+			return;
+		}
+
+		Set<String> successTokens = new HashSet<>(result.successTokens());
+		for (Map.Entry<Long, List<String>> entry : tokensByMember.entrySet()) {
+			Long memberId = entry.getKey();
+			boolean delivered = entry.getValue().stream().anyMatch(successTokens::contains);
+			try {
+				if (delivered) {
+					deliveryRepository.markSent(memberId, matchId, setNumber, eventType, eventOrder);
+					recordFeed(memberId, eventType, message);
+				} else {
+					deliveryRepository.markFailed(memberId, matchId, setNumber, eventType, eventOrder,
+							"FCM 전송 성공 기기가 없습니다.");
+				}
+			} catch (Exception e) {
+				markFailed(memberId, matchId, setNumber, eventType, eventOrder, truncate(e.getMessage()));
+				log.warn("Team live event push record failed memberId={} eventType={} matchId={} setNumber={} eventOrder={}",
+						memberId, eventType, matchId, setNumber, eventOrder, e);
+			}
+		}
+
+		if (!result.invalidTokens().isEmpty()) {
+			deactivateInvalidTokens(result.invalidTokens(), matchId, eventType);
 		}
 	}
 

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushFanOutBatchTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushFanOutBatchTest.java
@@ -1,0 +1,129 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.NaverEsportsScoreClient;
+import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberDevice;
+import com.toy.nar.domain.member.repository.MemberDeviceRepository;
+import com.toy.nar.domain.member.repository.MemberTeamEventPushDeliveryRepository;
+import com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 구독자 팬아웃이 발송 호출 1회로 묶이는지 지키는 회귀 테스트.
+ *
+ * 예전엔 구독자마다 pushGateway.send 를 호출했다. 실측 2026-07-29 LCK T1 vs KT 에서
+ * 구독자 약 1,500명 팬아웃이 이벤트당 8~18분 걸려 마지막 구독자는 세트가 끝난 뒤 알림을 받았다.
+ */
+class TeamLiveEventPushFanOutBatchTest {
+
+	private static final String MATCH_ID = "MATCH-1";
+	private static final int SET_NUMBER = 2;
+
+	private final MemberDeviceRepository deviceRepository = mock(MemberDeviceRepository.class);
+	private final MemberTeamEventPushDeliveryRepository deliveryRepository =
+			mock(MemberTeamEventPushDeliveryRepository.class);
+	private final MobilePushGateway pushGateway = mock(MobilePushGateway.class);
+	private final MemberNotificationService notificationService = mock(MemberNotificationService.class);
+
+	private TeamLiveEventPushService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new TeamLiveEventPushService(
+				deviceRepository,
+				deliveryRepository,
+				mock(TeamExternalIdentityRepository.class),
+				mock(LeagueMatchRepository.class),
+				pushGateway,
+				notificationService,
+				mock(WorldsService.class),
+				mock(NaverEsportsScoreClient.class));
+		ReflectionTestUtils.setField(service, "fcmNotificationEnabled", true);
+		when(pushGateway.isAvailable()).thenReturn(true);
+	}
+
+	@Test
+	@DisplayName("구독자 3명이어도 발송 호출은 1회, 토큰은 한 번에 넘긴다")
+	void 구독자_전원을_한_번에_발송한다() {
+		List<MemberDevice> devices = List.of(device(1L, "token-1"), device(2L, "token-2"), device(3L, "token-3"));
+		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
+				.thenReturn(devices);
+		when(deliveryRepository.reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(3, 0, List.of(), List.of("token-1", "token-2", "token-3")));
+
+		service.notifyLiveEvent(MATCH_ID, SET_NUMBER, 10L, null, "제목", "본문");
+
+		ArgumentCaptor<List<String>> tokens = ArgumentCaptor.forClass(List.class);
+		verify(pushGateway, times(1)).send(tokens.capture(), any());
+		assertThat(tokens.getValue()).containsExactly("token-1", "token-2", "token-3");
+		verify(deliveryRepository, times(3))
+				.markSent(anyLong(), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong());
+	}
+
+	@Test
+	@DisplayName("토큰별 결과로 구독자를 갈라 기록한다")
+	void 성공한_토큰의_구독자만_발송_기록한다() {
+		List<MemberDevice> devices = List.of(device(1L, "token-1"), device(2L, "token-2"));
+		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
+				.thenReturn(devices);
+		when(deliveryRepository.reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+		// token-2 만 성공
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(1, 1, List.of(), List.of("token-2")));
+
+		service.notifyLiveEvent(MATCH_ID, SET_NUMBER, 11L, null, "제목", "본문");
+
+		verify(deliveryRepository).markSent(eq(2L), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong());
+		verify(deliveryRepository, never()).markSent(eq(1L), anyString(), anyInt(), anyString(), anyLong());
+		verify(deliveryRepository).markFailed(eq(1L), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong(), anyString());
+	}
+
+	@Test
+	@DisplayName("dedup 에 막힌 구독자는 토큰에 포함하지 않는다")
+	void 예약_실패_구독자는_발송_대상에서_빠진다() {
+		List<MemberDevice> devices = List.of(device(1L, "token-1"), device(2L, "token-2"));
+		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
+				.thenReturn(devices);
+		when(deliveryRepository.reserve(eq(1L), anyString(), anyInt(), anyString(), anyLong())).thenReturn(false);
+		when(deliveryRepository.reserve(eq(2L), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(1, 0, List.of(), List.of("token-2")));
+
+		service.notifyLiveEvent(MATCH_ID, SET_NUMBER, 12L, null, "제목", "본문");
+
+		ArgumentCaptor<List<String>> tokens = ArgumentCaptor.forClass(List.class);
+		verify(pushGateway).send(tokens.capture(), any());
+		assertThat(tokens.getValue()).containsExactly("token-2");
+	}
+
+	private MemberDevice device(Long memberId, String token) {
+		Member member = mock(Member.class);
+		when(member.getId()).thenReturn(memberId);
+		MemberDevice device = mock(MemberDevice.class);
+		when(device.getMember()).thenReturn(member);
+		when(device.getFcmToken()).thenReturn(token);
+		return device;
+	}
+}


### PR DESCRIPTION
## 문제

구독자 팬아웃이 이벤트당 8~18분 걸린다. 마지막 구독자는 세트가 끝난 뒤에 "세트 시작" 알림을 받는다.

`member_team_event_push_delivery.sent_at` 실측 (2026-07-29 LCK T1 vs KT):

| 세트 | 이벤트 | 구독자 | 첫 발송 | 마지막 발송 | 소요 | 1명당 |
|---|---|---|---|---|---|---|
1 | SET_START | 1,565 | 10:15:21 | 10:23:43 | **8분 22초** | 0.32초 |
1 | SET_END | 1,491 | 10:50:58 | 11:06:06 | **15분 8초** | 0.61초 |
2 | SET_START | 1,548 | 11:13:28 | 11:31:22 | **17분 54초** | 0.69초 |
2 | SET_END | 1,489 | 11:50:43 | 12:04:21 | **13분 38초** | 0.55초 |

(UTC 기준. 그날 경기 하나에 푸시 **28,600건**이 나갔다)

1명당 비용의 대부분은 FCM HTTP 왕복이다. 게이트웨이는 **이미 500토큰 멀티캐스트를 지원**하는데도 구독자마다 따로 호출해 그 배치가 무의미했다.

```java
private static final int MAX_MULTICAST_TOKENS = 500;   // 있는데 안 쓰이고 있었다
```

추가 발견 — 2세트 SET_START 팬아웃 구간(11:13:28~11:31:22 UTC = 20:13~20:31 KST)이 **폴링 스레드가 멈춰 있던 구간과 정확히 일치**한다. 팬아웃이 폴링 스레드에서 돌았기 때문이고, 그 분리는 #320에서 다룬다. 락 대기(50초 × 7건)는 그 18분의 일부일 뿐이었다.

## 변경

- **`TeamLiveEventPushService`** — 팬아웃을 `fanOutBatched`로 통합. 구독자별 dedup 예약을 먼저 돌려 통과한 구독자의 토큰만 모아 한 번에 발송한다. 1,500명이면 발송 호출이 **1,500회 → 3회**(500토큰 단위)
- **`MobilePushResult`** — `successTokens` 추가. 여러 구독자 토큰을 한 번에 보내면 집계값(`successCount`)만으로는 누가 받았는지 되돌릴 수 없다. 기존 3인자 생성자를 유지해 단일 구독자 발송 호출부(`PlayerSoloRankPushService`)는 손대지 않았다
- **`FirebaseMobilePushGateway`** — 토큰별 응답에서 성공 토큰 수집. 이미 있던 `collectInvalidTokens`와 같은 방식이다
- 발송 자체가 실패하면 예약한 구독자 전원을 `FAILED`로 남겨 재예약 대상이 되게 했다. 예전엔 구독자별 예외 처리라 이 경로가 없어서, 오늘 락 타임아웃으로 실패한 건들은 **DB에 흔적도 없이 사라졌다**(`PENDING` 0건, `FAILED` 15건 전부 죽은 토큰 사유)

## 검증

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

회귀 테스트 3개:
- 구독자 3명 → 발송 호출 1회, 토큰 3개를 한 번에 전달
- 토큰별 결과로 구독자를 갈라 `markSent`/`markFailed`
- dedup에 막힌 구독자는 토큰 목록에서 제외

멤버별 발송으로 되돌리면 첫 테스트가 FAILED 되는 것 확인 후 복원했다.

## 남긴 것

dedup 예약과 발송 기록은 아직 구독자 단위 쿼리다(1명당 DB 3~4회 = 1,500명이면 ~5,000회). 그 배치화는 후속으로 남겼다. 이 변경만으로 HTTP 왕복이 사라져 사용자 체감(마지막 구독자 지연)은 해결되고, DB 왕복은 락 경합 쪽 과제로 남는다.

`PlayerSoloRankPushService`도 같은 구독자 팬아웃 구조다. 솔랭 알림은 규모가 작아 우선순위를 낮췄지만 같은 수정이 필요하다.

## 관련

- #320 폴링 스레드 분리 + Riot 모니터 트랜잭션 분해
- #322 락 대기 50초 → 5초 (기여도는 1,074초 중 350초)

세 PR이 각각 다른 층을 고친다. 이 PR이 가장 큰 몫(HTTP 왕복)을 담당한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)