### PR TITLE
feat: 공지사항 API (앱 조회 + 백오피스 CRUD + Cloudinary 이미지)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ src/main/build/
 # 애플리케이션 로그
 logs/
 test_result.log
+.env.local

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -5,6 +5,8 @@ import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
 import com.toy.nar.app.lolesports.repository.LeagueConfig;
 import com.toy.nar.app.member.service.MemberDeleteService;
+import com.toy.nar.app.notice.service.NoticeImageStorageService;
+import com.toy.nar.app.notice.service.NoticeService;
 import com.toy.nar.app.participant.service.PlayerAdminService;
 import com.toy.nar.app.riot.RiotAccountVerifyService;
 import com.toy.nar.app.riot.RiotApiException;
@@ -13,6 +15,7 @@ import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberFavoritePlayerRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.MemberTeamNotificationSubscriptionRepository;
+import com.toy.nar.domain.notice.entity.Notice;
 import com.toy.nar.domain.participant.LckTeamCatalog;
 import com.toy.nar.domain.participant.entity.Player;
 import com.toy.nar.domain.participant.repository.PlayerRepository;
@@ -37,7 +40,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -69,6 +74,8 @@ public class BackofficeController {
     private final LeagueMatchRepository leagueMatchRepository;
     private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
     private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
+    private final NoticeService noticeService;
+    private final NoticeImageStorageService noticeImageStorageService;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
@@ -200,6 +207,46 @@ public class BackofficeController {
                                               @RequestBody LeagueConfigUpdateRequest request) {
         return LeagueConfigRow.from(leagueConfigService.update(
                 leagueName, request.liveEnabled(), request.notificationEnabled(), request.syncEnabled()));
+    }
+
+    // ── 공지사항 ─────────────────────────────────────────────────────
+    // 앱 노출은 MobileNoticeController(/api/notices) — 여기는 임시저장 포함 관리 전용.
+
+    @GetMapping("/notices")
+    public Page<NoticeRow> notices(Pageable pageable) {
+        return noticeService.adminPage(pageable).map(NoticeRow::from);
+    }
+
+    @GetMapping("/notices/{id}")
+    public NoticeRow notice(@PathVariable Long id) {
+        return NoticeRow.from(noticeService.findById(id));
+    }
+
+    @PostMapping("/notices")
+    @ResponseStatus(HttpStatus.CREATED)
+    public NoticeRow createNotice(@RequestBody NoticeSaveRequest request) {
+        return NoticeRow.from(noticeService.create(
+                request.title(), request.content(), request.pinned(),
+                request.promoteUntil(), request.published()));
+    }
+
+    @PutMapping("/notices/{id}")
+    public NoticeRow updateNotice(@PathVariable Long id, @RequestBody NoticeSaveRequest request) {
+        return NoticeRow.from(noticeService.update(
+                id, request.title(), request.content(), request.pinned(),
+                request.promoteUntil(), request.published()));
+    }
+
+    @DeleteMapping("/notices/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteNotice(@PathVariable Long id) {
+        noticeService.delete(id);
+    }
+
+    // 공지 본문 이미지 업로드. 에디터가 붙여넣기/드롭 시 호출하고 반환 URL 을 마크다운에 삽입.
+    @PostMapping("/notices/images")
+    public Map<String, String> uploadNoticeImage(@RequestParam("file") MultipartFile file) {
+        return Map.of("url", noticeImageStorageService.upload(file));
     }
 
     // LCK 선수 한정 수정(이미지 = 수동 잠금 동반, 소속팀 변경, 솔랭 계정 수동 잠금). 서버에서 LCK 출전 이력 검증.
@@ -381,6 +428,20 @@ public class BackofficeController {
     public record CronJob(String name, String type, String schedule, String expression, String description) {}
 
     // ponytail: @Scheduled 작업 정적 카탈로그. 16개라 잘 안 바뀜.
+    /** 공지 행. promoteUntil/publishedAt 은 FE 가 날짜만 잘라 표시한다. */
+    public record NoticeRow(Long id, String title, String content, boolean pinned,
+                            LocalDateTime promoteUntil, LocalDateTime publishedAt,
+                            LocalDateTime createdAt) {
+        static NoticeRow from(Notice n) {
+            return new NoticeRow(n.getId(), n.getTitle(), n.getContent(), n.isPinned(),
+                    n.getPromoteUntil(), n.getPublishedAt(), n.getCreatedAt());
+        }
+    }
+
+    /** 공지 저장 요청. published=false 는 임시저장, promoteUntil 은 배너 노출 종료일(null = 배너 없음). */
+    public record NoticeSaveRequest(String title, String content, boolean pinned,
+                                    LocalDate promoteUntil, boolean published) {}
+
     // 실행 성공/실패 이력까지 필요해지면 SchedulerAlertService 저장소 연결, 존재/스케줄 자동추적이 필요하면 ScheduledTaskHolder 도입.
     private static final List<CronJob> CRON_CATALOG = List.of(
             new CronJob("sendDailySummary", "CRON", "매일 09:00", "0 0 9 * * * (KST)", "전일 스케줄러 작업 통계 일일 요약 전송"),

--- a/src/main/java/com/toy/nar/api/mobile/notice/MobileNoticeController.java
+++ b/src/main/java/com/toy/nar/api/mobile/notice/MobileNoticeController.java
@@ -1,0 +1,47 @@
+package com.toy.nar.api.mobile.notice;
+
+import com.toy.nar.app.notice.dto.NoticeResponse;
+import com.toy.nar.app.notice.service.NoticeService;
+import com.toy.nar.domain.notice.entity.Notice;
+import org.springframework.security.core.Authentication;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 모바일 공지사항 API. 비회원도 보는 공개 API 라 인증이 없다
+ * (SecurityConfig 의 /api/** permitAll 에 포함).
+ */
+@Tag(name = "Mobile. 공지사항", description = "앱 공지 목록·캘린더 띠배너 공지 조회 (인증 불필요)")
+@RestController
+@RequestMapping("/api/notices")
+@RequiredArgsConstructor
+public class MobileNoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "공지 목록",
+            description = "발행된 공지만, 고정 공지 먼저 그 안에서 최신순. Spring Page 형식. "
+                    + "ADMIN 토큰으로 호출하면 임시저장(publishedAt null)도 포함해 내려준다 — 앱 검수용.")
+    @GetMapping
+    public Page<NoticeResponse> notices(Pageable pageable, Authentication authentication) {
+        boolean admin = authentication != null && authentication.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
+        Page<Notice> page =
+                admin ? noticeService.adminPage(pageable) : noticeService.publishedPage(pageable);
+        return page.map(NoticeResponse::from);
+    }
+
+    @Operation(summary = "띠배너 공지 목록",
+            description = "캘린더 상단 띠배너 대상 공지 (최신 발행순, 최대 5건). 앱은 닫지 않은 첫 건을 띄운다. 없으면 빈 배열.")
+    @GetMapping("/promoted")
+    public List<NoticeResponse> promoted() {
+        return noticeService.promoted().stream().map(NoticeResponse::from).toList();
+    }
+}

--- a/src/main/java/com/toy/nar/app/notice/dto/NoticeResponse.java
+++ b/src/main/java/com/toy/nar/app/notice/dto/NoticeResponse.java
@@ -1,0 +1,22 @@
+package com.toy.nar.app.notice.dto;
+
+import com.toy.nar.domain.notice.entity.Notice;
+import java.time.LocalDateTime;
+
+/** 앱 공지 응답. 작성자는 앱이 "관리자" 고정으로 표기하므로 내려주지 않는다. */
+public record NoticeResponse(
+        Long id,
+        String title,
+        String content,
+        boolean pinned,
+        LocalDateTime publishedAt
+) {
+    public static NoticeResponse from(Notice notice) {
+        return new NoticeResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.isPinned(),
+                notice.getPublishedAt());
+    }
+}

--- a/src/main/java/com/toy/nar/app/notice/service/NoticeImageStorageService.java
+++ b/src/main/java/com/toy/nar/app/notice/service/NoticeImageStorageService.java
@@ -1,0 +1,97 @@
+package com.toy.nar.app.notice.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.toy.nar.app.auth.profile.CloudinarySignatureService;
+import com.toy.nar.config.CloudinaryProperties;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * 공지 본문 이미지 저장 — Cloudinary 서버사이드 업로드.
+ * 백오피스 에디터가 파일을 올리면 서버가 서명해 Cloudinary 로 넘기고 CDN URL 을 돌려준다.
+ * 본문 마크다운에는 이 URL 문자열만 박히므로 서버에 상태가 남지 않는다 (볼륨 마운트 불필요).
+ *
+ * 전송량 절약을 위해 URL 에 f_auto,q_auto,w_750 변환을 끼워 반환한다 —
+ * 원본은 Cloudinary 에 그대로 있고 앱은 최적화본을 받는다.
+ */
+@Service
+@RequiredArgsConstructor
+public class NoticeImageStorageService {
+
+    private static final long MAX_BYTES = 5 * 1024 * 1024;
+    private static final Set<String> ALLOWED_TYPES =
+            Set.of("image/png", "image/jpeg", "image/webp", "image/gif");
+    /** 폰 화면(시안 375, @3x=1125)에 충분한 폭 + 포맷/품질 자동. */
+    private static final String DELIVERY_TRANSFORM = "f_auto,q_auto,w_750,c_limit";
+
+    private final CloudinaryProperties properties;
+    private final CloudinarySignatureService signatureService;
+    private final WebClient webClient;
+
+    public String upload(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 비어 있습니다.");
+        }
+        if (file.getSize() > MAX_BYTES) {
+            throw new IllegalArgumentException("이미지는 5MB 이하만 업로드할 수 있습니다.");
+        }
+        if (!ALLOWED_TYPES.contains(file.getContentType())) {
+            throw new IllegalArgumentException("지원하지 않는 이미지 형식입니다. (png/jpg/webp/gif)");
+        }
+
+        String publicId = "notices/" + UUID.randomUUID();
+        long timestamp = Instant.now().getEpochSecond();
+        String signature = signatureService.sign(Map.of(
+                "public_id", publicId,
+                "timestamp", String.valueOf(timestamp)));
+
+        MultipartBodyBuilder body = new MultipartBodyBuilder();
+        body.part("file", toResource(file));
+        body.part("public_id", publicId);
+        body.part("timestamp", String.valueOf(timestamp));
+        body.part("api_key", properties.getApiKey());
+        body.part("signature", signature);
+
+        JsonNode response = webClient.post()
+                .uri("https://api.cloudinary.com/v1_1/" + properties.getCloudName() + "/image/upload")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(body.build()))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+        if (response == null || response.path("secure_url").isMissingNode()) {
+            throw new IllegalStateException("이미지 업로드에 실패했습니다.");
+        }
+        return withDeliveryTransform(response.path("secure_url").asText());
+    }
+
+    private static ByteArrayResource toResource(MultipartFile file) {
+        try {
+            byte[] bytes = file.getBytes();
+            String name = file.getOriginalFilename();
+            return new ByteArrayResource(bytes) {
+                @Override
+                public String getFilename() {
+                    return name == null || name.isBlank() ? "image" : name;
+                }
+            };
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("업로드 파일을 읽지 못했습니다.", e);
+        }
+    }
+
+    /** https://res.cloudinary.com/{cloud}/image/upload/... → /upload/{transform}/... */
+    private static String withDeliveryTransform(String secureUrl) {
+        return secureUrl.replaceFirst("/image/upload/", "/image/upload/" + DELIVERY_TRANSFORM + "/");
+    }
+}

