### PR TITLE
perf: 라이브 푸시 fan-out DB 왕복을 상수로 줄임

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
@@ -16,7 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -43,6 +46,32 @@ public class MemberNotificationService {
 		}
 		Member member = memberRepository.getReferenceById(memberId);
 		notificationRepository.save(new MemberNotification(member, type, title, body, data));
+	}
+
+	/**
+	 * 여러 구독자에게 같은 알림을 한 번에 기록한다.
+	 *
+	 * <p>fan-out 에서 구독자마다 {@link #record} 를 부르면 INSERT 왕복이 구독자 수만큼 난다.
+	 * saveAll 로 넘기면 {@code hibernate.jdbc.batch_size}(50) 단위로 묶이고,
+	 * prod 는 {@code rewriteBatchedStatements=true} 라 다중 VALUES 로 다시 쓰인다.</p>
+	 */
+	@Transactional
+	public void recordAll(
+			Collection<Long> memberIds,
+			MemberNotificationType type,
+			String title,
+			String body,
+			Map<String, String> data) {
+		if (memberIds == null || memberIds.isEmpty() || type == null || title == null) {
+			return;
+		}
+		List<MemberNotification> notifications = memberIds.stream()
+				.filter(Objects::nonNull)
+				.distinct()
+				.map(memberId -> new MemberNotification(
+						memberRepository.getReferenceById(memberId), type, title, body, data))
+				.toList();
+		notificationRepository.saveAll(notifications);
 	}
 
 	public MemberNotificationListResponse getNotifications(

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -306,14 +308,25 @@ public class TeamLiveEventPushService {
 						LinkedHashMap::new,
 						Collectors.toList()));
 
+		if (devicesByMember.isEmpty()) {
+			return;
+		}
+
 		// dedup: 양 팀 구독자라도 (member, matchId, setNumber, eventType, eventOrder) 1회만 통과한다.
+		// 구독자 수만큼 왕복하지 않도록 한 번에 예약하고 발송 대상만 돌려받는다.
+		List<Long> reservedIds =
+				deliveryRepository.reserveAll(devicesByMember.keySet(), matchId, setNumber, eventType, eventOrder);
+		if (reservedIds.isEmpty()) {
+			return;
+		}
+
 		Map<Long, List<String>> tokensByMember = new LinkedHashMap<>();
