### PR TITLE
fix: 업스트림 피드 동결 시 세트 종료·다음 세트 미감지 수정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveFrameStallTracker.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveFrameStallTracker.java
@@ -1,0 +1,81 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 게임별 프레임 진전을 추적해 피드 정지를 감지한다.
+ *
+ * <p>업스트림 livestats 가 세트 종료를 알리지 않고 그냥 멈추는 경우가 있다
+ * (2026-07-30 LCK HLE vs DK 2세트: 마지막 프레임 20:44:38 이후 29분간 gameState=in_game 으로
+ * 동결, finished 미도착). 종료 판정이 프레임 gameState=finished 하나에만 의존하면 이때 세트가
+ * 영원히 LIVE 로 남고 SET_END 도 나가지 않는다.</p>
+ *
+ * <p>정지는 "종료"의 증거가 아니라 "의심"일 뿐이다 — 퍼즈 중에도 피드가 얼 수 있고, LCK 기술
+ * 퍼즈는 수십 분씩 간다. 그래서 이 추적기는 정지 여부만 알려주고, 종료 확정은 호출부가 별도
+ * 신호(매치 스코어)와 조합해서 판단한다. 마지막 프레임이 gameState=paused 면 명시적 퍼즈이므로
+ * 진전으로 취급해 정지로 세지 않는다.</p>
+ */
+@Component
+public class LiveFrameStallTracker {
+
+	private final Clock clock;
+	private final long stallThresholdMs;
+	private final Map<String, Progress> progressByGame = new ConcurrentHashMap<>();
+
+	public LiveFrameStallTracker(
+			@Value("${lolesports.live.frame-stall-threshold-ms:180000}") long stallThresholdMs) {
+		this(Clock.systemUTC(), stallThresholdMs);
+	}
+
+	LiveFrameStallTracker(Clock clock, long stallThresholdMs) {
+		this.clock = clock;
+		this.stallThresholdMs = stallThresholdMs;
+	}
+
+	/**
+	 * window 응답을 관측하고, 이 게임의 프레임이 임계 시간 이상 정지해 있는지 돌려준다.
+	 * 프레임이 없으면(픽밴 등 시작 전) 정지로 보지 않는다.
+	 */
+	public boolean observeAndCheckStalled(String gameId, JsonNode windowResponse) {
+		JsonNode frames = windowResponse == null ? null : windowResponse.path("frames");
+		if (frames == null || !frames.isArray() || frames.isEmpty()) {
+			return false;
+		}
+		JsonNode last = frames.get(frames.size() - 1);
+		String lastTimestamp = last.path("rfc460Timestamp").asText(null);
+		boolean paused = "paused".equalsIgnoreCase(last.path("gameState").asText());
+		Instant now = clock.instant();
+
+		Progress progress = progressByGame.compute(gameId, (id, previous) -> {
+			if (previous == null
+					|| paused
+					|| lastTimestamp == null
+					|| !lastTimestamp.equals(previous.lastFrameTimestamp())) {
+				return new Progress(lastTimestamp, now);
+			}
+			return previous;
+		});
+		return now.toEpochMilli() - progress.lastAdvanceAt().toEpochMilli() >= stallThresholdMs;
+	}
+
+	/** 관측 없이 현재 정지 여부만 조회한다(디스커버리에서 사용). 관측 이력이 없으면 false. */
+	public boolean isStalled(String gameId) {
+		Progress progress = progressByGame.get(gameId);
+		return progress != null
+				&& clock.instant().toEpochMilli() - progress.lastAdvanceAt().toEpochMilli() >= stallThresholdMs;
+	}
+
+	public void evict(String gameId) {
+		progressByGame.remove(gameId);
+	}
+
+	private record Progress(String lastFrameTimestamp, Instant lastAdvanceAt) {
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -48,6 +48,8 @@ public class LivePollingScheduler {
 	private final CacheEvictionService cacheEvictionService;
 	private final NotificationService notificationService;
 	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
+	private final LiveFrameStallTracker frameStallTracker;
+	private final com.toy.nar.app.lolesports.repository.LeagueMatchRepository leagueMatchRepository;
 	@org.springframework.beans.factory.annotation.Qualifier("applicationTaskExecutor")
 	private final java.util.concurrent.Executor applicationTaskExecutor;
 
@@ -135,7 +137,16 @@ public class LivePollingScheduler {
 					List<String> feedLiveGameIds = List.of();
 					boolean upstreamKnowsLiveGames =
 							match.getLiveGameIds() != null && !match.getLiveGameIds().isEmpty();
-					if (!upstreamKnowsLiveGames && !"completed".equalsIgnoreCase(match.getState())) {
+					// liveGameIds 가 차 있어도 그 게임의 프레임이 얼어 있으면(다음 세트로 못 넘어간
+					// 낡은 값 — 2026-07-30 HLE vs DK: 세트3 피드가 살아난 뒤에도 업스트림이 세트2 를
+					// 계속 가리킴) 매치의 전체 gameId 를 직접 찔러 다음 세트를 찾는다.
+					boolean trackedGameStalled = hasStalledTrackedGame(activeGames, match.getMatchId());
+					if ((!upstreamKnowsLiveGames || trackedGameStalled)
+							&& !"completed".equalsIgnoreCase(match.getState())) {
+						if (trackedGameStalled && upstreamKnowsLiveGames) {
+							log.info("[live-discovery] 추적 중 게임 프레임 정지 — 피드 직접 프로브 matchId={}",
+									match.getMatchId());
+						}
 						FeedProbe probe = probeFeed(match);
 						feedLiveGameIds = probe.liveGameIds();
 						if (!feedLiveGameIds.isEmpty()) {
@@ -181,6 +192,12 @@ public class LivePollingScheduler {
 						}
 						discoveredGameIds.add(gameId);
 						ActiveLiveGame current = activeGames.get(gameId);
+						if (current == null) {
+							// 조사 때마다 디스커버리가 뭘 봤는지 로그가 없어 피드를 수동 조회해야 했다.
+							// 신규 편입은 세트당 1회라 스팸이 아니다.
+							log.info("[live-discovery] 신규 추적 gameId={} matchId={} state={} feedProbe={}",
+									gameId, match.getMatchId(), match.getState(), !feedLiveGameIds.isEmpty());
+						}
 						String resolvedLeagueName = (match.getLeagueName() == null || match.getLeagueName().isBlank())
 								? league
 								: match.getLeagueName();
@@ -245,6 +262,7 @@ public class LivePollingScheduler {
 		toRemove.forEach(gameId -> {
 			liveStateStore.removeGame(gameId);
 			liveObjectEventRecorder.evict(gameId);
+			frameStallTracker.evict(gameId);
 			setEndNotifiedGameIds.remove(gameId);
 			frameFinishedGameIds.remove(gameId);
 			startNotifiedGameIds.remove(gameId);
@@ -406,6 +424,42 @@ public class LivePollingScheduler {
 		});
 	}
 
+	/**
+	 * 매치 스코어 합이 세트 번호에 도달했으면 그 세트는 실제로 끝난 것이다.
+	 * 스코어는 네이버 종료 확정 sync 로만 올라가므로 퍼즈 중에는 절대 도달하지 않는다.
+	 */
+	private boolean scoreConfirmsSetEnd(ActiveLiveGame activeGame) {
+		Integer setNumber = activeGame.setNumber();
+		if (setNumber == null || setNumber <= 0 || activeGame.matchId() == null) {
+			return false;
+		}
+		try {
+			return leagueMatchRepository.findById(activeGame.matchId())
+					.map(match -> {
+						int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
+						int red = match.getRedScore() == null ? 0 : match.getRedScore();
+						return blue + red >= setNumber;
+					})
+					.orElse(false);
+		} catch (Exception e) {
+			log.warn("Set-end score check failed matchId={}: {}", activeGame.matchId(), e.getMessage());
+			return false;
+		}
+	}
+
+	/** 이 매치의 추적 중 게임 가운데 프레임이 정지한 것이 있는지. */
+	private boolean hasStalledTrackedGame(Map<String, ActiveLiveGame> activeGames, String matchId) {
+		if (matchId == null || matchId.isBlank()) {
+			return false;
+		}
+		for (ActiveLiveGame activeGame : activeGames.values()) {
+			if (matchId.equals(activeGame.matchId()) && frameStallTracker.isStalled(activeGame.gameId())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private Set<String> activeMatchIds(Map<String, ActiveLiveGame> activeGames) {
 		Set<String> matchIds = new HashSet<>();
 		for (ActiveLiveGame activeGame : activeGames.values()) {
@@ -439,7 +493,14 @@ public class LivePollingScheduler {
 
 				// 세트 종료 1차 판정: 프레임 gameState=finished (실제 종료 후 수 초 내 반영).
 				// finished 프레임은 timestamp 가 멈춰 aggregator 의 stale 필터에 걸리므로 여기 raw 응답에서 본다.
-				if (isFrameFinished(window)) {
+				//
+				// 2차 판정: 프레임 정지 + 매치 스코어 확인. 업스트림이 finished 를 안 주고 피드를
+				// 그냥 얼려버리는 경우가 있다(2026-07-30 HLE vs DK 2세트: 29분 동결). 정지 단독으로는
+				// 절대 종료로 보지 않는다 — 퍼즈 중에도 피드가 얼 수 있고 그때 쏘면 가짜 SET_END 가
+				// 나가고 dedup 이 소진돼 진짜 종료가 무음 스킵된다. 스코어 합(네이버 sync, 세트가
+				// 실제로 끝나야만 갱신됨)이 세트 번호에 도달했을 때만 확정한다.
+				boolean frameStalled = frameStallTracker.observeAndCheckStalled(activeGame.gameId(), window);
+				if (isFrameFinished(window) || (frameStalled && scoreConfirmsSetEnd(activeGame))) {
 					// store 에 마킹해야 세트 상태(LIVE/ENDED)가 stale 3분 잔상 동안 LIVE 로 남지 않는다.
 					// 푸시 게이트(isEnabled/리그)와 무관하게 마킹한다.
 					liveStateStore.markFinished(activeGame.gameId());
@@ -447,7 +508,8 @@ public class LivePollingScheduler {
 							&& teamLiveEventPushService.isEnabled()
 							&& isNotifiableLeague(activeGame.leagueName())
 							&& setEndNotifiedGameIds.add(activeGame.gameId())) {
-						log.info("[live-notify] set-end(frame) gameId={} matchId={} set={}",
+						log.info("[live-notify] set-end({}) gameId={} matchId={} set={}",
+								isFrameFinished(window) ? "frame" : "stall+score",
 								activeGame.gameId(), activeGame.matchId(), activeGame.setNumber());
 						fireSetEndNotification(activeGame);
 					}
@@ -460,6 +522,7 @@ public class LivePollingScheduler {
 					log.warn("Removing game {} after {} consecutive polling failures", failed.gameId(), failed.consecutiveFailures());
 					liveStateStore.removeGame(failed.gameId());
 					liveObjectEventRecorder.evict(failed.gameId());
+					frameStallTracker.evict(failed.gameId());
 					continue;
 				}
 				liveStateStore.getActiveGames().put(failed.gameId(), failed);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveFrameStallTrackerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveFrameStallTrackerTest.java
@@ -1,0 +1,116 @@
+package com.toy.nar.app.lolesports.live;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 프레임 정지 감지가 진짜 정지만 잡는지 지키는 회귀 테스트.
+ *
+ * 실제 사고: 2026-07-30 HLE vs DK 2세트 — 업스트림이 finished 없이 피드를 얼려
+ * 마지막 프레임(20:44:38)이 29분간 그대로였고, 앱은 세트를 영원히 LIVE 로 표시했다.
+ * 반대로 퍼즈는 정지로 세면 안 된다 — 가짜 SET_END 가 나가고 dedup 이 소진된다.
+ */
+class LiveFrameStallTrackerTest {
+
+	private static final long THRESHOLD_MS = 180_000L;
+
+	private final MutableClock clock = new MutableClock(Instant.parse("2026-07-30T11:44:38Z"));
+	private final LiveFrameStallTracker tracker = new LiveFrameStallTracker(clock, THRESHOLD_MS);
+
+	@Test
+	@DisplayName("프레임이 계속 진전하면 정지가 아니다")
+	void 진전하는_프레임은_정지가_아니다() {
+		assertThat(tracker.observeAndCheckStalled("G1", window("t1", "in_game"))).isFalse();
+		clock.advance(Duration.ofMinutes(4));
+		// 4분이 지났어도 새 타임스탬프가 왔으므로 진전으로 리셋된다.
+		assertThat(tracker.observeAndCheckStalled("G1", window("t2", "in_game"))).isFalse();
+	}
+
+	@Test
+	@DisplayName("같은 프레임이 임계 시간 이상 반복되면 정지다")
+	void 동결된_프레임은_정지다() {
+		tracker.observeAndCheckStalled("G1", window("frozen", "in_game"));
+		clock.advance(Duration.ofMinutes(2));
+		assertThat(tracker.observeAndCheckStalled("G1", window("frozen", "in_game"))).isFalse();
+		clock.advance(Duration.ofMinutes(2));
+		assertThat(tracker.observeAndCheckStalled("G1", window("frozen", "in_game"))).isTrue();
+		assertThat(tracker.isStalled("G1")).isTrue();
+	}
+
+	@Test
+	@DisplayName("gameState=paused 는 프레임이 멈춰도 정지로 세지 않는다")
+	void 퍼즈는_정지가_아니다() {
+		tracker.observeAndCheckStalled("G1", window("frozen", "paused"));
+		clock.advance(Duration.ofMinutes(10));
+		// 10분째 같은 프레임이지만 paused 는 매 관측마다 진전으로 취급된다.
+		assertThat(tracker.observeAndCheckStalled("G1", window("frozen", "paused"))).isFalse();
+		assertThat(tracker.isStalled("G1")).isFalse();
+	}
+
+	@Test
+	@DisplayName("프레임이 없으면(픽밴 등) 정지가 아니다")
+	void 프레임_없음은_정지가_아니다() {
+		ObjectNode empty = JsonNodeFactory.instance.objectNode();
+		empty.putArray("frames");
+		assertThat(tracker.observeAndCheckStalled("G1", empty)).isFalse();
+	}
+
+	@Test
+	@DisplayName("evict 하면 관측 이력이 사라진다")
+	void 제거하면_정지_판정이_사라진다() {
+		tracker.observeAndCheckStalled("G1", window("frozen", "in_game"));
+		clock.advance(Duration.ofMinutes(5));
+		assertThat(tracker.isStalled("G1")).isTrue();
+
+		tracker.evict("G1");
+
+		assertThat(tracker.isStalled("G1")).isFalse();
+	}
+
+	private ObjectNode window(String timestamp, String gameState) {
+		ObjectNode root = JsonNodeFactory.instance.objectNode();
+		ArrayNode frames = root.putArray("frames");
+		ObjectNode frame = frames.addObject();
+		frame.put("rfc460Timestamp", timestamp);
+		frame.put("gameState", gameState);
+		return root;
+	}
+
+	/** 테스트에서 시간을 직접 미는 시계. */
+	private static final class MutableClock extends Clock {
+		private Instant now;
+
+		MutableClock(Instant start) {
+			this.now = start;
+		}
+
+		void advance(Duration duration) {
+			now = now.plus(duration);
+		}
+
+		@Override
+		public Instant instant() {
+			return now;
+		}
+
+		@Override
+		public ZoneOffset getZone() {
+			return ZoneOffset.UTC;
+		}
+
+		@Override
+		public Clock withZone(java.time.ZoneId zone) {
+			return this;
+		}
+	}
+}

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -50,6 +50,8 @@ class LivePollingSchedulerTest {
 				cacheEvictionService,
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 2);
 		liveStateStore.getActiveGames().put("game-1", new ActiveLiveGame(
@@ -92,6 +94,8 @@ class LivePollingSchedulerTest {
 				cacheEvictionService,
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		ActiveLiveGame activeGame = new ActiveLiveGame(
@@ -287,6 +291,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		MatchResultDto ewcUnstarted = MatchResultDto.builder()
@@ -322,6 +328,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		// 이미 추적 중인 상태로 시작
@@ -358,6 +366,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		MatchResultDto ewcUnstarted = MatchResultDto.builder()
@@ -395,6 +405,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		// 마지막 세트를 라이브로 추적하던 중이었음
@@ -434,6 +446,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		MatchResultDto completed = MatchResultDto.builder()
@@ -468,6 +482,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, cacheEvictionService, mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		MatchResultDto kespaUnstarted = MatchResultDto.builder()
@@ -508,6 +524,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, cacheEvictionService, mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		MatchResultDto kespaUnstarted = MatchResultDto.builder()
@@ -542,6 +560,8 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		MatchResultDto oldCompleted = MatchResultDto.builder()
@@ -620,6 +640,65 @@ class LivePollingSchedulerTest {
 				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
 	}
 
+	@Test
+	void stalledFrameWithConfirmedScoreFiresSetEnd() throws InterruptedException {
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		// 스코어 합 2 = lckGame 의 setNumber(2) 도달 → 종료 확정 가능.
+		com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepository =
+				matchRepositoryWithScore(1, 1);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(1L), matchRepository);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		// 두 폴 모두 같은 프레임(동결) + gameState=in_game — finished 는 오지 않는다.
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("in_game"));
+
+		scheduler.pollActiveGames();
+		Thread.sleep(10); // 임계 1ms 를 넘긴다
+		scheduler.pollActiveGames();
+
+		assertThat(liveStateStore.isFinished("game-1")).isTrue();
+		verify(pushService, times(1)).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				eq("match-1"), eq(2), eq("100"), eq("200"), eq("KT"), eq("HLE"));
+	}
+
+	@Test
+	void stalledFrameWithoutScoreDoesNotFireSetEnd() throws InterruptedException {
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		// 스코어 합 1 < setNumber(2) — 퍼즈로 피드가 얼었을 뿐일 수 있다. 절대 쏘면 안 된다.
+		com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepository =
+				matchRepositoryWithScore(1, 0);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(1L), matchRepository);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("in_game"));
+
+		scheduler.pollActiveGames();
+		Thread.sleep(10);
+		scheduler.pollActiveGames();
+
+		assertThat(liveStateStore.isFinished("game-1")).isFalse();
+		verify(pushService, never()).notifyMatchEvent(
+				eq(TeamLiveEventPushService.TYPE_SET_END),
+				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
+	}
+
+	private com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepositoryWithScore(
+			int blueScore, int redScore) {
+		var match = mock(com.toy.nar.app.lolesports.repository.LeagueMatch.class);
+		when(match.getBlueScore()).thenReturn(blueScore);
+		when(match.getRedScore()).thenReturn(redScore);
+		var repository = mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class);
+		when(repository.findById("match-1")).thenReturn(java.util.Optional.of(match));
+		return repository;
+	}
+
 	private ActiveLiveGame lckGame(String gameId) {
 		return new ActiveLiveGame(
 				gameId,
@@ -652,6 +731,35 @@ class LivePollingSchedulerTest {
 		return schedulerWith(liveStateStore, pushService, mock(WorldsService.class), mock(LeagueMatchService.class));
 	}
 
+	/** 정지 감지 테스트용 — 임계값이 짧은 tracker 와 스코어를 주는 매치 리포지토리를 주입한다. */
+	private LivePollingScheduler schedulerWith(
+			LiveStateStore liveStateStore,
+			TeamLiveEventPushService pushService,
+			LiveFrameStallTracker frameStallTracker,
+			com.toy.nar.app.lolesports.repository.LeagueMatchRepository leagueMatchRepository) {
+		LeagueConfigService leagueConfigService = mock(LeagueConfigService.class);
+		when(leagueConfigService.liveLeagues()).thenReturn(List.of("LCK"));
+		when(leagueConfigService.isNotificationEnabled("LCK")).thenReturn(true);
+		LivePollingScheduler scheduler = new LivePollingScheduler(
+				mock(WorldsService.class),
+				mock(LiveStatsClient.class),
+				mock(LiveObjectEventRecorder.class),
+				liveStateStore,
+				mock(LiveFrameProcessor.class),
+				liveGameMetadataServiceMock(),
+				mock(LeagueMatchService.class),
+				leagueConfigService,
+				mock(CacheEvictionService.class),
+				mock(NotificationService.class),
+				pushService,
+				frameStallTracker,
+				leagueMatchRepository,
+				Runnable::run);
+		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
+		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 6);
+		return scheduler;
+	}
+
 	private LivePollingScheduler schedulerWith(
 			LiveStateStore liveStateStore,
 			TeamLiveEventPushService pushService,
@@ -672,6 +780,8 @@ class LivePollingSchedulerTest {
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				pushService,
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 		ReflectionTestUtils.setField(scheduler, "staleThresholdMs", 180000L);
 		ReflectionTestUtils.setField(scheduler, "maxConsecutiveFailures", 6);
@@ -696,6 +806,8 @@ class LivePollingSchedulerTest {
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				new LiveFrameStallTracker(180_000L),
+				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
 
 		Instant nextWindow = ReflectionTestUtils.invokeMethod(


### PR DESCRIPTION
## 증상 (2026-07-30 LCK HLE vs DK)

2세트가 끝났는데 앱은 계속 "2세트 진행중"으로 표시했고, 3세트는 시작을 감지하지 못했다.

## 관측 — 피드 직접 조회로 확정

```
세트2 피드:  20:44:38 프레임에서 동결. 29분 뒤에도 같은 프레임, gameState=in_game.
            finished 는 끝내 오지 않았다.
세트3 피드:  21:10 부터 실시간 공급 (frames 32~43, in_game). 앱은 미인지.
매치 스코어: 21:00:29 에 네이버 sync 로 이미 1:1 갱신 — 종료 정보가 DB 에 있었다.
```

원인 두 갈래:
1. **종료 판정이 프레임 `gameState=finished` 하나에만 의존.** 업스트림이 finished 없이 피드를 얼리면 세트가 영원히 LIVE 로 남는다.
2. **#319 프로브 게이트의 사각.** "liveGameIds 가 비어 있을 때만 직접 프로브"인데, 이번엔 업스트림이 **죽은 세트2 를 계속 가리켜서**(낡은 값) 게이트를 통과하지 못했다. 어제는 빈 값, 오늘은 낡은 값 — 같은 지연의 다른 변종이다.

## 변경

**1. `LiveFrameStallTracker` 신설** — 게임별 마지막 프레임 타임스탬프 진전을 추적, 임계(기본 3분, `lolesports.live.frame-stall-threshold-ms`) 이상 동결 감지. `gameState=paused` 는 명시적 퍼즈이므로 진전으로 취급한다.

**2. 세트 종료 2차 판정 — 정지는 트리거, 스코어가 확정자**

```
프레임 정지 3분        →  의심. 단독으로는 절대 발화하지 않는다
+ 스코어 합 ≥ 세트번호  →  종료 확정 (markFinished + SET_END)
```

정지 단독 발화가 위험한 이유: LCK 기술 퍼즈는 수십 분씩 가고 퍼즈 중에도 피드가 얼 수 있다. 그때 쏘면 가짜 SET_END 가 ~1,500 구독자에게 나가고, dedup 키가 소진돼 **진짜 종료가 무음 스킵**된다. 스코어는 세트가 실제로 끝나야만 갱신되므로 퍼즈와 종료를 가른다.

| 상황 | 프레임 | 스코어 | 판정 |
|---|---|---|---|
오늘 (진짜 종료) | 동결 | 합=2 | 종료 — 21:00:29 직후 폴에 잡혔다 |
퍼즈(피드 동결형) | 동결 | 그대로 | 대기. 가짜 알림 0, 재개 시 자동 복귀 |
퍼즈(`paused` 프레임형) | 진전 취급 | — | 정지 감지 자체가 안 걸림 |

**3. 프로브 게이트 확장** — 추적 중 게임의 프레임이 얼어 있으면 `liveGameIds` 가 차 있어도 매치 전체 gameId 를 직접 프로브. 오늘 케이스라면 세트3 을 21:10 에 바로 잡았다.

**부수: 디스커버리 신규 편입 INFO 로그** — 이번 조사 두 번 모두 디스커버리가 뭘 봤는지 로그가 없어 피드를 수동 조회해야 했다. 신규 편입은 세트당 1회라 스팸 아님.

## 검증

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

- `LiveFrameStallTrackerTest` 5개(주입 시계): 진전=정상 / 동결 3분=정지 / **paused=정지 아님** / 프레임 없음=정지 아님 / evict
- `LivePollingSchedulerTest` 2개: 정지+스코어 확정 → SET_END 1회 + `markFinished` / 정지+스코어 미달(퍼즈 상황) → **절대 발화 안 함**
- 판정 분기를 `false` 로 무력화하면 전자가 FAILED 되는 것 확인 후 복원

## 관련·주의

- #325(팬아웃 DB 배치)와 `LivePollingScheduler` 는 안 겹치지만 머지 순서에 따라 한쪽 리베이스 필요할 수 있다 — 이 PR 이 유저 가시 버그라 먼저 권장
- 남는 한계: 다음 세트 gameId 가 업스트림에 아예 발급되지 않은 구간(오늘 21:00~21:10)은 어떤 프로브로도 못 잡는다. 그 구간은 세트 시작 알림이 피드 공급 시점까지 늦는다

🤖 Generated with [Claude Code](https://claude.com/claude-code)