### PR TITLE
perf: 세트 승자 쿼리 1초 → 7ms — 내 리뷰·경기상세 지연 해소

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchGameRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchGameRepository.java
@@ -76,6 +76,9 @@ public interface LeagueMatchGameRepository extends JpaRepository<LeagueMatchGame
 	 * <p>세트 승자는 적재된 경기 기록(game_participants.is_win)에만 있다 — 업스트림
 	 * getEventDetails 의 games[].teams 는 side 만 주고 세트별 승패를 주지 않는다(실측).
 	 * 팀 식별은 lolesports 외부 팀 id 를 우선한다. 내부 팀 코드는 리그 표기와 다를 수 있다.</p>
+	 *
+	 * <p>winner 파생 테이블은 반드시 이 매치의 게임으로 한정해야 한다 — 한정이 없으면
+	 * game_participants 전체(수십만 행)를 호출마다 머티리얼라이즈해 프로드에서 쿼리당 1초가 걸렸다.</p>
 	 */
 	@Query(value = """
 			SELECT lmg.match_id AS matchId,
@@ -98,6 +101,14 @@ public interface LeagueMatchGameRepository extends JpaRepository<LeagueMatchGame
 			      ON tei.team_id = t.team_id
 			     AND tei.source = :source
 			    WHERE gp.is_win = TRUE
+			      AND gp.game_id IN (
+			          SELECT gei2.game_id
+			          FROM league_match_game lmg2
+			          JOIN game_external_identity gei2
+			            ON gei2.source = :source
+			           AND gei2.external_game_id = lmg2.game_id
+			          WHERE lmg2.match_id = :matchId
+			      )
 			) winner ON winner.game_id = gei.game_id
 			WHERE lmg.match_id = :matchId
 			ORDER BY lmg.game_order ASC

--- a/src/main/resources/db/migration/V60__Add_snapshot_match_id_index.sql
+++ b/src/main/resources/db/migration/V60__Add_snapshot_match_id_index.sql
@@ -1,0 +1,6 @@
+-- 세트 목록(getMatchGames)의 findGameIdsByMatchIdOrderByStart 가
+-- WHERE match_id ... GROUP BY game_id ... MIN(frame_timestamp_utc) 로 읽는데
+-- match_id 인덱스가 없어 매 호출 풀 인덱스 스캔(프로드 실측 150ms)이었다.
+-- 커버링 인덱스로 테이블 접근 없이 해소한다.
+ALTER TABLE live_game_minute_snapshot
+    ADD INDEX idx_live_minute_snapshot_match_game_frame (match_id, game_id, frame_timestamp_utc);


### PR DESCRIPTION
## 문제

어제 #332(내 리뷰 matchInfo 폴백) 배포 후 마이페이지 내 리뷰 페이지가 페이지당 +1~2.5초 느려짐.

## 원인 (프로드 실측)

- `findMappedGameWinnerRowsByMatchId`(#330에서 도입)의 winner 파생 테이블이 `WHERE lmg.match_id = ?` 와 무관하게 **game_participants 16.5만 행 전체에서 is_win=TRUE(~7만 행)를 호출마다 DISTINCT 머티리얼라이즈** — 쿼리 단독 **1.003초** (EXPLAIN: `Materialize rows=69472`)
- #332 폴백이 내 리뷰 목록에서 미매핑 매치마다 `getMatchGames` 호출 → 위 쿼리 × 1~2회
- 부가: 폴백이 쓰는 `findGameIdsByMatchIdOrderByStart` 도 `live_game_minute_snapshot.match_id` 인덱스 부재로 매 호출 150ms 풀 스캔

## 수정

1. winner 파생 테이블에 `gp.game_id IN (해당 매치의 내부 game_id)` 한정
2. `live_game_minute_snapshot(match_id, game_id, frame_timestamp_utc)` 커버링 인덱스 (V60)

## 검증

- 프로드 읽기 전용 실측: 쿼리 **1.003s → 0.007s** (140배)
- 승자 데이터 있는 매치 5개 + 미매핑 매치 1개에서 신·구 쿼리 결과 **전부 동일** 확인
- `./gradlew test` 전체 통과

## 영향 범위

- 경기상세 세트 목록(`GET /api/mobile/matches/{id}/games`): 1.0s → ~수십 ms
- 마이페이지 내 리뷰 목록: 폴백 비용 제거로 배포 전 수준 복구

🤖 Generated with [Claude Code](https://claude.com/claude-code)