### PR TITLE
fix: 종료 경기 리뷰 상세 10초 지연 수정 — 메타데이터 완비 시 외부 스케줄 크롤 스킵

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LiveStateQueryService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LiveStateQueryService.java
@@ -94,6 +94,11 @@ public class LiveStateQueryService {
 	}
 
 	private LiveGameState enrichMetadata(LiveGameState state) {
+		// 메타데이터가 이미 완비면 resolve 생략. league_match_game에 매핑 없는 게임은
+		// resolve가 라이브 리그 전체 스케줄 API 순회(수 초)로 빠지는데, 채울 것도 없이 낭비다.
+		if (hasCompleteMetadata(state)) {
+			return state;
+		}
 		ActiveLiveGame metadata = liveGameMetadataService.enrich(new ActiveLiveGame(
 				state.gameId(),
 				state.matchId(),
@@ -112,6 +117,17 @@ public class LiveStateQueryService {
 				state.frameTimestampUtc(),
 				state.participants(),
 				state.objectTimeline());
+	}
+
+	private boolean hasCompleteMetadata(LiveGameState state) {
+		return !isBlank(state.matchId())
+				&& !isBlank(state.leagueName())
+				&& !isBlank(state.blueTeamName())
+				&& !isBlank(state.redTeamName());
+	}
+
+	private boolean isBlank(String value) {
+		return value == null || value.isBlank();
 	}
 
 	private LiveObjectEventResponse toObjectEventResponse(LiveGameObjectEvent event) {

--- a/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingService.java
@@ -3,8 +3,12 @@ package com.toy.nar.app.mobile.rating;
 import com.toy.nar.app.lolesports.live.LiveStateQueryService;
 import com.toy.nar.app.lolesports.live.dto.LiveGameState;
 import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchGame;
 import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.schedule.MobileScheduleService;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingDetailResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingListResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingRequest;
@@ -50,6 +54,8 @@ public class MobileLivePlayerRatingService {
 	private final MemberRepository memberRepository;
 	private final PlayerRepository playerRepository;
 	private final LeagueMatchGameRepository leagueMatchGameRepository;
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final MobileScheduleService mobileScheduleService;
 
 	public LivePlayerRatingListResponse getRatings(String gameId, String teamSide, Long memberId) {
 		LiveGameState state = requireState(gameId);
@@ -193,10 +199,17 @@ public class MobileLivePlayerRatingService {
 				? Map.of()
 				: leagueMatchGameRepository.findAllWithMatchByGameIdIn(gameIds).stream()
 						.collect(Collectors.toMap(LeagueMatchGame::getGameId, Function.identity(), (left, right) -> left));
+		// league_match_game 동기화 구멍(마지막 세트 누락 등)이 있어도 경기상세와 동일하게 보이도록,
+		// 미매핑 게임은 경기상세 세트 목록 로직(라이브 스냅샷 보강 포함)으로 matchInfo를 만든다.
+		Map<String, MyRatingListResponse.MatchInfo> fallbackMatchInfoByGameId =
+				buildFallbackMatchInfo(ratings.getContent(), matchGamesByGameId.keySet());
 
 		return new MyRatingListResponse(
 				ratings.getContent().stream()
-						.map(rating -> toMyRatingItem(rating, matchGamesByGameId.get(rating.getLiveGameId())))
+						.map(rating -> toMyRatingItem(
+								rating,
+								matchGamesByGameId.get(rating.getLiveGameId()),
+								fallbackMatchInfoByGameId.get(rating.getLiveGameId())))
 						.toList(),
 				ratings.getNumber(),
 				ratings.getSize(),
@@ -338,7 +351,10 @@ public class MobileLivePlayerRatingService {
 		return sum / count;
 	}
 
-	private MyRatingListResponse.MyRatingItem toMyRatingItem(LivePlayerRating rating, LeagueMatchGame matchGame) {
+	private MyRatingListResponse.MyRatingItem toMyRatingItem(
+			LivePlayerRating rating,
+			LeagueMatchGame matchGame,
+			MyRatingListResponse.MatchInfo fallbackMatchInfo) {
 		Player player = rating.getPlayer();
 		Member member = rating.getMember();
 		Team favoriteTeam = member != null ? member.getFavoriteTeam() : null;
@@ -358,21 +374,59 @@ public class MobileLivePlayerRatingService {
 				rating.getUpdatedAt(),
 				member != null ? member.getProfileImageUrl() : null,
 				favoriteTeam != null ? favoriteTeam.getImageUrl() : null,
-				toMatchInfo(matchGame));
+				matchGame != null ? toMatchInfo(matchGame) : fallbackMatchInfo);
 	}
 
 	private MyRatingListResponse.MatchInfo toMatchInfo(LeagueMatchGame matchGame) {
-		if (matchGame == null) {
-			return null;
-		}
+		return toMatchInfo(matchGame.getLeagueMatch(), matchGame.getGameOrder());
+	}
+
+	private MyRatingListResponse.MatchInfo toMatchInfo(LeagueMatch match, Integer gameOrder) {
 		return new MyRatingListResponse.MatchInfo(
-				matchGame.getLeagueMatch().getId(),
-				matchGame.getGameOrder(),
-				matchGame.getLeagueMatch().getLeagueName(),
-				matchGame.getLeagueMatch().getMatchTitle(),
-				matchGame.getLeagueMatch().getBlueTeamCode(),
-				matchGame.getLeagueMatch().getRedTeamCode(),
-				toKst(matchGame.getLeagueMatch().getMatchDate()));
+				match.getId(),
+				gameOrder,
+				match.getLeagueName(),
+				match.getMatchTitle(),
+				match.getBlueTeamCode(),
+				match.getRedTeamCode(),
+				toKst(match.getMatchDate()));
+	}
+
+	/**
+	 * 매핑 테이블에 없는 게임의 matchInfo 폴백. 리뷰 행이 이미 matchId를 알고 있으므로
+	 * 매치는 직접 조회하고, 세트 번호는 경기상세 세트 목록(getMatchGames)에서 찾는다 —
+	 * 화면 간 세트 번호가 항상 일치한다.
+	 */
+	private Map<String, MyRatingListResponse.MatchInfo> buildFallbackMatchInfo(
+			List<LivePlayerRating> ratings,
+			Set<String> mappedGameIds) {
+		Map<String, List<String>> gameIdsByMatchId = ratings.stream()
+				.filter(rating -> !mappedGameIds.contains(rating.getLiveGameId()))
+				.filter(rating -> rating.getMatchId() != null && !rating.getMatchId().isBlank())
+				.collect(Collectors.groupingBy(LivePlayerRating::getMatchId,
+						Collectors.mapping(LivePlayerRating::getLiveGameId,
+								Collectors.collectingAndThen(Collectors.toSet(), List::copyOf))));
+		if (gameIdsByMatchId.isEmpty()) {
+			return Map.of();
+		}
+		Map<String, MyRatingListResponse.MatchInfo> result = new HashMap<>();
+		for (Map.Entry<String, List<String>> entry : gameIdsByMatchId.entrySet()) {
+			Optional<LeagueMatch> match = leagueMatchRepository.findById(entry.getKey());
+			if (match.isEmpty()) {
+				continue;
+			}
+			Map<String, Integer> orderByGameId = mobileScheduleService.getMatchGames(entry.getKey())
+					.games().stream()
+					.filter(game -> game.gameOrder() != null)
+					.collect(Collectors.toMap(
+							MobileScheduleListResponse.MobileGameSummary::gameId,
+							MobileScheduleListResponse.MobileGameSummary::gameOrder,
+							(left, right) -> left));
+			for (String gameId : entry.getValue()) {
+				result.put(gameId, toMatchInfo(match.get(), orderByGameId.get(gameId)));
+			}
+		}
+		return result;
 	}
 
 	private LocalDateTime toKst(LocalDateTime utcDateTime) {

--- a/src/main/java/com/toy/nar/app/mobile/rating/dto/MyRatingListResponse.java
+++ b/src/main/java/com/toy/nar/app/mobile/rating/dto/MyRatingListResponse.java
@@ -38,7 +38,7 @@ public record MyRatingListResponse(
 
 	public record MatchInfo(
 			String matchId,
-			@Schema(description = "세트 순서(1부터 시작)", example = "2")
+			@Schema(description = "세트 순서(1부터 시작). 세트를 특정할 수 없으면 null", example = "2", nullable = true)
 			Integer gameOrder,
 			String leagueName,
 			String matchTitle,

--- a/src/test/java/com/toy/nar/app/lolesports/live/LiveStateQueryServiceTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LiveStateQueryServiceTest.java
@@ -110,4 +110,52 @@ class LiveStateQueryServiceTest {
 		assertThat(result.redTeamName()).isEqualTo("HLE");
 		assertThat(result.frameTimestampUtc()).isEqualTo(frameTimestampUtc);
 	}
+
+	@Test
+	void skipsMetadataResolveWhenSnapshotMetadataIsComplete() {
+		LocalDateTime frameTimestampUtc = LocalDateTime.of(2026, 5, 17, 8, 18, 9);
+		LiveGameMinuteSnapshot snapshot = new LiveGameMinuteSnapshot(
+				"game-1",
+				frameTimestampUtc.withSecond(0));
+		snapshot.updateSnapshot("match-1", "LCK", "KT", "HLE", frameTimestampUtc);
+		when(snapshotRepository.findTopByGameIdOrderByMinuteBucketUtcDesc("game-1"))
+				.thenReturn(Optional.of(snapshot));
+		when(participantSnapshotRepository.findBySnapshot_IdOrderByParticipantIdAsc(null)).thenReturn(List.of());
+		when(objectEventRepository
+				.findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+						"game-1",
+						frameTimestampUtc))
+				.thenReturn(List.of());
+
+		LiveGameState result = service.getLatestState("game-1").orElseThrow();
+
+		assertThat(result.matchId()).isEqualTo("match-1");
+		verify(liveGameMetadataService, never()).enrich(any(ActiveLiveGame.class));
+	}
+
+	@Test
+	void resolvesMetadataWhenSnapshotMetadataIsIncomplete() {
+		LocalDateTime frameTimestampUtc = LocalDateTime.of(2026, 5, 17, 8, 18, 9);
+		LiveGameMinuteSnapshot snapshot = new LiveGameMinuteSnapshot(
+				"game-1",
+				frameTimestampUtc.withSecond(0));
+		snapshot.updateSnapshot(null, "LCK", "KT", "HLE", frameTimestampUtc);
+		when(snapshotRepository.findTopByGameIdOrderByMinuteBucketUtcDesc("game-1"))
+				.thenReturn(Optional.of(snapshot));
+		when(participantSnapshotRepository.findBySnapshot_IdOrderByParticipantIdAsc(null)).thenReturn(List.of());
+		when(liveGameMetadataService.enrich(any(ActiveLiveGame.class)))
+				.thenAnswer(invocation -> ((ActiveLiveGame) invocation.getArgument(0))
+						.mergeMissingMetadata(new ActiveLiveGame(
+								"game-1", "match-1", "LCK", "KT", "HLE", null, 0)));
+		when(objectEventRepository
+				.findByGameIdAndSourceFrameTimestampUtcLessThanEqualOrderBySourceFrameTimestampUtcAscIdAsc(
+						"game-1",
+						frameTimestampUtc))
+				.thenReturn(List.of());
+
+		LiveGameState result = service.getLatestState("game-1").orElseThrow();
+
+		assertThat(result.matchId()).isEqualTo("match-1");
+		verify(liveGameMetadataService).enrich(any(ActiveLiveGame.class));
+	}
 }

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -299,6 +299,38 @@ class MobileLivePlayerRatingServiceTest {
 		});
 	}
 
+	@Test
+	void getMyRatingsFallbackKeepsMatchInfoEvenWhenSetNumberUnknown() {
+		Member member = member(7L, "용맹한바론");
+		LivePlayerRating myRating = rating(member, 4, null);
+		LeagueMatch match = LeagueMatch.builder()
+				.id("match-1")
+				.leagueName("LCK")
+				.matchTitle("GEN vs T1")
+				.matchDate(LocalDateTime.of(2026, 7, 31, 10, 0))
+				.state("completed")
+				.blueTeamCode("GEN")
+				.redTeamCode("T1")
+				.build();
+		when(ratingRepository.findByMember_IdOrderByCreatedAtDesc(7L, PageRequest.of(0, 20)))
+				.thenReturn(new PageImpl<>(List.of(myRating), PageRequest.of(0, 20), 1));
+		when(leagueMatchGameRepository.findAllWithMatchByGameIdIn(java.util.Set.of("game-1")))
+				.thenReturn(List.of());
+		when(leagueMatchRepository.findById("match-1")).thenReturn(Optional.of(match));
+		// 세트 목록에도 이 게임이 없으면(스냅샷 미수집 등) 세트 번호만 null, 매치 정보는 유지
+		when(mobileScheduleService.getMatchGames("match-1")).thenReturn(new MobileMatchGamesResponse(
+				"match-1",
+				List.of(new MobileScheduleListResponse.MobileGameSummary(1, "game-0", null, "ENDED", null, "GEN"))));
+
+		var response = service.getMyRatings(7L, 0, 20);
+
+		assertThat(response.ratings()).singleElement().satisfies(item -> {
+			assertThat(item.match()).isNotNull();
+			assertThat(item.match().matchTitle()).isEqualTo("GEN vs T1");
+			assertThat(item.match().gameOrder()).isNull();
+		});
+	}
+
 	private Member member(Long id, String nickname) {
 		Member member = Member.builder().name(nickname).tag("0000").email("test@example.com").build();
 		ReflectionTestUtils.setField(member, "id", id);

--- a/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/rating/MobileLivePlayerRatingServiceTest.java
@@ -6,6 +6,10 @@ import com.toy.nar.app.lolesports.live.dto.LiveParticipantState;
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchGame;
 import com.toy.nar.app.lolesports.repository.LeagueMatchGameRepository;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.schedule.MobileScheduleService;
+import com.toy.nar.app.mobile.schedule.dto.MobileMatchGamesResponse;
+import com.toy.nar.app.mobile.schedule.dto.MobileScheduleListResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingListResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingDetailResponse;
 import com.toy.nar.app.mobile.rating.dto.LivePlayerRatingRequest;
@@ -44,6 +48,8 @@ class MobileLivePlayerRatingServiceTest {
 	private MemberRepository memberRepository;
 	private PlayerRepository playerRepository;
 	private LeagueMatchGameRepository leagueMatchGameRepository;
+	private LeagueMatchRepository leagueMatchRepository;
+	private MobileScheduleService mobileScheduleService;
 	private MobileLivePlayerRatingService service;
 
 	@BeforeEach
@@ -53,12 +59,16 @@ class MobileLivePlayerRatingServiceTest {
 		memberRepository = mock(MemberRepository.class);
 		playerRepository = mock(PlayerRepository.class);
 		leagueMatchGameRepository = mock(LeagueMatchGameRepository.class);
+		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		mobileScheduleService = mock(MobileScheduleService.class);
 		service = new MobileLivePlayerRatingService(
 				liveStateQueryService,
 				ratingRepository,
 				memberRepository,
 				playerRepository,
-				leagueMatchGameRepository);
+				leagueMatchGameRepository,
+				leagueMatchRepository,
+				mobileScheduleService);
 	}
 
 	@Test
@@ -243,11 +253,50 @@ class MobileLivePlayerRatingServiceTest {
 				.thenReturn(new PageImpl<>(List.of(myRating), PageRequest.of(0, 20), 1));
 		when(leagueMatchGameRepository.findAllWithMatchByGameIdIn(java.util.Set.of("game-1")))
 				.thenReturn(List.of());
+		when(leagueMatchRepository.findById("match-1")).thenReturn(Optional.empty());
 
 		var response = service.getMyRatings(7L, 0, 20);
 
 		assertThat(response.ratings()).singleElement()
 				.satisfies(item -> assertThat(item.match()).isNull());
+	}
+
+	@Test
+	void getMyRatingsFallsBackToMatchGamesWhenMappingMissing() {
+		Member member = member(7L, "용맹한바론");
+		LivePlayerRating myRating = rating(member, 4, "2세트 리뷰");
+		LeagueMatch match = LeagueMatch.builder()
+				.id("match-1")
+				.leagueName("LCK")
+				.matchTitle("GEN vs T1")
+				.matchDate(LocalDateTime.of(2026, 7, 31, 10, 0))
+				.state("completed")
+				.blueTeamCode("GEN")
+				.redTeamCode("T1")
+				.build();
+		when(ratingRepository.findByMember_IdOrderByCreatedAtDesc(7L, PageRequest.of(0, 20)))
+				.thenReturn(new PageImpl<>(List.of(myRating), PageRequest.of(0, 20), 1));
+		// 매핑 테이블에는 이 게임이 없다 (동기화 구멍)
+		when(leagueMatchGameRepository.findAllWithMatchByGameIdIn(java.util.Set.of("game-1")))
+				.thenReturn(List.of());
+		when(leagueMatchRepository.findById("match-1")).thenReturn(Optional.of(match));
+		// 경기상세 세트 목록은 스냅샷 보강으로 이 게임을 2세트로 알고 있다
+		when(mobileScheduleService.getMatchGames("match-1")).thenReturn(new MobileMatchGamesResponse(
+				"match-1",
+				List.of(
+						new MobileScheduleListResponse.MobileGameSummary(1, "game-0", null, "ENDED", null, "GEN"),
+						new MobileScheduleListResponse.MobileGameSummary(2, "game-1", null, "ENDED", null, "T1"))));
+
+		var response = service.getMyRatings(7L, 0, 20);
+
+		assertThat(response.ratings()).singleElement().satisfies(item -> {
+			assertThat(item.match()).isNotNull();
+			assertThat(item.match().matchId()).isEqualTo("match-1");
+			assertThat(item.match().gameOrder()).isEqualTo(2);
+			assertThat(item.match().leagueName()).isEqualTo("LCK");
+			assertThat(item.match().matchTitle()).isEqualTo("GEN vs T1");
+			assertThat(item.match().matchDate()).isEqualTo(LocalDateTime.of(2026, 7, 31, 19, 0));
+		});
 	}
 
 	private Member member(Long id, String nickname) {


### PR DESCRIPTION
## 문제

마이페이지 **내 리뷰 > 리뷰보기**(선수 평점 상세, `GET /api/mobile/live/games/{gameId}/participants/{pid}/ratings`)가 특정 게임에서 **10.7초** 걸림 (프로드 실측). 같은 게임들은 마이페이지 목록에서 matchInfo(리그명·경기 제목)도 null.

## 원인

공통 뿌리: `league_match_game` 동기화 구멍. 게임 ID 동기화가 dirty 사이클에 1회성으로 돌아 마지막 세트가 자주 누락됨 (2026-07-31 완료 경기 8개 중 5개, 리뷰 달린 게임 29개 중 6개 — 전부 "그 매치의 마지막 세트" 패턴).

**증상 1 — 10초 지연**: `LiveStateQueryService.enrichMetadata`가 스냅샷에 matchId·리그·팀명이 전부 있어도 무조건 `resolve()` 호출 → 매핑 미스 → `loadFromSchedule` 폴백이 live 켜진 **11개 리그 전체**를 LoL Esports API로 순회(리그별 스케줄 + 매치별 상세) → 10초. 캐시 TTL 60초라 사실상 매번 cold.

**증상 2 — matchInfo null**: 경기상세 세트 목록은 라이브 스냅샷 보강 폴백이 있어 구멍을 스스로 메우는데, 마이페이지 내 리뷰는 매핑 테이블만 직조회.

## 수정

1. **10초 지연**: 메타데이터(matchId·리그·양팀명) 완비 시 resolve 생략. 미완비(라이브 초기 인메모리 상태 등)에는 기존 폴백 그대로.
2. **matchInfo null**: 미매핑 게임은 리뷰 행이 아는 matchId로 매치 직접 조회 + 세트 번호는 경기상세와 동일한 `getMatchGames` 결과에서 획득 — 두 화면 세트 번호 항상 일치.

## 실측 (프로드)

| 케이스 | 시간 |
|---|---|
| 미매핑 게임 상세 (수정 전, cold) | 10.68s |
| 매핑 게임 상세 (= 수정 후 예상 경로) | 0.13s |

## 테스트

- `skipsMetadataResolveWhenSnapshotMetadataIsComplete` — 완비 시 enrich 미호출
- `resolvesMetadataWhenSnapshotMetadataIsIncomplete` — matchId 결손 시 기존 폴백 동작
- `getMyRatingsFallsBackToMatchGamesWhenMappingMissing` — 미매핑 게임 matchInfo 폴백 (세트 번호 포함)
- `getMyRatingsReturnsNullMatchWhenMappingMissing` — 매치 자체가 없으면 기존대로 null
- 전체 테스트 통과

## 남은 것 (별도)

동기화 구멍 자체의 재발 방지(completed인데 게임 행 수 < 스코어 합이면 재동기화)는 이 PR 범위 밖. 두 증상 모두 폴백으로 흡수되므로 급하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)