-		for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
-			if (!deliveryRepository.reserve(entry.getKey(), matchId, setNumber, eventType, eventOrder)) {
+		for (Long memberId : reservedIds) {
+			List<MemberDevice> memberDevices = devicesByMember.get(memberId);
+			if (memberDevices == null) {
 				continue;
 			}
-			tokensByMember.put(entry.getKey(),
-					entry.getValue().stream().map(MemberDevice::getFcmToken).toList());
+			tokensByMember.put(memberId, memberDevices.stream().map(MemberDevice::getFcmToken).toList());
 		}
 		if (tokensByMember.isEmpty()) {
 			return;
@@ -325,34 +338,75 @@ public class TeamLiveEventPushService {
 			result = pushGateway.send(allTokens, message);
 		} catch (Exception e) {
 			// 발송 자체가 실패하면 예약한 구독자 전원을 FAILED 로 남긴다(재예약 대상이 된다).
-			tokensByMember.keySet().forEach(memberId ->
-					markFailed(memberId, matchId, setNumber, eventType, eventOrder, truncate(e.getMessage())));
+			markFailedAll(tokensByMember.keySet(), matchId, setNumber, eventType, eventOrder,
+					truncate(e.getMessage()));
 			log.warn("Team live event multicast failed eventType={} matchId={} setNumber={} members={} tokens={}",
 					eventType, matchId, setNumber, tokensByMember.size(), allTokens.size(), e);
 			return;
 		}
 
 		Set<String> successTokens = new HashSet<>(result.successTokens());
-		for (Map.Entry<Long, List<String>> entry : tokensByMember.entrySet()) {
-			Long memberId = entry.getKey();
-			boolean delivered = entry.getValue().stream().anyMatch(successTokens::contains);
-			try {
-				if (delivered) {
-					deliveryRepository.markSent(memberId, matchId, setNumber, eventType, eventOrder);
-					recordFeed(memberId, eventType, message);
-				} else {
-					deliveryRepository.markFailed(memberId, matchId, setNumber, eventType, eventOrder,
-							"FCM 전송 성공 기기가 없습니다.");
-				}
-			} catch (Exception e) {
-				markFailed(memberId, matchId, setNumber, eventType, eventOrder, truncate(e.getMessage()));
-				log.warn("Team live event push record failed memberId={} eventType={} matchId={} setNumber={} eventOrder={}",
-						memberId, eventType, matchId, setNumber, eventOrder, e);
-			}
-		}
+		List<Long> delivered = new ArrayList<>();
+		List<Long> undelivered = new ArrayList<>();
+		tokensByMember.forEach((memberId, tokens) ->
+				(tokens.stream().anyMatch(successTokens::contains) ? delivered : undelivered).add(memberId));
+
+		markSentAll(delivered, matchId, setNumber, eventType, eventOrder);
+		markFailedAll(undelivered, matchId, setNumber, eventType, eventOrder, "FCM 전송 성공 기기가 없습니다.");
+		recordFeedAll(delivered, eventType, message);
 
 		if (!result.invalidTokens().isEmpty()) {
 			deactivateInvalidTokens(result.invalidTokens(), matchId, eventType);
+		}
+	}
+
+	/** 마감 기록 실패가 발송 흐름을 깨면 안 되므로 흡수한다(푸시는 이미 나갔다). */
+	private void markSentAll(
+			List<Long> memberIds, String matchId, int setNumber, String eventType, long eventOrder) {
+		if (memberIds.isEmpty()) {
+			return;
+		}
+		try {
+			deliveryRepository.markSentAll(memberIds, matchId, setNumber, eventType, eventOrder);
+		} catch (Exception e) {
+			log.warn("Failed to mark team live event pushes sent eventType={} matchId={} setNumber={} members={}",
+					eventType, matchId, setNumber, memberIds.size(), e);
+		}
+	}
+
+	private void markFailedAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder,
+			String errorMessage) {
+		if (memberIds.isEmpty()) {
+			return;
+		}
+		try {
+			deliveryRepository.markFailedAll(memberIds, matchId, setNumber, eventType, eventOrder, errorMessage);
+		} catch (Exception e) {
+			log.warn("Failed to mark team live event pushes failed eventType={} matchId={} setNumber={} members={}",
+					eventType, matchId, setNumber, memberIds.size(), e);
+		}
+	}
+
+	/** 마이구독 알림 피드에 한 번에 기록한다. 피드 실패가 푸시 흐름을 깨면 안 되므로 흡수한다. */
+	private void recordFeedAll(List<Long> memberIds, String eventType, MobilePushMessage message) {
+		if (memberIds.isEmpty()) {
+			return;
+		}
+		try {
+			notificationService.recordAll(
+					memberIds,
+					MemberNotificationType.valueOf(eventType),
+					message.title(),
+					message.body(),
+					message.data());
+		} catch (Exception e) {
+			log.warn("Failed to record team event notification feed eventType={} members={}",
+					eventType, memberIds.size(), e);
 		}
 	}
 

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepository.java
@@ -13,7 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 멱등 키는 (member_id, match_id, set_number, event_type, event_order).
  */
 public interface MemberTeamEventPushDeliveryRepository
