### PR TITLE
ci: 배포 파이프라인 단축 — arm64 단일 빌드·잡 통합·Gradle 빌드 캐시

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 
-      - name: Set up QEMU  # arm64(t4g) 크로스 빌드용 에뮬레이터
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -66,17 +63,15 @@ jobs:
         with:
           context: .
           push: true
-          # amd64(t3)·arm64(t4g) 둘 다 빌드 — 인스턴스 아키텍처 무관하게 실행 + 롤백 안전.
-          platforms: linux/amd64,linux/arm64
+          # 서버는 t4g(arm64) 고정 — arm64만 빌드해 배포 시간을 줄인다.
+          # Dockerfile에 RUN이 없어(레이어 조립뿐) QEMU 에뮬레이터도 불필요.
+          # RUN 스텝을 추가하거나 amd64 인스턴스로 옮기면 QEMU/amd64를 되살릴 것.
+          platforms: linux/arm64
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/nar-gg:latest
             ${{ secrets.DOCKER_HUB_USERNAME }}/nar-gg:${{ github.sha }}
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
+      # 별도 잡으로 분리하면 러너 기동 비용(~15초)이 추가되므로 같은 잡에서 이어서 배포한다.
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v0.1.6
         env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# Gradle 빌드 캐시 — 입력이 같은 태스크의 산출물을 재사용한다.
+# CI에서는 actions/cache 로 ~/.gradle/caches 가 복원되므로 clean build 도 미변경 태스크를 건너뛴다.
+org.gradle.caching=true


### PR DESCRIPTION
## 배경

머지 → 서비스 반영 실측 ~3.5분 (#332 기준 분해):

| 구간 | 시간 |
|---|---|
| Gradle 빌드 | 48s |
| Docker 멀티아치 빌드+푸시 (+QEMU) | 35s |
| deploy 잡 러너 재기동 | ~15s |
| EC2 SSH (pull+기동+헬스체크+전환) | 77s |

## 변경

1. **arm64 단일 빌드**: 서버는 t4g(arm64) 고정인데 amd64를 병행 빌드하고 있었음. arm64만 남기고, Dockerfile에 RUN 스텝이 없어(jar 레이어 조립뿐) QEMU 에뮬레이터 스텝도 제거. RUN 추가하거나 amd64 인스턴스로 옮기면 되살리라는 주석 남김.
2. **build/deploy 잡 통합**: 별도 잡의 러너 기동 비용 제거. 같은 시크릿 스코프라 보안 변화 없음.
3. **Gradle 빌드 캐시** (`org.gradle.caching=true`): CI의 actions/cache(~/.gradle/caches)와 결합해 `clean build`도 미변경 태스크 산출물 재사용. PR CI에도 동일 적용.

기대: 머지 → 반영 3.5분 → 2.5분대. EC2 77초는 대부분 앱 기동+헬스체크(무중단 배포 본질 비용)라 이번 범위 밖.

## 검증

- YAML 파싱 확인, 로컬 `./gradlew build` 정상 (빌드 캐시 켠 상태)
- 실효과는 머지 후 첫 배포 run에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)