### PR TITLE
fix: LiveFrameStallTracker 빈 생성 실패로 인한 기동 불능 수정

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveFrameStallTracker.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveFrameStallTracker.java
@@ -29,6 +29,9 @@ public class LiveFrameStallTracker {
 	private final long stallThresholdMs;
 	private final Map<String, Progress> progressByGame = new ConcurrentHashMap<>();
 
+	// 생성자가 둘(운영용 + 테스트용 Clock 주입)이라 @Autowired 로 스프링이 쓸 쪽을 지정해야 한다.
+	// 없으면 기본 생성자를 찾다 기동 실패한다(2026-07-30 배포 실패 실사례 — 블루그린 헬스체크가 차단).
+	@org.springframework.beans.factory.annotation.Autowired
 	public LiveFrameStallTracker(
 			@Value("${lolesports.live.frame-stall-threshold-ms:180000}") long stallThresholdMs) {
 		this(Clock.systemUTC(), stallThresholdMs);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveFrameStallTrackerBeanCreationTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveFrameStallTrackerBeanCreationTest.java
@@ -1,0 +1,29 @@
+package com.toy.nar.app.lolesports.live;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 스프링이 이 빈을 실제로 생성할 수 있는지 지키는 회귀 테스트.
+ *
+ * 생성자가 둘(운영용 @Value + 테스트용 Clock 주입)인데 @Autowired 지정이 없으면 스프링은
+ * 기본 생성자를 찾다 기동에 실패한다. 단위 테스트는 직접 생성이라 이걸 못 잡았고, 풀 컨텍스트
+ * 테스트는 로컬 전용 게이트라 CI 도 못 잡아 2026-07-30 배포가 헬스체크에서 반려됐다.
+ * ApplicationContextRunner 는 이 빈 하나만 컨텍스트로 띄우므로 CI 에서 항상 돈다.
+ */
+class LiveFrameStallTrackerBeanCreationTest {
+
+	@Test
+	@DisplayName("스프링 컨텍스트가 빈을 생성할 수 있다")
+	void 스프링이_빈을_생성한다() {
+		new ApplicationContextRunner()
+				.withUserConfiguration(LiveFrameStallTracker.class)
+				.run(context -> {
+					assertThat(context).hasNotFailed();
+					assertThat(context).hasSingleBean(LiveFrameStallTracker.class);
+				});
+	}
+}


### PR DESCRIPTION
## 무엇

#326 배포가 신규 컨테이너 기동 실패로 헬스체크에서 반려됐다. **블루그린 덕에 무중단** — 구 컨테이너가 계속 서빙 중이고, 대신 #326 의 수정(피드 동결 감지)도 아직 프로덕션에 없다.

```
BeanCreationException: Error creating bean with name 'liveFrameStallTracker':
Failed to instantiate [LiveFrameStallTracker]: No default constructor found
```

## 원인

`LiveFrameStallTracker` 생성자가 둘이다 — 운영용(`@Value`)과 테스트용(Clock 주입). 생성자가 여러 개면 스프링은 `@Autowired` 지정이 없는 한 기본 생성자로 폴백하는데, 기본 생성자가 없어 기동이 죽었다.

CI 가 못 잡은 이유: 단위 테스트는 빈을 직접 생성하고, 풀 컨텍스트 테스트(`NarApplicationTests`)는 로컬 전용 시스템 프로퍼티로 게이트돼 있다.

## 변경

- 운영용 생성자에 `@Autowired` 지정 (1줄)
- `ApplicationContextRunner` 로 이 빈 하나만 띄우는 회귀 테스트 추가 — CI 에서 항상 돌고, `@Autowired` 를 제거하면 FAILED 되는 것 확인했다

## 검증

```
./gradlew test    # BUILD SUCCESSFUL (전체)
```

## 후속 과제 (별건)

이 계급의 버그(빈 배선 오류)는 풀 컨텍스트를 띄워야 확실히 잡힌다. CI 에서 돌 수 있는 컨텍스트 스모크 테스트(외부 의존은 스텁) 도입을 검토할 가치가 있다 — 이번이 그 부재로 배포가 반려된 첫 사례다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)