-		extends JpaRepository<MemberTeamEventPushDelivery, Long> {
+		extends JpaRepository<MemberTeamEventPushDelivery, Long>,
+		MemberTeamEventPushDeliveryRepositoryCustom {
 
 	/*
 	 * [중복 발송 버그 수정] 기존 reserve 는 INSERT ... ON DUPLICATE KEY UPDATE + IF 패턴으로

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepositoryCustom.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepositoryCustom.java
@@ -1,0 +1,44 @@
+package com.toy.nar.domain.member.repository;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 라이브 푸시 fan-out 용 배치 연산.
+ *
+ * <p>구독자마다 reserve/markSent 를 한 건씩 돌면 구독자 수만큼 DB 왕복이 난다. 앱(AWS 서울)과
+ * DB(Oracle Cloud 춘천) 사이 왕복이 실측 6.5ms 라 구독자 747명 SET_START 발송이 37초 걸렸다
+ * (2026-07-30 LCK HLE vs DK). 구독자 단위 루프를 벌크 문장으로 접어 왕복을 상수로 만든다.</p>
+ */
+public interface MemberTeamEventPushDeliveryRepositoryCustom {
+
+	/**
+	 * 후보 구독자를 한 번에 예약하고, 실제로 발송해야 하는 구독자만 돌려준다.
+	 *
+	 * <p>단건 {@code reserve} 와 판정 규칙이 같다 — 신규이거나, FAILED 이거나,
+	 * PENDING 으로 1분 넘게 방치된 건만 통과한다. 이미 SENT 면 제외된다.</p>
+	 */
+	List<Long> reserveAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder);
+
+	/** 발송 성공 구독자를 한 번에 SENT 로 마감한다. */
+	int markSentAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder);
+
+	/** 발송 실패 구독자를 한 번에 FAILED 로 마감한다. */
+	int markFailedAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder,
+			String errorMessage);
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepositoryImpl.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamEventPushDeliveryRepositoryImpl.java
@@ -1,0 +1,164 @@
+package com.toy.nar.domain.member.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class MemberTeamEventPushDeliveryRepositoryImpl
+		implements MemberTeamEventPushDeliveryRepositoryCustom {
+
+	/** IN 절 한 번에 넣을 최대 개수. SQL 이 과하게 길어지지 않게 나눈다. */
+	private static final int CHUNK_SIZE = 500;
+
+	/** PENDING 방치 재예약 기준. 단건 reserve 의 reactivateStale 과 같은 값이어야 한다. */
+	private static final String STALE_PENDING_MINUTES = "1";
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Override
+	public List<Long> reserveAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder) {
+		List<Long> targets = new ArrayList<>();
+		for (List<Long> chunk : chunk(memberIds)) {
+			targets.addAll(reserveChunk(chunk, matchId, setNumber, eventType, eventOrder));
+		}
+		return targets;
+	}
+
+	private List<Long> reserveChunk(
+			List<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder) {
+		String placeholders = placeholders(memberIds.size());
+
+		// 1) 기존 행을 한 번에 읽어 신규/재예약/제외를 자바에서 가른다.
+		//    단건 reserve 의 "INSERT IGNORE 실패 → 조건부 UPDATE" 순서를 그대로 재현한다.
+		List<Object[]> existing = jdbcTemplate.query(
+				"SELECT member_id, status, updated_at < DATE_SUB(NOW(), INTERVAL "
+						+ STALE_PENDING_MINUTES + " MINUTE) AS stale"
+						+ " FROM member_team_event_push_delivery"
+						+ " WHERE match_id = ? AND set_number = ? AND event_type = ? AND event_order = ?"
+						+ " AND member_id IN (" + placeholders + ")",
+				(rs, rowNum) -> new Object[] { rs.getLong(1), rs.getString(2), rs.getBoolean(3) },
+				args(matchId, setNumber, eventType, eventOrder, memberIds));
+
+		Set<Long> existingIds = existing.stream()
+				.map(row -> (Long) row[0])
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+		List<Long> reactivateIds = existing.stream()
+				.filter(row -> "FAILED".equals(row[1])
+						|| ("PENDING".equals(row[1]) && Boolean.TRUE.equals(row[2])))
+				.map(row -> (Long) row[0])
+				.toList();
+		List<Long> newIds = memberIds.stream().filter(id -> !existingIds.contains(id)).toList();
+
+		if (!newIds.isEmpty()) {
+			jdbcTemplate.update(
+					"INSERT IGNORE INTO member_team_event_push_delivery"
+							+ " (member_id, match_id, set_number, event_type, event_order,"
+							+ "  status, created_at, updated_at) VALUES "
+							+ newIds.stream()
+									.map(id -> "(?, ?, ?, ?, ?, 'PENDING', NOW(), NOW())")
+									.collect(Collectors.joining(", ")),
+					newIds.stream()
+							.flatMap(id -> List.of(
+									(Object) id, matchId, setNumber, eventType, eventOrder).stream())
+							.toArray());
+		}
+		if (!reactivateIds.isEmpty()) {
+			jdbcTemplate.update(
+					"UPDATE member_team_event_push_delivery"
+							+ " SET status = 'PENDING', error_message = NULL, updated_at = NOW()"
+							+ " WHERE match_id = ? AND set_number = ? AND event_type = ? AND event_order = ?"
+							+ " AND member_id IN (" + placeholders(reactivateIds.size()) + ")",
+					args(matchId, setNumber, eventType, eventOrder, reactivateIds));
+		}
+
+		List<Long> targets = new ArrayList<>(newIds);
+		targets.addAll(reactivateIds);
+		return targets;
+	}
+
+	@Override
+	public int markSentAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder) {
+		int updated = 0;
+		for (List<Long> chunk : chunk(memberIds)) {
+			updated += jdbcTemplate.update(
+					"UPDATE member_team_event_push_delivery"
+							+ " SET status = 'SENT', error_message = NULL,"
+							+ "     sent_at = NOW(), updated_at = NOW()"
+							+ " WHERE match_id = ? AND set_number = ? AND event_type = ? AND event_order = ?"
+							+ " AND member_id IN (" + placeholders(chunk.size()) + ")",
+					args(matchId, setNumber, eventType, eventOrder, chunk));
+		}
+		return updated;
+	}
+
+	@Override
+	public int markFailedAll(
+			Collection<Long> memberIds,
+			String matchId,
+			int setNumber,
+			String eventType,
+			long eventOrder,
+			String errorMessage) {
+		int updated = 0;
+		for (List<Long> chunk : chunk(memberIds)) {
+			List<Object> params = new ArrayList<>();
+			params.add(errorMessage);
+			params.add(matchId);
+			params.add(setNumber);
+			params.add(eventType);
+			params.add(eventOrder);
+			params.addAll(chunk);
+			updated += jdbcTemplate.update(
+					"UPDATE member_team_event_push_delivery"
+							+ " SET status = 'FAILED', error_message = ?, updated_at = NOW()"
+							+ " WHERE match_id = ? AND set_number = ? AND event_type = ? AND event_order = ?"
+							+ " AND member_id IN (" + placeholders(chunk.size()) + ")",
+					params.toArray());
+		}
+		return updated;
+	}
+
+	private List<List<Long>> chunk(Collection<Long> memberIds) {
+		List<Long> distinct = memberIds.stream().filter(java.util.Objects::nonNull).distinct().toList();
+		List<List<Long>> chunks = new ArrayList<>();
+		for (int start = 0; start < distinct.size(); start += CHUNK_SIZE) {
+			chunks.add(distinct.subList(start, Math.min(start + CHUNK_SIZE, distinct.size())));
+		}
+		return chunks;
+	}
+
+	private String placeholders(int count) {
+		return String.join(", ", java.util.Collections.nCopies(count, "?"));
+	}
+
+	private Object[] args(String matchId, int setNumber, String eventType, long eventOrder, List<Long> memberIds) {
+		List<Object> params = new ArrayList<>();
+		params.add(matchId);
+		params.add(setNumber);
+		params.add(eventType);
+		params.add(eventOrder);
+		params.addAll(memberIds);
+		return params.toArray();
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushFanOutBatchTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushFanOutBatchTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,10 +31,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * 구독자 팬아웃이 발송 호출 1회로 묶이는지 지키는 회귀 테스트.
+ * 구독자 팬아웃이 발송·DB 왕복을 상수로 묶는지 지키는 회귀 테스트.
  *
- * 예전엔 구독자마다 pushGateway.send 를 호출했다. 실측 2026-07-29 LCK T1 vs KT 에서
- * 구독자 약 1,500명 팬아웃이 이벤트당 8~18분 걸려 마지막 구독자는 세트가 끝난 뒤 알림을 받았다.
+ * 예전엔 구독자마다 pushGateway.send 와 reserve/markSent 를 한 건씩 돌았다.
+ * 실측: 2026-07-29 구독자 1,548명 SET_START 이 1,074초(1명당 0.69초),
+ * FCM 배치화 후 2026-07-30 구독자 747명이 37초(1명당 0.05초 = DB 왕복 비용).
+ * 앱→DB 왕복이 6.5ms 라 구독자 단위 쿼리가 남아 있으면 시간이 구독자 수에 비례한다.
  */
 class TeamLiveEventPushFanOutBatchTest {
 
@@ -64,12 +67,11 @@ class TeamLiveEventPushFanOutBatchTest {
 	}
 
 	@Test
-	@DisplayName("구독자 3명이어도 발송 호출은 1회, 토큰은 한 번에 넘긴다")
-	void 구독자_전원을_한_번에_발송한다() {
-		List<MemberDevice> devices = List.of(device(1L, "token-1"), device(2L, "token-2"), device(3L, "token-3"));
-		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
-				.thenReturn(devices);
-		when(deliveryRepository.reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+	@DisplayName("구독자 3명이어도 발송 1회·예약 1회·마감 1회로 끝낸다")
+	void 구독자_수와_무관하게_호출_횟수가_상수다() {
+		givenSubscribers(List.of(device(1L, "token-1"), device(2L, "token-2"), device(3L, "token-3")));
+		when(deliveryRepository.reserveAll(any(), anyString(), anyInt(), anyString(), anyLong()))
+				.thenReturn(List.of(1L, 2L, 3L));
 		when(pushGateway.send(any(), any()))
 				.thenReturn(new MobilePushResult(3, 0, List.of(), List.of("token-1", "token-2", "token-3")));
 
@@ -78,36 +80,37 @@ class TeamLiveEventPushFanOutBatchTest {
 		ArgumentCaptor<List<String>> tokens = ArgumentCaptor.forClass(List.class);
 		verify(pushGateway, times(1)).send(tokens.capture(), any());
 		assertThat(tokens.getValue()).containsExactly("token-1", "token-2", "token-3");
-		verify(deliveryRepository, times(3))
-				.markSent(anyLong(), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong());
+
+		verify(deliveryRepository, times(1)).reserveAll(any(), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong());
+		verify(deliveryRepository, times(1)).markSentAll(any(), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong());
+		verify(notificationService, times(1)).recordAll(any(), any(), anyString(), any(), any());
+		// 구독자 단위 호출이 남아 있으면 안 된다.
+		verify(deliveryRepository, never()).reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong());
+		verify(deliveryRepository, never()).markSent(anyLong(), anyString(), anyInt(), anyString(), anyLong());
 	}
 
 	@Test
-	@DisplayName("토큰별 결과로 구독자를 갈라 기록한다")
+	@DisplayName("토큰별 결과로 구독자를 갈라 마감한다")
 	void 성공한_토큰의_구독자만_발송_기록한다() {
-		List<MemberDevice> devices = List.of(device(1L, "token-1"), device(2L, "token-2"));
-		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
-				.thenReturn(devices);
-		when(deliveryRepository.reserve(anyLong(), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+		givenSubscribers(List.of(device(1L, "token-1"), device(2L, "token-2")));
+		when(deliveryRepository.reserveAll(any(), anyString(), anyInt(), anyString(), anyLong()))
+				.thenReturn(List.of(1L, 2L));
 		// token-2 만 성공
 		when(pushGateway.send(any(), any()))
 				.thenReturn(new MobilePushResult(1, 1, List.of(), List.of("token-2")));
 
 		service.notifyLiveEvent(MATCH_ID, SET_NUMBER, 11L, null, "제목", "본문");
 
-		verify(deliveryRepository).markSent(eq(2L), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong());
-		verify(deliveryRepository, never()).markSent(eq(1L), anyString(), anyInt(), anyString(), anyLong());
-		verify(deliveryRepository).markFailed(eq(1L), eq(MATCH_ID), eq(SET_NUMBER), anyString(), anyLong(), anyString());
+		assertThat(capturedIds(sentCaptor())).containsExactly(2L);
+		assertThat(capturedIds(failedCaptor())).containsExactly(1L);
 	}
 
 	@Test
-	@DisplayName("dedup 에 막힌 구독자는 토큰에 포함하지 않는다")
-	void 예약_실패_구독자는_발송_대상에서_빠진다() {
-		List<MemberDevice> devices = List.of(device(1L, "token-1"), device(2L, "token-2"));
-		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
-				.thenReturn(devices);
-		when(deliveryRepository.reserve(eq(1L), anyString(), anyInt(), anyString(), anyLong())).thenReturn(false);
-		when(deliveryRepository.reserve(eq(2L), anyString(), anyInt(), anyString(), anyLong())).thenReturn(true);
+	@DisplayName("예약에서 빠진 구독자는 토큰에 포함하지 않는다")
+	void 예약되지_않은_구독자는_발송_대상에서_빠진다() {
+		givenSubscribers(List.of(device(1L, "token-1"), device(2L, "token-2")));
+		when(deliveryRepository.reserveAll(any(), anyString(), anyInt(), anyString(), anyLong()))
+				.thenReturn(List.of(2L));
 		when(pushGateway.send(any(), any()))
 				.thenReturn(new MobilePushResult(1, 0, List.of(), List.of("token-2")));
 
@@ -116,6 +119,40 @@ class TeamLiveEventPushFanOutBatchTest {
 		ArgumentCaptor<List<String>> tokens = ArgumentCaptor.forClass(List.class);
 		verify(pushGateway).send(tokens.capture(), any());
 		assertThat(tokens.getValue()).containsExactly("token-2");
+	}
+
+	@Test
+	@DisplayName("예약 대상이 없으면 발송하지 않는다")
+	void 예약_대상이_없으면_발송하지_않는다() {
+		givenSubscribers(List.of(device(1L, "token-1")));
+		when(deliveryRepository.reserveAll(any(), anyString(), anyInt(), anyString(), anyLong()))
+				.thenReturn(List.of());
+
+		service.notifyLiveEvent(MATCH_ID, SET_NUMBER, 13L, null, "제목", "본문");
+
+		verify(pushGateway, never()).send(any(), any());
+	}
+
+	private void givenSubscribers(List<MemberDevice> devices) {
+		when(deviceRepository.findActiveDevicesBySubscribedMatchId(MATCH_ID, TeamLiveEventPushService.TYPE_LIVE_EVENT))
+				.thenReturn(devices);
+	}
+
+	private ArgumentCaptor<Collection<Long>> sentCaptor() {
+		ArgumentCaptor<Collection<Long>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(deliveryRepository).markSentAll(captor.capture(), anyString(), anyInt(), anyString(), anyLong());
+		return captor;
+	}
+
+	private ArgumentCaptor<Collection<Long>> failedCaptor() {
+		ArgumentCaptor<Collection<Long>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(deliveryRepository)
+				.markFailedAll(captor.capture(), anyString(), anyInt(), anyString(), anyLong(), anyString());
+		return captor;
+	}
+
+	private List<Long> capturedIds(ArgumentCaptor<Collection<Long>> captor) {
+		return List.copyOf(captor.getValue());
 	}
 
 	private MemberDevice device(Long memberId, String token) {


### PR DESCRIPTION
## 왜

#323으로 FCM HTTP 왕복은 사라졌지만 구독자 단위 DB 쿼리가 남아 시간이 여전히 구독자 수에 비례한다.

| 날짜 | 구독자 | SET_START spread | 1명당 | 비용 구성 |
|---|---|---|---|---|
2026-07-29 | 1,548 | 1,074초 | 0.694초 | HTTP + DB |
2026-07-30 | 747 | **37초** | **0.050초** | DB만 |

앱→DB TCP 왕복을 EC2에서 10회 실측했다 — 중위 **6.5ms** (AWS 서울 ↔ Oracle Cloud 춘천).

```
7.65  6.31  6.40  6.66  6.19  6.71  6.17  6.85  6.20  6.57  (ms)
```

구독자당 쿼리가 `reserve` 1~2 + `markSent` 1 + 알림 피드 INSERT 1 = **3~4개**. 747명이면 약 2,600 왕복 × 6.5ms ≈ 17초로, 관측된 37초와 자리수가 맞는다. 구독자 1,500명 경기(T1 등)면 **75초 이상**이 된다.

## 변경

**`MemberTeamEventPushDeliveryRepositoryCustom` / `Impl` 추가** (JdbcTemplate)

`reserveAll`은 기존 행을 한 번에 조회해 신규/재예약/제외를 자바에서 가른 뒤, 신규는 다중 VALUES `INSERT IGNORE`, 재예약은 `IN` 절 `UPDATE`로 처리한다. 판정 규칙은 단건 `reserve`와 동일하다 — 신규이거나 `FAILED`이거나 `PENDING` 1분 초과만 통과하고 `SENT`는 제외된다.

`markSentAll` / `markFailedAll`도 `IN` 절 벌크. `IN`은 500개씩 나눈다.

**`MemberNotificationService.recordAll` 추가** — `saveAll`로 넘겨 `hibernate.jdbc.batch_size`(50)와 prod의 `rewriteBatchedStatements=true`를 타게 한다.

**`TeamLiveEventPushService`** — 구독자 루프를 벌크 호출로 교체.

```
747명 기준 DB 왕복 약 2,600회 → 약 20회
```

## 검증

**배치 SQL을 실제 MySQL 8.0.46에서 실행 확인.** 프로덕션과 동일한 DDL로 테이블을 만들고 생성되는 문장을 그대로 돌렸다.

| 확인 | 결과 |
|---|---|
신규 3건 다중 VALUES `INSERT IGNORE` | 3행 생성 |
`status` + stale 판정 조회 | `SENT`/stale=0 제외, `FAILED` 및 `PENDING`+stale=1만 재예약 대상 |
재예약 `UPDATE` | 대상 id만 `PENDING`, `error_message` 초기화 |
`INSERT IGNORE` 재실행 | **`SENT` 행 무변경**(`sent_at` 유지) |
`markSentAll` / `markFailedAll` | 상태·`sent_at`·`error_message` 정상 |

**단위 테스트 4개** — 구독자 수와 무관하게 발송·예약·마감 각 1회, 구독자 단위 메서드 미사용(`never()`), 토큰별 결과로 구독자 분리, 예약 대상 0이면 발송 안 함. 구독자 루프로 되돌리면 3개가 FAILED 된다.

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

## 하지 못한 것

Testcontainers MySQL 통합 테스트를 작성했으나 **이 환경의 Gradle 테스트 JVM이 도커 소켓에 접근하지 못해 실행하지 못했다.** 실행해보지 못한 테스트를 남기지 않기로 해서 제거했다 — 검토 중 `member_id` FK 때문에 member 행 선행 생성이 필요하다는 것도 발견했다(그대로 두면 첫 실행에서 실패한다). SQL 검증은 위 수동 실행으로 대체했다.

## 배포 후 측정

```sql
SELECT set_number, event_type, COUNT(*) n,
       TIMESTAMPDIFF(SECOND, MIN(sent_at), MAX(sent_at)) spread_sec
  FROM member_team_event_push_delivery
 WHERE match_id='<다음 경기>' AND event_type IN ('SET_START','SET_END') AND status='SENT'
 GROUP BY 1,2;
```

747명 37초 → 한 자리 초로 떨어져야 한다. 구독자 1,500명 경기에서도 마찬가지다.

## 남은 것

`PlayerSoloRankPushService`도 같은 구독자 팬아웃 구조다. 솔랭 알림은 규모가 작아 우선순위를 낮췄지만 같은 수정이 적용 가능하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)