### PR TITLE
fix: 같은 초 리프레시 토큰 발급 시 중복키 500 수정

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -270,7 +270,9 @@ public class AuthController {
         String newAccessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded(), member.getRole().name());
         String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
 
-        refreshTokenRepository.delete(stored);
+        // 벌크 삭제 — 동시 리프레시의 늦은 쪽이 이미 지워진 행을 만나도(0건 삭제) 예외 없이
+        // 자기 토큰을 커밋한다. 두 클라이언트 모두 유효한 토큰을 받는다.
+        refreshTokenRepository.deleteByToken(refreshToken);
         refreshTokenRepository.save(RefreshToken.builder()
                 .member(member)
                 .token(newRefreshToken)

--- a/src/main/java/com/toy/nar/app/auth/JwtTokenProvider.java
+++ b/src/main/java/com/toy/nar/app/auth/JwtTokenProvider.java
@@ -38,6 +38,10 @@ public class JwtTokenProvider {
     public String createRefreshToken(Long memberId) {
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
+                // jti 가 없으면 페이로드가 (subject, iat, exp)뿐인데 iat/exp 는 초 단위라
+                // 같은 회원에게 같은 초에 발급한 토큰이 바이트 동일해진다. DB unique(token)에
+                // 걸려 동시 리프레시/로그인이 500 으로 죽었다(실측 2026-07-31 새벽 14건).
+                .id(java.util.UUID.randomUUID().toString())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRY_MS))
                 .signWith(secretKey)

--- a/src/main/java/com/toy/nar/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/RefreshTokenRepository.java
@@ -8,4 +8,13 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
     void deleteByMemberId(Long memberId);
+
+    /**
+     * 토큰 회전용 벌크 삭제. 엔티티 삭제(delete(stored))는 동시 리프레시 두 건이 같은 행을
+     * 지우면 늦은 쪽이 row count 0 flush 예외로 500 이 난다(#321 탈퇴와 같은 계급).
+     * 벌크 삭제는 0건도 정상이라 늦은 쪽도 자기 토큰으로 커밋된다.
+     */
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Query("delete from RefreshToken rt where rt.token = :token")
+    int deleteByToken(@org.springframework.data.repository.query.Param("token") String token);
 }

--- a/src/test/java/com/toy/nar/app/auth/JwtTokenProviderRefreshTokenTest.java
+++ b/src/test/java/com/toy/nar/app/auth/JwtTokenProviderRefreshTokenTest.java
@@ -1,0 +1,40 @@
+package com.toy.nar.app.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 리프레시 토큰이 발급 시각과 무관하게 항상 유니크한지 지키는 회귀 테스트.
+ *
+ * jti 가 없으면 페이로드가 (subject, iat, exp)뿐인데 iat/exp 는 초 단위라 같은 회원에게
+ * 같은 초에 발급한 토큰이 바이트 동일했다. DB unique(token)에 걸려 동시 리프레시/로그인이
+ * 500 으로 죽었다(실측 2026-07-31 새벽 14건 — 앱의 이중 401 인터셉터가 동시에 refresh 호출).
+ */
+class JwtTokenProviderRefreshTokenTest {
+
+	private final JwtTokenProvider provider =
+			new JwtTokenProvider("test-secret-key-must-be-long-enough-for-hs256");
+
+	@Test
+	@DisplayName("같은 회원에게 같은 초에 발급해도 토큰이 다르다")
+	void 같은_초_발급_토큰이_유니크하다() {
+		// 루프 안 연속 호출은 사실상 항상 같은 초에 떨어진다 — jti 가 없으면 전부 동일해진다.
+		String first = provider.createRefreshToken(7L);
+		String second = provider.createRefreshToken(7L);
+		String third = provider.createRefreshToken(7L);
+
+		assertThat(first).isNotEqualTo(second).isNotEqualTo(third);
+		assertThat(second).isNotEqualTo(third);
+	}
+
+	@Test
+	@DisplayName("jti 를 넣어도 기존 파싱(memberId 추출)이 그대로 동작한다")
+	void 기존_파싱과_호환된다() {
+		String token = provider.createRefreshToken(7L);
+
+		assertThat(provider.getMemberId(token)).isEqualTo(7L);
+		assertThat(provider.validate(token)).isTrue();
+	}
+}


### PR DESCRIPTION
## 증상

`POST /api/auth/refresh`(및 로그인)가 간헐적으로 500. 2026-07-31 새벽에만 **14건** — 버스트 없이 2분~48분 간격으로 흩어진 개별 사건. 앱의 이중 401 인터셉터가 동시에 refresh를 호출하는 패턴이다.

```
Duplicate entry '...' for key 'refresh_token.token'
```

## 원인

**1. 리프레시 JWT가 같은 초에 발급되면 바이트 동일**

```java
Jwts.builder().subject(memberId).issuedAt(new Date()).expiration(...).compact()
```

페이로드가 `(subject, iat, exp)`뿐인데 **iat/exp는 JWT NumericDate 규격상 초 단위**다. 같은 회원 + 같은 초 = 동일 문자열 → `unique(token)` 충돌. Hibernate는 INSERT를 DELETE보다 먼저 flush하므로 회전(구 토큰 삭제)이 실행되기 전에 중복이 먼저 터진다.

**2. jti만 넣으면 500이 자리만 옮긴다**

동시 리프레시 두 건이 같은 구 토큰 행을 `delete(stored)`(엔티티 삭제)하면, 늦은 쪽이 이미 지워진 행에서 `row count 0` flush 예외 → 여전히 500. **#321 탈퇴 버그와 같은 계급**이고 해법도 같다(벌크 삭제).

## 변경

- `createRefreshToken`에 `jti`(랜덤 UUID) — 1줄. 발급 시각 무관 유니크. 로그인·리프레시 양쪽 동시 해결
- 회전 삭제를 `deleteByToken` 벌크 쿼리로 교체 — 0건 삭제도 정상. 동시 리프레시 두 건 **모두 유효한 토큰으로 200**

## 검증

- 회귀 테스트: 연속 발급 3개 전부 상이 / jti 추가 후 기존 파싱(`getMemberId`, `validate`) 호환
- `.id(UUID...)` 제거 시 첫 테스트 FAILED 확인 후 복원 — jti 없으면 연속 발급이 실제로 동일 토큰이라는 증명이기도 하다
- 전체 `./gradlew test` BUILD SUCCESSFUL

## 남긴 것

로그인 경로 `deleteByMemberId`(파생 삭제)에 같은 잠재 위험(동시 로그인 시 row count 0)이 있으나 관측 0건이라 손대지 않았다. 나오면 같은 패턴으로.

기존 발급 토큰과의 호환: jti는 추가 클레임일 뿐이라 기존 토큰 검증·신규 토큰 파싱 모두 영향 없다.

## 배포 후 확인

`refresh_token.token` 중복키 ERROR 소멸 (기준선: 새벽 14건/밤).

🤖 Generated with [Claude Code](https://claude.com/claude-code)