### PR TITLE
feat: 백오피스 가입자 상세 + 목록 구독 수 집계

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -13,6 +13,7 @@ import com.toy.nar.app.riot.RiotAccountVerifyService;
 import com.toy.nar.app.riot.RiotApiException;
 import com.toy.nar.app.riot.dto.RiotAccountVerification;
 import com.toy.nar.domain.game.repository.LeagueRepository;
+import com.toy.nar.domain.member.repository.MemberDeviceRepository;
 import com.toy.nar.domain.member.repository.MemberFavoritePlayerRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.MemberTeamNotificationSubscriptionRepository;
@@ -28,6 +29,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -75,15 +77,71 @@ public class BackofficeController {
     private final LivePlayerRatingRepository livePlayerRatingRepository;
     private final LeagueMatchRepository leagueMatchRepository;
     private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
+    private final MemberDeviceRepository memberDeviceRepository;
     private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
     private final NoticeService noticeService;
     private final NoticeImageStorageService noticeImageStorageService;
 
     @GetMapping("/members")
     public Page<MemberRow> members(@RequestParam(required = false) String q, Pageable pageable) {
-        return memberRepository.searchForBackoffice(blankToNull(q), pageable)
-                .map(m -> new MemberRow(m.getId(), m.getNickname(), m.getEmail(),
-                        m.getFavoriteLeagueName(), m.getCreatedAt()));
+        return memberRepository.searchForBackoffice(blankToNull(q), sanitizeMemberSort(pageable))
+                .map(m -> new MemberRow(m.getId(), m.getName() + "#" + m.getTag(), m.getEmail(),
+                        m.getFavoriteLeagueName(), m.getCreatedAt(),
+                        m.getFavoritePlayerCount(), m.getFavoriteTeamCount()));
+    }
+
+    // 회원 목록 native 쿼리는 정렬 프로퍼티를 SELECT 별칭 그대로 ORDER BY 에 붙인다.
+    // 목록에 없는 값이 오면 Unknown column 으로 500 이 나므로 화이트리스트 밖은 버린다.
+    private static final Set<String> MEMBER_SORT_KEYS =
+            Set.of("id", "name", "email", "createdAt", "favoritePlayerCount", "favoriteTeamCount");
+
+    static Pageable sanitizeMemberSort(Pageable pageable) {
+        Sort sort = Sort.by(pageable.getSort().stream()
+                .filter(order -> MEMBER_SORT_KEYS.contains(order.getProperty()))
+                .toList());
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+    }
+
+    /**
+     * 회원 상세 — 구독(선수·팀)·작성 리뷰까지 한 번에. 목록 행 클릭으로 진입한다.
+     * 쿼리 5방(회원 + 선수구독 + 팀구독 + 리뷰 + 기기 수) + 리뷰 경기 정보 배치 조회 1방.
+     */
+    @GetMapping("/members/{id}")
+    public MemberDetail member(@PathVariable Long id) {
+        var member = memberRepository.findWithFavoriteTeamById(id)
+                .orElseThrow(() -> new NoSuchElementException("회원을 찾을 수 없습니다: " + id));
+
+        List<SubscribedPlayerRow> players = memberFavoritePlayerRepository
+                .findWithPlayerAndTeamByMember_IdOrderByCreatedAtDesc(id).stream()
+                .map(favorite -> {
+                    Player player = favorite.getPlayer();
+                    var team = player.getCurrentTeam();
+                    return new SubscribedPlayerRow(player.getId(), player.getName(), player.getImageUrl(),
+                            team != null ? team.getName() : null, player.getRole(), favorite.getCreatedAt());
+                })
+                .toList();
+
+        List<SubscribedTeamRow> teams = teamSubscriptionRepository.findByMember_IdOrderByCreatedAtDesc(id).stream()
+                .map(subscription -> {
+                    var team = subscription.getTeam();
+                    return new SubscribedTeamRow(team.getId(), team.getName(), team.getCode(),
+                            team.getImageUrl(), subscription.getCreatedAt());
+                })
+                .toList();
+
+        // ponytail: 리뷰 최근 100건 캡(현재 최다 작성자도 두 자릿수). 넘치면 별도 엔드포인트로 분리.
+        List<LivePlayerRating> ratings = livePlayerRatingRepository
+                .findByMember_IdOrderByCreatedAtDesc(id, PageRequest.of(0, 100)).getContent();
+        Map<String, LeagueMatch> matches = findMatchesOf(ratings);
+        List<RatingRow> comments = ratings.stream()
+                .map(r -> RatingRow.from(r, matches.get(r.getMatchId()), member.getNickname()))
+                .toList();
+
+        var favoriteTeam = member.getFavoriteTeam();
+        return new MemberDetail(member.getId(), member.getNickname(), member.getEmail(),
+                member.getFavoriteLeagueName(), favoriteTeam != null ? favoriteTeam.getName() : null,
+                memberDeviceRepository.countByMember_IdAndActiveTrue(id), member.getCreatedAt(),
+                players, teams, comments);
     }
 
     @GetMapping("/players")
@@ -177,12 +235,17 @@ public class BackofficeController {
         String fieldParam = blankToNull(field);
         Page<LivePlayerRating> page = livePlayerRatingRepository.searchForBackoffice(
                 blankToNull(q), fieldParam == null ? "all" : fieldParam, rating, pageable);
-        Set<String> matchIds = page.getContent().stream()
+        Map<String, LeagueMatch> matches = findMatchesOf(page.getContent());
+        return page.map(r -> RatingRow.from(r, matches.get(r.getMatchId())));
+    }
+
+    // 리뷰 목록에 붙일 경기 정보를 matchId 로 배치 조회한다(행마다 조회하면 N+1).
+    private Map<String, LeagueMatch> findMatchesOf(List<LivePlayerRating> ratings) {
+        Set<String> matchIds = ratings.stream()
                 .map(LivePlayerRating::getMatchId)
                 .collect(Collectors.toSet());
-        Map<String, LeagueMatch> matches = leagueMatchRepository.findAllById(matchIds).stream()
+        return leagueMatchRepository.findAllById(matchIds).stream()
                 .collect(Collectors.toMap(LeagueMatch::getId, m -> m));
-        return page.map(r -> RatingRow.from(r, matches.get(r.getMatchId())));
     }
 
     @DeleteMapping("/ratings/{id}")
@@ -348,8 +411,22 @@ public class BackofficeController {
                 .body(Map.of("message", "Riot API 오류로 저장하지 못했습니다. 잠시 후 다시 시도해 주세요"));
     }
 
-    public record MemberRow(Long id, String name, String email,
-                            String favoriteLeagueName, LocalDateTime createdAt) {}
+    public record MemberRow(Long id, String name, String email, String favoriteLeagueName,
+                            LocalDateTime createdAt, long favoritePlayerCount, long favoriteTeamCount) {}
+
+    /** 회원 상세. comments 는 목록(/ratings)과 같은 {@link RatingRow} 라 FE 가 표를 재사용한다. */
+    public record MemberDetail(Long id, String name, String email, String favoriteLeagueName,
+                               String favoriteTeamName, long deviceCount, LocalDateTime createdAt,
+                               List<SubscribedPlayerRow> players, List<SubscribedTeamRow> teams,
+                               List<RatingRow> comments) {}
+
+    /** id = 선수 id (FE 가 구독 탭 선수 상세로 이동한다). */
+    public record SubscribedPlayerRow(Long id, String playerName, String imageUrl, String teamName,
+                                      String role, LocalDateTime subscribedAt) {}
+
+    /** id = 팀 id (FE 가 구독 탭 팀 상세로 이동한다). */
+    public record SubscribedTeamRow(Long id, String teamName, String teamCode, String imageUrl,
+                                    LocalDateTime subscribedAt) {}
 
     // 구독 탭 — 구독 가능 선수 행(구독자 수 포함). id 필드는 FE 데이터그리드 rowKey 용.
     public record SubscribablePlayerRow(Long id, String playerName, String imageUrl, String role,
@@ -401,6 +478,11 @@ public class BackofficeController {
                             String memberNickname, Integer rating, String comment,
                             LocalDateTime createdAt) {
         static RatingRow from(LivePlayerRating r, LeagueMatch match) {
+            return from(r, match, r.getMember().getNickname());
+        }
+
+        // 회원 상세처럼 닉네임을 이미 아는 경로용 — r.getMember() 는 지연 로딩이라 건드리지 않는다.
+        static RatingRow from(LivePlayerRating r, LeagueMatch match, String memberNickname) {
             return new RatingRow(r.getId(), r.getMatchId(),
                     match != null ? match.getLeagueName() : null,
                     match != null ? match.getMatchTitle() : null,
@@ -408,7 +490,7 @@ public class BackofficeController {
                     match != null ? match.getRedTeamCode() : null,
                     match != null ? toKst(match.getMatchDate()) : null,
                     r.getPlayerName(), r.getChampionName(), r.getRole(),
-                    r.getMember().getNickname(), r.getRating(), r.getComment(),
+                    memberNickname, r.getRating(), r.getComment(),
                     r.getCreatedAt());
         }
 

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberDeviceRepository.java
@@ -18,6 +18,9 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
 
 	Optional<MemberDevice> findByIdAndMember_Id(Long id, Long memberId);
 
+	// 백오피스 회원 상세: 푸시 받을 수 있는 기기 수.
+	long countByMember_IdAndActiveTrue(Long memberId);
+
 	@EntityGraph(attributePaths = "member")
 	@Query("""
 			SELECT DISTINCT device

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberFavoritePlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberFavoritePlayerRepository.java
@@ -21,6 +21,10 @@ public interface MemberFavoritePlayerRepository extends JpaRepository<MemberFavo
 	@EntityGraph(attributePaths = "player")
 	Optional<MemberFavoritePlayer> findByMember_IdAndPlayer_Id(Long memberId, Long playerId);
 
+	// 백오피스 회원 상세: 소속팀 이름까지 한 방에(선수마다 팀 조회하면 N+1).
+	@EntityGraph(attributePaths = {"player", "player.currentTeam"})
+	List<MemberFavoritePlayer> findWithPlayerAndTeamByMember_IdOrderByCreatedAtDesc(Long memberId);
+
 	@Query("""
 			SELECT favorite.player.id
 			FROM MemberFavoritePlayer favorite

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
@@ -3,11 +3,13 @@ package com.toy.nar.domain.member.repository;
 import com.toy.nar.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -27,12 +29,59 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("delete from Member member where member.id = :memberId")
     int deleteByMemberId(@Param("memberId") Long memberId);
 
-    // 백오피스 검색: 닉네임(name)·이메일 부분일치. q 가 null 이면 전체.
-    @Query("""
-            SELECT m FROM Member m
+    // 백오피스 상세: 관심 팀 이름을 같이 쓰므로 fetch 해둔다(OSIV off).
+    @EntityGraph(attributePaths = "favoriteTeam")
+    Optional<Member> findWithFavoriteTeamById(Long id);
+
+    /**
+     * 백오피스 검색: 닉네임(name)·이메일 부분일치. q 가 null 이면 전체.
+     * 구독 수 두 개는 스칼라 서브쿼리 — 각각 (member_id, …) 유니크 인덱스 선두 컬럼을 탄다.
+     *
+     * <p>파생 테이블로 한 겹 감싸는 이유: Spring 이 정렬을 붙일 때 별칭 앞에 테이블 별칭을 박는다
+     * ({@code order by m.favoritePlayerCount}). 서브쿼리 별칭은 바깥에서 그렇게 참조할 수 없어
+     * {@code Unknown column} 500 이 났다(실측). 감싸면 전부 파생 테이블 m 의 진짜 컬럼이 된다.
+     * 정렬 프로퍼티는 그대로 SQL 로 나가므로 컨트롤러에서 화이트리스트로 거른다.
+     */
+    @Query(value = """
+            SELECT *
+            FROM (SELECT m.id AS id,
+                         m.name AS name,
+                         m.tag AS tag,
+                         m.email AS email,
+                         m.favorite_league_name AS favoriteLeagueName,
+                         m.created_at AS createdAt,
+                         (SELECT COUNT(*) FROM member_favorite_player f WHERE f.member_id = m.id) AS favoritePlayerCount,
+                         (SELECT COUNT(*) FROM member_team_notification_subscription s WHERE s.member_id = m.id) AS favoriteTeamCount
+                  FROM member m
+                  WHERE :q IS NULL
+                     OR LOWER(m.name) LIKE LOWER(CONCAT('%', :q, '%'))
+                     OR LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%'))) m
+            """,
+            countQuery = """
+            SELECT COUNT(*)
+            FROM member m
             WHERE :q IS NULL
                OR LOWER(m.name) LIKE LOWER(CONCAT('%', :q, '%'))
                OR LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%'))
-            """)
-    Page<Member> searchForBackoffice(@Param("q") String q, Pageable pageable);
+            """,
+            nativeQuery = true)
+    Page<BackofficeMemberView> searchForBackoffice(@Param("q") String q, Pageable pageable);
+
+    interface BackofficeMemberView {
+        Long getId();
+
+        String getName();
+
+        String getTag();
+
+        String getEmail();
+
+        String getFavoriteLeagueName();
+
+        LocalDateTime getCreatedAt();
+
+        long getFavoritePlayerCount();
+
+        long getFavoriteTeamCount();
+    }
 }

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberRepository.java
@@ -35,10 +35,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     /**
      * 백오피스 검색: 닉네임(name)·이메일 부분일치. q 가 null 이면 전체.
-     * 구독 수 두 개는 스칼라 서브쿼리 — 각각 (member_id, …) 유니크 인덱스 선두 컬럼을 탄다.
+     *
+     * <p>구독 수는 미리 GROUP BY 로 접은 파생 테이블을 LEFT JOIN 한다. 회원마다 도는
+     * 상관 서브쿼리로 쓰면 회원 수만큼(프로덕션 3,281명 × 2회) 인덱스 탐색이 돌아
+     * 같은 결과에 90~155ms 가 걸렸다. 집계 테이블은 커버링 인덱스 한 번 훑고 끝이라 24~31ms 다
+     * (2026-08-02 프로덕션 EXPLAIN ANALYZE 실측).
      *
      * <p>파생 테이블로 한 겹 감싸는 이유: Spring 이 정렬을 붙일 때 별칭 앞에 테이블 별칭을 박는다
-     * ({@code order by m.favoritePlayerCount}). 서브쿼리 별칭은 바깥에서 그렇게 참조할 수 없어
+     * ({@code order by m.favoritePlayerCount}). 조인/서브쿼리 별칭은 바깥에서 그렇게 참조할 수 없어
      * {@code Unknown column} 500 이 났다(실측). 감싸면 전부 파생 테이블 m 의 진짜 컬럼이 된다.
      * 정렬 프로퍼티는 그대로 SQL 로 나가므로 컨트롤러에서 화이트리스트로 거른다.
      */
@@ -50,9 +54,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                          m.email AS email,
                          m.favorite_league_name AS favoriteLeagueName,
                          m.created_at AS createdAt,
-                         (SELECT COUNT(*) FROM member_favorite_player f WHERE f.member_id = m.id) AS favoritePlayerCount,
-                         (SELECT COUNT(*) FROM member_team_notification_subscription s WHERE s.member_id = m.id) AS favoriteTeamCount
+                         COALESCE(f.c, 0) AS favoritePlayerCount,
+                         COALESCE(s.c, 0) AS favoriteTeamCount
                   FROM member m
+                  LEFT JOIN (SELECT member_id, COUNT(*) c FROM member_favorite_player GROUP BY member_id) f
+                         ON f.member_id = m.id
+                  LEFT JOIN (SELECT member_id, COUNT(*) c FROM member_team_notification_subscription GROUP BY member_id) s
+                         ON s.member_id = m.id
                   WHERE :q IS NULL
                      OR LOWER(m.name) LIKE LOWER(CONCAT('%', :q, '%'))
                      OR LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%'))) m

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberTeamNotificationSubscriptionRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberTeamNotificationSubscriptionRepository.java
@@ -18,6 +18,10 @@ public interface MemberTeamNotificationSubscriptionRepository
 	@EntityGraph(attributePaths = "team")
 	List<MemberTeamNotificationSubscription> findByMember_Id(Long memberId);
 
+	// 백오피스 회원 상세: 최근 구독순.
+	@EntityGraph(attributePaths = "team")
+	List<MemberTeamNotificationSubscription> findByMember_IdOrderByCreatedAtDesc(Long memberId);
+
 	@EntityGraph(attributePaths = "team")
 	Optional<MemberTeamNotificationSubscription> findByMember_IdAndTeam_Id(Long memberId, Long teamId);
 

--- a/src/test/java/com/toy/nar/api/admin/BackofficeMemberSortTest.java
+++ b/src/test/java/com/toy/nar/api/admin/BackofficeMemberSortTest.java
@@ -1,0 +1,35 @@
+package com.toy.nar.api.admin;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 회원 목록은 native 쿼리라 정렬 프로퍼티가 SQL 로 그대로 나간다.
+ * 화이트리스트가 무너지면 임의 문자열이 ORDER BY 에 실려 500(또는 그 이상)이 된다.
+ */
+class BackofficeMemberSortTest {
+
+	@Test
+	@DisplayName("허용된 정렬 컬럼은 그대로 유지한다")
+	void keepsAllowedSort() {
+		var sorted = BackofficeController.sanitizeMemberSort(
+				PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "favoritePlayerCount")));
+
+		assertThat(sorted.getSort().getOrderFor("favoritePlayerCount")).isNotNull();
+	}
+
+	@Test
+	@DisplayName("목록에 없는 정렬 프로퍼티는 버린다")
+	void dropsUnknownSort() {
+		var sorted = BackofficeController.sanitizeMemberSort(
+				PageRequest.of(1, 20, Sort.by("createdAt").descending().and(Sort.by("drop table"))));
+
+		assertThat(sorted.getSort().stream().map(Sort.Order::getProperty)).containsExactly("createdAt");
+		assertThat(sorted.getPageNumber()).isEqualTo(1);
+		assertThat(sorted.getPageSize()).isEqualTo(20);
+	}
+}


### PR DESCRIPTION
백오피스 가입자 탭에서 행을 눌러 들어가는 상세 화면(FE 작업 완료, mock 으로 붙여둠)에 필요한 백엔드.

## 변경

### `GET /api/admin/members/{id}` (신규)
회원 정보 + 선수 구독 + 팀 구독 + 작성 리뷰 + 활성 기기 수를 한 번에 내린다.

- 쿼리 5방 + 리뷰 경기 정보 배치 조회 1방. 연관은 전부 `@EntityGraph` 로 미리 채운다(`open-in-view: false`).
- 리뷰는 목록(`/ratings`)과 같은 `RatingRow` — FE 가 표를 그대로 재사용한다.
  `RatingRow.from` 에 닉네임을 받는 오버로드를 추가해 `rating.getMember()` 지연 로딩을 건드리지 않는다.
- 없는 회원은 기존 핸들러가 404 + `{message}`.
- 리뷰는 최근 100건 캡(`ponytail:` 주석). 넘치면 그때 섹션 엔드포인트로 분리.

### `GET /api/admin/members` — 구독 수 집계
`favoritePlayerCount`, `favoriteTeamCount` 를 스칼라 서브쿼리로 함께 내리고 정렬도 지원한다.

- 서브쿼리는 두 테이블의 `(member_id, …)` 유니크 인덱스 선두 컬럼을 탄다. 회원 3,275명 규모.
- 별칭 정렬이 필요해 JPQL → native 로 교체. Spring 이 정렬 프로퍼티 앞에 테이블 별칭(`m.`)을 붙여
  `Unknown column 'm.favoritePlayerCount'` 500 이 났고, 파생 테이블로 한 겹 감싸 해결했다.
- native 라 정렬 프로퍼티가 SQL 로 그대로 나간다 → 화이트리스트(`id, name, email, createdAt, favoritePlayerCount, favoriteTeamCount`) 밖은 버린다. 단위 테스트 1개.

## 검증

로컬(prod 사본 DB)에서 실행해 확인:

- 목록: `sort=favoritePlayerCount,desc` / `sort=createdAt,desc` / `q=naver` / 없는 정렬 프로퍼티(200, 무시)
- 상세: 존재하는 회원 200(구독 3명·팀 1개·리뷰), 없는 회원 404
- 회귀: `/ratings` 목록 정상
- `./gradlew test --tests "com.toy.nar.api.admin.BackofficeMemberSortTest"` 통과

로컬 회원은 3명뿐이라 대량 데이터 체감은 배포 후 확인.

## 후속

FE 의 `USE_MEMBER_MOCK = false` 로 되돌리고 실데이터 확인 — 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)