--- a/src/main/java/com/toy/nar/app/notice/service/NoticeService.java
+++ b/src/main/java/com/toy/nar/app/notice/service/NoticeService.java
@@ -1,0 +1,85 @@
+package com.toy.nar.app.notice.service;
+
+import com.toy.nar.common.error.ErrorCode;
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.domain.notice.entity.Notice;
+import com.toy.nar.domain.notice.repository.NoticeRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 공지사항 조회(앱)·관리(백오피스) 로직.
+ *
+ * 배너 종료일은 백오피스에서 날짜(yyyy-MM-dd)로 받고 그날 자정 직전까지 노출한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    /** 앱 공지 목록 — 발행분만, 고정 먼저. */
+    @Transactional(readOnly = true)
+    public Page<Notice> publishedPage(Pageable pageable) {
+        return noticeRepository.findByPublishedAtIsNotNullOrderByPinnedDescPublishedAtDesc(pageable);
+    }
+
+    /** 앱 캘린더 띠배너 공지 목록 (최신 발행순, 최대 5건). 앱이 안 닫은 첫 건을 띄운다. */
+    @Transactional(readOnly = true)
+    public List<Notice> promoted() {
+        return noticeRepository
+                .findByPublishedAtIsNotNullAndPromoteUntilAfterOrderByPublishedAtDesc(
+                        LocalDateTime.now(), PageRequest.of(0, 5));
+    }
+
+    /** 백오피스 목록 — 임시저장 포함, 고정 먼저. */
+    @Transactional(readOnly = true)
+    public Page<Notice> adminPage(Pageable pageable) {
+        return noticeRepository.findAllByOrderByPinnedDescCreatedAtDesc(pageable);
+    }
+
+    /** 백오피스 단건 조회 (수정 화면). */
+    @Transactional(readOnly = true)
+    public Notice findById(Long id) {
+        return noticeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTICE_NOT_FOUND));
+    }
+
+    @Transactional
+    public Notice create(String title, String content, boolean pinned,
+                         LocalDate promoteUntil, boolean published) {
+        Notice notice = new Notice(title, content, pinned, toEndOfDay(promoteUntil));
+        notice.changePublished(published);
+        return noticeRepository.save(notice);
+    }
+
+    @Transactional
+    public Notice update(Long id, String title, String content, boolean pinned,
+                         LocalDate promoteUntil, boolean published) {
+        Notice notice = noticeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTICE_NOT_FOUND));
+        notice.update(title, content, pinned, toEndOfDay(promoteUntil));
+        notice.changePublished(published);
+        return notice;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!noticeRepository.existsById(id)) {
+            throw new CustomException(ErrorCode.NOTICE_NOT_FOUND);
+        }
+        noticeRepository.deleteById(id);
+    }
+
+    /** 배너 종료 '일' → 그날 23:59:59 까지 노출. 백오피스가 날짜만 보낸다. */
+    private static LocalDateTime toEndOfDay(LocalDate date) {
+        return date == null ? null : date.atTime(23, 59, 59);
+    }
+}

