### PR TITLE
fix: 재온보딩 시 즐겨찾기 선수 유니크 제약 위반 500 수정

### DIFF
--- a/src/main/java/com/toy/nar/domain/member/entity/Member.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/Member.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.time.LocalDateTime;
 
 @Entity
@@ -75,13 +77,28 @@ public class Member {
         this.onboardedAt = LocalDateTime.now();
     }
 
+    /**
+     * 즐겨찾기 선수를 목표 집합으로 맞춘다. 이미 있는 항목은 남기고 빠진 것만 지우고 새것만 넣는다.
+     *
+     * <p>예전엔 전부 clear 한 뒤 다시 add 했다. 그러면 같은 선수를 유지하는 재온보딩에서
+     * Hibernate 가 컬렉션 삭제보다 INSERT 를 먼저 flush 해
+     * {@code Duplicate entry '<member>-<player>' for key 'uq_member_favorite_player'} 로 500 이 났다
+     * (실측 2026-07-29 23:27:55, POST /api/auth/onboarding). 유니크 제약이 있는 컬렉션에서
+     * clear-then-add 는 쓸 수 없다.</p>
+     */
     private void replaceFavoritePlayers(Collection<Player> players) {
-        this.favoritePlayers.clear();
-        if (players == null) {
-            return;
-        }
-        players.stream()
-                .distinct()
+        List<Player> desired = players == null
+                ? List.of()
+                : players.stream().filter(player -> player != null && player.getId() != null).distinct().toList();
+
+        Set<Long> desiredIds = desired.stream().map(Player::getId).collect(Collectors.toSet());
+        this.favoritePlayers.removeIf(favorite -> !desiredIds.contains(favorite.getPlayer().getId()));
+
+        Set<Long> keptIds = this.favoritePlayers.stream()
+                .map(favorite -> favorite.getPlayer().getId())
+                .collect(Collectors.toSet());
+        desired.stream()
+                .filter(player -> !keptIds.contains(player.getId()))
                 .map(player -> MemberFavoritePlayer.builder()
                         .member(this)
                         .player(player)

--- a/src/test/java/com/toy/nar/domain/member/entity/MemberFavoritePlayerReplaceTest.java
+++ b/src/test/java/com/toy/nar/domain/member/entity/MemberFavoritePlayerReplaceTest.java
@@ -1,0 +1,92 @@
+package com.toy.nar.domain.member.entity;
+
+import com.toy.nar.domain.participant.entity.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 즐겨찾기 선수 교체가 기존 항목을 유지하는지 지키는 회귀 테스트.
+ *
+ * 예전엔 전부 clear 한 뒤 다시 add 해서, 같은 선수를 유지하는 재온보딩에서 Hibernate 가
+ * 컬렉션 삭제보다 INSERT 를 먼저 flush 해 유니크 제약을 위반했다
+ * (실측 2026-07-29 23:27:55 POST /api/auth/onboarding → 500).
+ * 같은 선수가 남아 있으면 새 INSERT 가 생기지 않아 위반 자체가 발생하지 않는다.
+ */
+class MemberFavoritePlayerReplaceTest {
+
+	@Test
+	@DisplayName("같은 선수로 재온보딩하면 기존 항목을 그대로 유지한다")
+	void 재온보딩해도_기존_항목을_유지한다() {
+		Player faker = player(1L, "Faker");
+		Player oner = player(2L, "Oner");
+		Member member = member();
+
+		member.completeOnboarding("LCK", null, List.of(faker, oner));
+		List<MemberFavoritePlayer> first = List.copyOf(member.getFavoritePlayers());
+
+		member.completeOnboarding("LCK", null, List.of(faker, oner));
+
+		// 같은 인스턴스가 유지돼야 한다 — 새로 만들면 INSERT 가 나가 유니크 제약을 위반한다.
+		assertThat(member.getFavoritePlayers()).containsExactlyElementsOf(first);
+	}
+
+	@Test
+	@DisplayName("빠진 선수는 지우고 새 선수만 추가한다")
+	void 차집합만_반영한다() {
+		Player faker = player(1L, "Faker");
+		Player oner = player(2L, "Oner");
+		Player keria = player(3L, "Keria");
+		Member member = member();
+		member.completeOnboarding("LCK", null, List.of(faker, oner));
+		MemberFavoritePlayer keptFaker = member.getFavoritePlayers().stream()
+				.filter(f -> f.getPlayer().getId().equals(1L))
+				.findFirst()
+				.orElseThrow();
+
+		member.completeOnboarding("LCK", null, List.of(faker, keria));
+
+		assertThat(member.getFavoritePlayers())
+				.extracting(f -> f.getPlayer().getId())
+				.containsExactlyInAnyOrder(1L, 3L);
+		assertThat(member.getFavoritePlayers()).contains(keptFaker);
+	}
+
+	@Test
+	@DisplayName("선수 목록이 비면 전부 지운다")
+	void 빈_목록이면_모두_지운다() {
+		Member member = member();
+		member.completeOnboarding("LCK", null, List.of(player(1L, "Faker")));
+
+		member.completeOnboarding("LCK", null, List.of());
+
+		assertThat(member.getFavoritePlayers()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("중복 입력은 한 건으로 접는다")
+	void 중복_입력을_접는다() {
+		Player faker = player(1L, "Faker");
+		Member member = member();
+
+		member.completeOnboarding("LCK", null, List.of(faker, faker));
+
+		assertThat(member.getFavoritePlayers()).hasSize(1);
+	}
+
+	private Member member() {
+		Member member = Member.builder().name("나르").tag("KR1").build();
+		ReflectionTestUtils.setField(member, "id", 100L);
+		return member;
+	}
+
+	private Player player(Long id, String name) {
+		Player player = Player.builder().name(name).build();
+		ReflectionTestUtils.setField(player, "id", id);
+		return player;
+	}
+}


### PR DESCRIPTION
## 증상

`POST /api/auth/onboarding` 이 500을 낸다. 프로덕션 로그 (2026-07-29 23:27:55):

```
[START] URI: [POST]/api/auth/onboarding
SQL Error: 1062, SQLState: 23000
Duplicate entry '2347-45' for key 'member_favorite_player.uq_member_favorite_player'
[END] Status: 500, Duration: 934ms
23:28:04  [START] URI: [GET]/api/auth/onboarding/teams     ← 온보딩 화면으로 되돌아간다
```

07-29 00:20:02, 00:21:07, 00:21:33에도 같은 에러가 있었다(회원 2117·2118·2119). 유저는 온보딩을 끝낼 수 없고 화면에 갇힌다.

## 원인

`Member.replaceFavoritePlayers` 의 clear-then-add 다.

```java
this.favoritePlayers.clear();                    // orphanRemoval → DELETE 예약
players.stream()...forEach(favoritePlayers::add); // 같은 선수도 새 INSERT
```

컬렉션이 `cascade = ALL` + `orphanRemoval = true` 인데, **Hibernate 는 컬렉션 삭제보다 INSERT 를 먼저 flush 한다.** 그래서 같은 선수를 유지하는 재온보딩에서 `(member_id, player_id)` 유니크 제약을 스스로 위반한다.

MySQL 은 지연 제약(deferred constraint)이 없어 flush 순서로는 피할 수 없다. 유니크 제약이 걸린 컬렉션에 clear-then-add 를 쓸 수 없다는 뜻이다.

프로덕션 스키마 확인:
```sql
UNIQUE KEY uq_member_favorite_player (member_id, player_id)
```

## 변경

목표 집합과의 **차집합만 반영**한다. 이미 있는 항목은 인스턴스를 그대로 유지하므로 INSERT 가 생기지 않고, 빠진 것만 `orphanRemoval` 로 삭제된다.

같은 선수로 재온보딩하면 즐겨찾기 관련 쓰기가 **0건**이다. DB 부하도 같이 줄어든다.

## 검증

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

회귀 테스트 4개 — 재온보딩 시 기존 인스턴스 유지, 차집합만 반영, 빈 목록이면 전부 삭제, 중복 입력 접기. `clear-then-add` 로 되돌리면 앞의 두 개가 FAILED 되는 것 확인 후 복원했다.

엔티티 순수 로직이라 DB 없이 검증된다.

## 남은 케이스

진짜 동시 요청 두 건이 즐겨찾기가 없는 회원에게 동시에 INSERT 하면 여전히 위반할 수 있다. 관측된 실패는 **순차 재온보딩**(같은 스레드에서 앞 요청이 200으로 끝난 뒤 다음 요청)이라 이 변경으로 해결된다. 동시성 방어가 필요해지면 `DataIntegrityViolationException` 흡수를 별도로 검토한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)