### PR TITLE
fix: 온보딩 10초 지연·연타 중복키 500 수정

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -42,6 +42,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,6 +68,10 @@ import static org.springframework.http.HttpStatus.*;
 public class AuthController {
 
     private static final int DEFAULT_ONBOARDING_YEAR = 2026;
+
+    /** 온보딩 선수 목록은 페이징 없이 전체를 쓴다. LCK 로스터는 한 시즌 100명 미만이라 상한 200이면 충분하다. */
+    private static final org.springframework.data.domain.PageRequest ONBOARDING_PLAYER_PAGE =
+            org.springframework.data.domain.PageRequest.of(0, 200);
 
     private static final List<OnboardingLeagueOptionResponse> ONBOARDING_LEAGUES = List.of(
             new OnboardingLeagueOptionResponse(
@@ -109,6 +115,7 @@ public class AuthController {
     private final MobileTeamNotificationService mobileTeamNotificationService;
     private final ProfileService profileService;
     private final CloudinarySignatureService cloudinarySignatureService;
+    private final TransactionTemplate transactionTemplate;
 
     @Operation(
             summary = "모바일 카카오 로그인",
@@ -226,8 +233,11 @@ public class AuthController {
         if (teamId != null) {
             validateSelectableTeam(teamId);
         }
+        // findLckPlayerOptions 는 ROW_NUMBER 기반이라 상관 서브쿼리 없이 한 번에 스캔한다.
+        // 예전 findOnboardingPlayers(상관 MAX 서브쿼리)는 실측 팀 지정 1.1초·전체 7.2초로,
+        // 온보딩 응답 지연 → 연타 → 중복키 500 폭주의 근원이었다.
         List<OnboardingPlayerOptionResponse> players = playerRepository
-                .findOnboardingPlayers("LCK", DEFAULT_ONBOARDING_YEAR, teamId)
+                .findLckPlayerOptions("LCK", DEFAULT_ONBOARDING_YEAR, teamId, null, ONBOARDING_PLAYER_PAGE)
                 .stream()
                 .map(OnboardingPlayerOptionResponse::from)
                 .toList();
@@ -300,9 +310,23 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "회원 또는 팀을 찾을 수 없음")
     })
     @PostMapping("/onboarding")
-    @Transactional
     public ResponseEntity<MemberResponse> onboarding(@AuthenticationPrincipal Long memberId,
                                                       @Valid @RequestBody OnboardingRequest request) {
+        try {
+            return ResponseEntity.ok(
+                    transactionTemplate.execute(status -> completeOnboarding(memberId, request)));
+        } catch (DataIntegrityViolationException e) {
+            // 온보딩 연타로 동시 요청이 겹치면 즐겨찾기 유니크 제약에 늦은 쪽이 걸린다
+            // (실측 2026-07-31 새벽 29건 — 앞선 요청이 이미 같은 내용으로 완료된 상태).
+            // 이미 완료된 것은 실패가 아니므로 현재 상태를 그대로 돌려준다.
+            return ResponseEntity.ok(
+                    transactionTemplate.execute(status -> memberRepository.findById(memberId)
+                            .map(MemberResponse::from)
+                            .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"))));
+        }
+    }
+
+    private MemberResponse completeOnboarding(Long memberId, OnboardingRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "회원을 찾을 수 없습니다"));
         String favoriteLeague = normalizeOnboardingLeague(request.favoriteLeagueName());
@@ -315,7 +339,7 @@ public class AuthController {
 
         member.completeOnboarding(favoriteLeague, team, favoritePlayers);
         mobileTeamNotificationService.ensureDefaultSubscription(member, team);
-        return ResponseEntity.ok(MemberResponse.from(member));
+        return MemberResponse.from(member);
     }
 
     @Operation(
@@ -428,9 +452,9 @@ public class AuthController {
         }
 
         Set<Long> selectablePlayerIds = playerRepository
-                .findOnboardingPlayers("LCK", DEFAULT_ONBOARDING_YEAR, teamId)
+                .findLckPlayerOptions("LCK", DEFAULT_ONBOARDING_YEAR, teamId, null, ONBOARDING_PLAYER_PAGE)
                 .stream()
-                .map(Player::getId)
+                .map(PlayerRepository.LckPlayerOption::getPlayerId)
                 .collect(Collectors.toSet());
         boolean hasUnavailablePlayer = requestedIds.stream()
                 .anyMatch(playerId -> !selectablePlayerIds.contains(playerId));

--- a/src/main/java/com/toy/nar/api/auth/dto/OnboardingPlayerOptionResponse.java
+++ b/src/main/java/com/toy/nar/api/auth/dto/OnboardingPlayerOptionResponse.java
@@ -23,4 +23,14 @@ public record OnboardingPlayerOptionResponse(
                 player.getRole()
         );
     }
+
+    public static OnboardingPlayerOptionResponse from(
+            com.toy.nar.domain.participant.repository.PlayerRepository.LckPlayerOption option) {
+        return new OnboardingPlayerOptionResponse(
+                option.getPlayerId(),
+                option.getPlayerName(),
+                option.getPlayerImageUrl(),
+                option.getRole()
+        );
+    }
 }

--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -81,35 +81,6 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			""")
 	List<Player> findSoloRankSyncTargets(@Param("leagueName") String leagueName);
 
-	// 시즌 중 이적한 선수가 이적 전/후 팀 양쪽 목록에 중복으로 뜨는 것을 막기 위해
-	// 상관 서브쿼리로 선수별 "가장 최근 경기"의 참가 기록만 남긴다.
-	// 참고: findLckPlayerOption은 성능 때문에 이 상관 서브쿼리를 ROW_NUMBER()로 대체했다.
-	// 여기서는 페이징·정렬이 없고 보통 teamId로 한 팀만 조회해 스캔 범위가 작으므로 유지한다.
-	@Query("""
-			SELECT DISTINCT p
-			FROM GameParticipant gp
-			JOIN gp.player p
-			JOIN gp.team t
-			JOIN gp.game g
-			JOIN g.league l
-			WHERE l.leagueName = :leagueName
-			  AND l.seasonYear = :year
-			  AND (:teamId IS NULL OR t.id = :teamId)
-			  AND g.actualGameStartTime = (
-				  SELECT MAX(g2.actualGameStartTime)
-				  FROM GameParticipant gp2
-				  JOIN gp2.game g2
-				  JOIN g2.league l2
-				  WHERE gp2.player = p
-				    AND l2.leagueName = :leagueName
-				    AND l2.seasonYear = :year
-			  )
-			ORDER BY p.name
-			""")
-	List<Player> findOnboardingPlayers(
-			@Param("leagueName") String leagueName,
-			@Param("year") int year,
-			@Param("teamId") Long teamId);
 
 	/**
 	 * 해당 리그·시즌에서 선수별로 "가장 최근 경기"의 팀 하나로 중복 제거해 페이지로 반환한다.

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerOnboardingNotificationTest.java
@@ -26,6 +26,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,7 +63,8 @@ class AuthControllerOnboardingNotificationTest {
 				mobileDeviceService,
 				notificationService,
 				profileService,
-				mock(CloudinarySignatureService.class));
+				mock(CloudinarySignatureService.class),
+				immediateTransactionTemplate());
 		Member member = Member.builder().name("용맹한바론").tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", 7L);
 		Team team = Team.builder().name("T1").code("T1").imageUrl("t1.png").build();
@@ -126,8 +130,9 @@ class AuthControllerOnboardingNotificationTest {
 		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
 		when(context.playerRepository.findAllById(java.util.Set.of(10L, 11L, 12L, 13L)))
 				.thenReturn(players);
-		when(context.playerRepository.findOnboardingPlayers("LCK", 2026, 1L))
-				.thenReturn(players);
+		var lckOpts = lckOptions(players);
+		when(context.playerRepository.findLckPlayerOptions(eq("LCK"), eq(2026), eq(1L), isNull(), any()))
+				.thenReturn(new org.springframework.data.domain.PageImpl<>(lckOpts));
 
 		var response = context.controller.onboarding(
 				7L,
@@ -148,7 +153,9 @@ class AuthControllerOnboardingNotificationTest {
 		when(context.teamRepository.findById(1L)).thenReturn(Optional.of(team));
 		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
 		when(context.playerRepository.findAllById(java.util.Set.of(10L))).thenReturn(List.of(player));
-		when(context.playerRepository.findOnboardingPlayers("LCK", 2026, 1L)).thenReturn(List.of());
+		var lckOpts = lckOptions(List.of());
+		when(context.playerRepository.findLckPlayerOptions(eq("LCK"), eq(2026), eq(1L), isNull(), any()))
+				.thenReturn(new org.springframework.data.domain.PageImpl<>(lckOpts));
 
 		assertThatThrownBy(() -> context.controller.onboarding(
 				7L,
@@ -162,14 +169,51 @@ class AuthControllerOnboardingNotificationTest {
 		TestContext context = context();
 		Team t1 = team(1L, "T1", "T1");
 		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(t1));
-		when(context.playerRepository.findOnboardingPlayers("LCK", 2026, 1L)).thenReturn(List.of());
+		var lckOpts = lckOptions(List.of());
+		when(context.playerRepository.findLckPlayerOptions(eq("LCK"), eq(2026), eq(1L), isNull(), any()))
+				.thenReturn(new org.springframework.data.domain.PageImpl<>(lckOpts));
 
 		var teams = context.controller.getOnboardingTeams(2026);
 		context.controller.getOnboardingPlayers(2026, 1L);
 
 		assertThat(teams.getBody()).isNotNull();
 		assertThat(teams.getBody()).extracting("code").containsExactly("T1");
-		verify(context.playerRepository).findOnboardingPlayers("LCK", 2026, 1L);
+		verify(context.playerRepository).findLckPlayerOptions(eq("LCK"), eq(2026), eq(1L), isNull(), any());
+	}
+
+	/**
+	 * 온보딩 연타로 동시 요청이 겹치면 늦은 쪽이 즐겨찾기 유니크 제약(중복키)에 걸린다.
+	 * 실측 2026-07-31 새벽 29건 — 앞선 요청이 이미 완료된 상태이므로 500 이 아니라
+	 * 현재 상태로 200 을 돌려줘야 한다(앱이 온보딩 실패로 오인하지 않게).
+	 */
+	@Test
+	void onboardingAbsorbsConcurrentDuplicateAsSuccess() {
+		TestContext context = context();
+		Member member = member(7L);
+		Team team = team(1L, "T1", "T1");
+		Player faker = player(10L, "Faker");
+		member.completeOnboarding("LCK", team, List.of(faker)); // 앞선 요청이 이미 완료한 상태
+		when(context.memberRepository.findById(7L)).thenReturn(Optional.of(member));
+		when(context.teamRepository.findById(1L)).thenReturn(Optional.of(team));
+		when(context.teamRepository.findAllByCodeIn(LckTeamCatalog.TEAM_CODES)).thenReturn(List.of(team));
+		when(context.playerRepository.findAllById(java.util.Set.of(10L))).thenReturn(List.of(faker));
+		var lckOpts = lckOptions(List.of(faker));
+		when(context.playerRepository.findLckPlayerOptions(eq("LCK"), eq(2026), eq(1L), isNull(), any()))
+				.thenReturn(new org.springframework.data.domain.PageImpl<>(lckOpts));
+		// 트랜잭션 커밋 시점의 중복키를 재현: 첫 execute 는 예외, 흡수 후 재조회 execute 는 정상 실행
+		var template = mock(org.springframework.transaction.support.TransactionTemplate.class);
+		when(template.execute(any()))
+				.thenThrow(new org.springframework.dao.DataIntegrityViolationException(
+						"Duplicate entry '7-10' for key 'uq_member_favorite_player'"))
+				.thenAnswer(inv -> inv.getArgument(0,
+						org.springframework.transaction.support.TransactionCallback.class).doInTransaction(null));
+		ReflectionTestUtils.setField(context.controller, "transactionTemplate", template);
+
+		var response = context.controller.onboarding(7L, new OnboardingRequest("LCK", 1L, List.of(10L)));
+
+		assertThat(response.getStatusCode().value()).isEqualTo(200);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().favoritePlayerIds()).containsExactly(10L);
 	}
 
 	// 탈퇴 관련 테스트는 AuthControllerWithdrawTest 로 옮겼다(멱등 삭제로 동작이 바뀜).
@@ -202,7 +246,8 @@ class AuthControllerOnboardingNotificationTest {
 				mobileDeviceService,
 				notificationService,
 				profileService,
-				mock(CloudinarySignatureService.class));
+				mock(CloudinarySignatureService.class),
+				immediateTransactionTemplate());
 		return new TestContext(
 				memberSocialRepository,
 				controller,
@@ -237,5 +282,25 @@ class AuthControllerOnboardingNotificationTest {
 			TeamRepository teamRepository,
 			PlayerRepository playerRepository,
 			MobileTeamNotificationService notificationService) {
+	}
+
+	/** 콜백을 즉시 실행하는 TransactionTemplate — 컨트롤러의 트랜잭션 경계를 프로덕션과 같은 경로로 태운다. */
+	private static org.springframework.transaction.support.TransactionTemplate immediateTransactionTemplate() {
+		var template = mock(org.springframework.transaction.support.TransactionTemplate.class);
+		org.mockito.Mockito.lenient().when(template.execute(org.mockito.ArgumentMatchers.any()))
+				.thenAnswer(inv -> inv.getArgument(0,
+						org.springframework.transaction.support.TransactionCallback.class).doInTransaction(null));
+		return template;
+	}
+
+	/** Player 목록을 LckPlayerOption 프로젝션 목록으로 바꾼다(선수 검증 스텁용). */
+	private static List<com.toy.nar.domain.participant.repository.PlayerRepository.LckPlayerOption> lckOptions(
+			List<Player> players) {
+		return players.stream().map(pl -> {
+			var opt = mock(com.toy.nar.domain.participant.repository.PlayerRepository.LckPlayerOption.class);
+			org.mockito.Mockito.lenient().when(opt.getPlayerId()).thenReturn(pl.getId());
+			org.mockito.Mockito.lenient().when(opt.getPlayerName()).thenReturn(pl.getName());
+			return (com.toy.nar.domain.participant.repository.PlayerRepository.LckPlayerOption) opt;
+		}).toList();
 	}
 }

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerWithdrawTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerWithdrawTest.java
@@ -51,7 +51,8 @@ class AuthControllerWithdrawTest {
 			mock(MobileDeviceService.class),
 			mock(MobileTeamNotificationService.class),
 			mock(ProfileService.class),
-			mock(CloudinarySignatureService.class));
+			mock(CloudinarySignatureService.class),
+				immediateTransactionTemplate());
 
 	@Test
 	@DisplayName("탈퇴 시 소셜 연동과 회원을 벌크 삭제하고 204를 반환한다")
@@ -84,4 +85,14 @@ class AuthControllerWithdrawTest {
 				.isInstanceOf(ResponseStatusException.class)
 				.hasFieldOrPropertyWithValue("statusCode", HttpStatus.UNAUTHORIZED);
 	}
-}
+
+	/** 콜백을 즉시 실행하는 TransactionTemplate — 컨트롤러의 트랜잭션 경계를 프로덕션과 같은 경로로 태운다. */
+	private static org.springframework.transaction.support.TransactionTemplate immediateTransactionTemplate() {
+		var template = mock(org.springframework.transaction.support.TransactionTemplate.class);
+		org.mockito.Mockito.lenient().when(template.execute(org.mockito.ArgumentMatchers.any()))
+				.thenAnswer(inv -> inv.getArgument(0,
+						org.springframework.transaction.support.TransactionCallback.class).doInTransaction(null));
+		return template;
+	}
+
+	}


### PR DESCRIPTION
## 증상 → 인과

```
온보딩 POST 가 단독으로도 10.5초        (실측 01:59 e4371e8e = 10,575ms)
→ 유저가 0.6초부터 연타 (4초 안에 10건)
→ 동시 요청들이 서로 큐잉, 각각 14~24초로 붕괴
→ 첫 요청만 200, 늦은 쪽 전부 즐겨찾기 중복키 500
→ 데이터는 정상인데 앱은 마지막 응답(500)을 보고 온보딩 실패로 표시
```

2026-07-31 새벽에만 29사건/13명. #324 이후에도 계속 — #324는 같은 트랜잭션에서 읽은 컬렉션 기준이라 **미커밋 동시 요청을 볼 수 없다.**

## 근원 1 — 상관 서브쿼리 (프로덕션 실측)

| 쿼리 | 시간 |
|---|---|
`findOnboardingPlayers` 팀 지정 (POST 경로) | **1,071ms** (워밍 후 896ms) |
`findOnboardingPlayers` 전체 (GET 목록) | **7,243ms** |
교체 쿼리 (ROW_NUMBER, 팀 지정) | **105ms** — 동일 결과 5명 |

EXPLAIN: 참가 기록 행마다 `dependent subquery`로 선수별 참가기록(평균 48건)을 재스캔. 같은 파일 `findLckPlayerOptions` 주석에 답이 이미 있었다 — *"상관 서브쿼리로 8~9초 → ROW_NUMBER로 ~55배 단축"*. 온보딩 쿼리에만 옛 패턴이 남아 있었다.

DB가 1/8 OCPU(E2.1.Micro)라 1초 CPU 쿼리 × 동시 10건 = 각 10초+로 직렬화 — 연타가 지연을 지수적으로 키웠다.

## 근원 2 — 동시 온보딩 비멱등

앞선 요청이 커밋한 뒤 도착한 재시도가 같은 즐겨찾기를 INSERT → 중복키 → `GlobalExceptionHandler` 500. 이미 완료된 것은 실패가 아니다.

## 변경

**1. `findOnboardingPlayers` 삭제, `findLckPlayerOptions` 재사용** — GET 목록 + POST 선수 검증 둘 다. **신규 SQL 0줄**, 이미 검증된 쿼리의 재사용이다.
   - 부수 변화: 목록 정렬이 이름순 → 포지션순(탑→정글→미드→원딜→서폿)·이름순. 온보딩 UI에 오히려 자연스럽다

**2. 중복키 흡수** — POST를 `TransactionTemplate` 경계로 바꾸고 `DataIntegrityViolationException` → 현재 회원 상태 재조회 후 **200**. 커밋 시점 예외는 `@Transactional` 컨트롤러 메서드 안에서 잡을 수 없어 경계를 명시적으로 옮겼다.

## 과하지 않게 — 뺀 것

- ~~회원 행 비관 락~~ — 근본(10초)이 사라지면 연타 자체가 사라진다. 남는 더블탭은 흡수가 200으로 수렴. 서로 다른 페이로드의 동시 온보딩이 관측되면 그때
- ~~목록 캐시~~ — 105ms에 캐시는 불필요. 쿼리 교체 후에도 DB CPU가 문제면 그때
- ~~신규 ROW_NUMBER 쿼리 작성~~ — 옆에 있는 걸 재사용

## 검증

- 교체 쿼리를 **프로덕션 DB에서 직접 실행** — 결과 동일(5명), 105ms
- 회귀 테스트: 동시 중복키 → 200 + 현재 상태. 흡수 무력화 시 FAILED 확인 후 복원
- 기존 온보딩 테스트 전부 새 쿼리 스텁으로 갱신, 전체 `./gradlew test` BUILD SUCCESSFUL

## 배포 후 확인

- `POST /api/auth/onboarding` Duration이 10,000ms대 → **수백 ms**로
- `uq_member_favorite_player` 중복키 ERROR 소멸 (새벽 시간당 ~4건이 기준선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)