--- a/src/main/java/com/toy/nar/common/error/ErrorCode.java
+++ b/src/main/java/com/toy/nar/common/error/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 	/* 404 NOT_FOUND : 리소스를 찾을 수 없음 */
 	COMBINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 조건의 조합 데이터를 찾을 수 없습니다."),
 	DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다."),
+	NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
 
 	/* 500 INTERNAL_SERVER_ERROR : 서버 내부 오류 */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/toy/nar/domain/notice/entity/Notice.java
+++ b/src/main/java/com/toy/nar/domain/notice/entity/Notice.java
@@ -1,0 +1,97 @@
+package com.toy.nar.domain.notice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공지사항. 백오피스에서 관리자 1인이 작성하고 앱에는 항상 "관리자" 명의로 노출한다.
+ * 카테고리 컬럼 없음 — 구분이 필요한 공지는 제목 말머리([업데이트] 등)로 표현한다.
+ *
+ * <ul>
+ *   <li>{@code publishedAt} null = 임시저장. 앱 목록·배너에 나가지 않는다.</li>
+ *   <li>{@code promoteUntil} = 앱 캘린더 상단 띠배너 노출 종료 시각. null 이면 배너 미노출.</li>
+ *   <li>본문은 마크다운({@code #}, {@code ##}, {@code -}, 이미지) — 앱 렌더러와 계약.</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "notice")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "MEDIUMTEXT")
+    private String content;
+
+    @Column(name = "pinned", nullable = false)
+    private boolean pinned;
+
+    @Column(name = "promote_until")
+    private LocalDateTime promoteUntil;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public Notice(String title, String content, boolean pinned, LocalDateTime promoteUntil) {
+        this.title = Objects.requireNonNull(title);
+        this.content = Objects.requireNonNull(content);
+        this.pinned = pinned;
+        this.promoteUntil = promoteUntil;
+    }
+
+    /** 백오피스 저장 — 제목·본문·고정·배너 종료일을 한 번에 갱신한다. */
+    public void update(String title, String content, boolean pinned, LocalDateTime promoteUntil) {
+        this.title = Objects.requireNonNull(title);
+        this.content = Objects.requireNonNull(content);
+        this.pinned = pinned;
+        this.promoteUntil = promoteUntil;
+    }
+
+    /**
+     * 발행 상태 변경. 발행 시각은 최초 발행 때 한 번만 찍고 이후 재발행에도 유지한다
+     * (앱 목록 정렬·"NEW" 판단 기준이 흔들리지 않도록).
+     */
+    public void changePublished(boolean published) {
+        if (published) {
+            if (publishedAt == null) {
+                publishedAt = LocalDateTime.now();
+            }
+        } else {
+            publishedAt = null;
+        }
+    }
+
+    @PrePersist
+    void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/toy/nar/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/toy/nar/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,21 @@
+package com.toy.nar.domain.notice.repository;
+
+import com.toy.nar.domain.notice.entity.Notice;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    /** 앱 공지 목록 — 발행분만, 고정 공지 먼저 그 안에서 최신 발행순. */
+    Page<Notice> findByPublishedAtIsNotNullOrderByPinnedDescPublishedAtDesc(Pageable pageable);
+
+    /** 앱 캘린더 띠배너용 — 발행됐고 배너 기간이 남은 것들, 최신 발행순. */
+    List<Notice> findByPublishedAtIsNotNullAndPromoteUntilAfterOrderByPublishedAtDesc(
+            LocalDateTime now, Pageable pageable);
+
+    /** 백오피스 목록 — 임시저장 포함 전체, 고정 먼저 그 안에서 등록 최신순. */
+    Page<Notice> findAllByOrderByPinnedDescCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
 
+  # 공지 이미지 업로드(백오피스). 기본 1MB 면 서비스 검증(5MB) 전에 스프링이 먼저 막는다.
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 10MB
+
   # docker stop 의 35초보다 짧게 잡아, 강제 SIGKILL 전에 정상 종료가 끝나도록 한다.
   lifecycle:
     timeout-per-shutdown-phase: 30s

--- a/src/main/resources/db/migration/V59__Create_notice.sql
+++ b/src/main/resources/db/migration/V59__Create_notice.sql
@@ -1,0 +1,12 @@
+-- 공지사항: 백오피스에서 작성하고 앱(마이페이지 목록·캘린더 상단 띠배너)에 노출한다.
+-- published_at NULL = 임시저장(앱 미노출), promote_until = 띠배너 노출 종료 시각(NULL = 배너 미노출).
+CREATE TABLE IF NOT EXISTS notice (
+    id            BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    title         VARCHAR(200) NOT NULL,
+    content       MEDIUMTEXT   NOT NULL,
+    pinned        BOOLEAN      NOT NULL DEFAULT FALSE,
+    promote_until DATETIME     NULL,
+    published_at  DATETIME     NULL,
+    created_at    DATETIME     NOT NULL,
+    updated_at    DATETIME     NOT NULL
+);

--- a/src/test/java/com/toy/nar/app/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/toy/nar/app/notice/service/NoticeServiceTest.java
@@ -1,0 +1,81 @@
+package com.toy.nar.app.notice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.toy.nar.common.error.exception.CustomException;
+import com.toy.nar.domain.notice.entity.Notice;
+import com.toy.nar.domain.notice.repository.NoticeRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Test
+    @DisplayName("발행 생성: publishedAt 이 찍히고 배너 종료일은 그날 23:59:59")
+    void createPublished() {
+        when(noticeRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Notice notice = noticeService.create(
+                "[업데이트] 안내", "본문", true, LocalDate.of(2026, 8, 4), true);
+
+        assertThat(notice.getPublishedAt()).isNotNull();
+        assertThat(notice.getPromoteUntil())
+                .isEqualTo(LocalDateTime.of(2026, 8, 4, 23, 59, 59));
+        assertThat(notice.isPinned()).isTrue();
+    }
+
+    @Test
+    @DisplayName("임시저장 생성: publishedAt null")
+    void createDraft() {
+        when(noticeRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Notice notice = noticeService.create("초안", "본문", false, null, false);
+
+        assertThat(notice.getPublishedAt()).isNull();
+        assertThat(notice.getPromoteUntil()).isNull();
+    }
+
+    @Test
+    @DisplayName("재발행해도 최초 발행 시각 유지, 임시저장으로 내리면 null")
+    void publishTransitions() {
+        Notice notice = new Notice("제목", "본문", false, null);
+        notice.changePublished(true);
+        LocalDateTime firstPublishedAt = notice.getPublishedAt();
+        when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+
+        noticeService.update(1L, "제목", "본문", false, null, true);
+        assertThat(notice.getPublishedAt()).isEqualTo(firstPublishedAt);
+
+        noticeService.update(1L, "제목", "본문", false, null, false);
+        assertThat(notice.getPublishedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("없는 공지 수정/삭제는 NOTICE_NOT_FOUND")
+    void notFound() {
+        when(noticeRepository.findById(99L)).thenReturn(Optional.empty());
+        when(noticeRepository.existsById(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> noticeService.update(99L, "t", "c", false, null, true))
+                .isInstanceOf(CustomException.class);
+        assertThatThrownBy(() -> noticeService.delete(99L))
+                .isInstanceOf(CustomException.class);
+    }
+}


### PR DESCRIPTION
## 개요
공지사항 기능 백엔드. 백오피스에서 관리자가 작성·발행하고 앱(마이페이지 목록·캘린더 띠배너)에서 조회한다.

## 스키마 (V59)
`notice`: id, title, content(마크다운 MEDIUMTEXT), pinned, promote_until(배너 종료 시각, null=배너 없음), published_at(null=임시저장), created_at, updated_at
- 카테고리 컬럼 없음 — 말머리를 제목에 직접(`[업데이트]` 등)
- 작성자 컬럼 없음 — 앱에 항상 "관리자"로 노출
- **주의**: V57(feat/best-of-last-set)·V58(로컬 이력 존재)이 선점돼 있어 V59 사용. 머지 순서에 따라 번호 조정 필요할 수 있음

## API
| 엔드포인트 | 설명 |
|---|---|
| `GET /api/notices?page&size` | 공개. 발행분만, 고정 우선 최신순. **ADMIN 토큰이면 임시저장 포함** (앱 검수용) |
| `GET /api/notices/promoted` | 공개. 활성 배너(발행 + 기간 내) 최신순 최대 5건 |
| `GET/POST/PUT/DELETE /api/admin/notices[/{id}]` | ROLE_ADMIN. 임시저장 포함, `published` 플래그로 발행/임시저장 |
| `POST /api/admin/notices/images` | 본문 이미지 → **Cloudinary 서버사이드 업로드** → `{url}` |

## 이미지 저장
- 기존 `CloudinarySignatureService`·`CLOUDINARY_*` 자격증명 재사용 — 신규 시크릿·인프라 없음, 볼륨 마운트 불필요
- 반환 URL에 `f_auto,q_auto,w_750,c_limit` 변환 삽입 — 원본 보존, 앱엔 최적화본 전송
- 검증: 5MB, Content-Type 화이트리스트(png/jpg/webp/gif)
- `NoticeImageProperties/ResourceConfig`는 feat/player-image-upload의 동일 역할 클래스와 머지 시 통합 필요 (양쪽 주석 표기)

## 발행 규칙
- 발행 시각은 최초 발행 때 한 번만 기록 — 재발행에도 유지 (앱 정렬 기준 안정)
- 임시저장 전환 시 published_at null → 앱 미노출

## 테스트
- NoticeServiceTest 4건 (발행/임시저장/재발행 시각 유지/404)
- 로컬 dev에서 백오피스·앱 E2E 확인 (작성→발행→앱 노출, 이미지 업로드→Cloudinary URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)