### PR TITLE
feat: 공지사항 조회수 집계 + 백오피스 노출

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -522,10 +522,10 @@ public class BackofficeController {
     /** 공지 행. promoteUntil/publishedAt 은 FE 가 날짜만 잘라 표시한다. */
     public record NoticeRow(Long id, String title, String content, boolean pinned,
                             LocalDateTime promoteUntil, LocalDateTime publishedAt,
-                            LocalDateTime createdAt) {
+                            LocalDateTime createdAt, long viewCount) {
         static NoticeRow from(Notice n) {
             return new NoticeRow(n.getId(), n.getTitle(), n.getContent(), n.isPinned(),
-                    n.getPromoteUntil(), n.getPublishedAt(), n.getCreatedAt());
+                    n.getPromoteUntil(), n.getPublishedAt(), n.getCreatedAt(), n.getViewCount());
         }
     }
 

--- a/src/main/java/com/toy/nar/api/mobile/notice/MobileNoticeController.java
+++ b/src/main/java/com/toy/nar/api/mobile/notice/MobileNoticeController.java
@@ -10,8 +10,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -36,6 +40,15 @@ public class MobileNoticeController {
         Page<Notice> page =
                 admin ? noticeService.adminPage(pageable) : noticeService.publishedPage(pageable);
         return page.map(NoticeResponse::from);
+    }
+
+    @Operation(summary = "공지 조회수 증가",
+            description = "앱에서 공지 상세를 열 때 호출한다. 목록에 본문이 함께 내려가므로 앱이 직접 알려줘야 조회수가 쌓인다. "
+                    + "중복 제거 없이 열람 횟수를 센다. 없는 공지면 404.")
+    @PostMapping("/{id}/view")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void increaseViewCount(@PathVariable Long id) {
+        noticeService.increaseViewCount(id);
     }
 
     @Operation(summary = "띠배너 공지 목록",

--- a/src/main/java/com/toy/nar/app/notice/service/NoticeService.java
+++ b/src/main/java/com/toy/nar/app/notice/service/NoticeService.java
@@ -70,6 +70,14 @@ public class NoticeService {
         return notice;
     }
 
+    /** 앱에서 공지 상세를 열었을 때 조회수 +1. 중복 제거 없이 열람 횟수를 그대로 센다. */
+    @Transactional
+    public void increaseViewCount(Long id) {
+        if (noticeRepository.increaseViewCount(id) == 0) {
+            throw new CustomException(ErrorCode.NOTICE_NOT_FOUND);
+        }
+    }
+
     @Transactional
     public void delete(Long id) {
         if (!noticeRepository.existsById(id)) {

--- a/src/main/java/com/toy/nar/domain/notice/entity/Notice.java
+++ b/src/main/java/com/toy/nar/domain/notice/entity/Notice.java
@@ -49,6 +49,10 @@ public class Notice {
     @Column(name = "published_at")
     private LocalDateTime publishedAt;
 
+    /** 조회수. 증가는 NoticeRepository 의 UPDATE 쿼리로만 한다(updatedAt 을 건드리지 않도록). */
+    @Column(name = "view_count", nullable = false)
+    private long viewCount;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/toy/nar/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/toy/nar/domain/notice/repository/NoticeRepository.java
@@ -6,6 +6,9 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
@@ -18,4 +21,13 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     /** 백오피스 목록 — 임시저장 포함 전체, 고정 먼저 그 안에서 등록 최신순. */
     Page<Notice> findAllByOrderByPinnedDescCreatedAtDesc(Pageable pageable);
+
+    /**
+     * 조회수 +1. 엔티티를 읽지 않는 UPDATE 라 동시 호출이 겹쳐도 유실이 없고 updatedAt 도 안 바뀐다.
+     *
+     * @return 갱신된 행 수 (0 이면 없는 공지)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("update Notice n set n.viewCount = n.viewCount + 1 where n.id = :id")
+    int increaseViewCount(@Param("id") Long id);
 }

--- a/src/main/resources/db/migration/V61__Add_view_count_to_notice.sql
+++ b/src/main/resources/db/migration/V61__Add_view_count_to_notice.sql
@@ -1,0 +1,3 @@
+-- 공지 조회수. 앱이 공지 상세를 열 때 POST /api/notices/{id}/view 로 1 증가시킨다.
+-- 비회원도 보는 공개 공지라 회원 단위 중복 제거는 하지 않는다(순수 열람 횟수).
+ALTER TABLE notice ADD COLUMN view_count BIGINT NOT NULL DEFAULT 0;

--- a/src/test/java/com/toy/nar/app/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/toy/nar/app/notice/service/NoticeServiceTest.java
@@ -68,6 +68,18 @@ class NoticeServiceTest {
     }
 
     @Test
+    @DisplayName("조회수 증가: 갱신 행 없으면 NOTICE_NOT_FOUND")
+    void increaseViewCount() {
+        when(noticeRepository.increaseViewCount(1L)).thenReturn(1);
+        when(noticeRepository.increaseViewCount(99L)).thenReturn(0);
+
+        noticeService.increaseViewCount(1L);
+
+        assertThatThrownBy(() -> noticeService.increaseViewCount(99L))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
     @DisplayName("없는 공지 수정/삭제는 NOTICE_NOT_FOUND")
     void notFound() {
         when(noticeRepository.findById(99L)).thenReturn(Optional.empty());


### PR DESCRIPTION
## 배경
공지사항 조회수를 저장하지 않아 백오피스에서 확인할 수 없었다.

## 변경
- `notice.view_count BIGINT NOT NULL DEFAULT 0` 추가 (`V61`)
- `POST /api/notices/{id}/view` (인증 불필요) — 조회수 +1, 없는 공지면 404
- 증가는 `@Modifying` JPQL UPDATE — 엔티티를 읽지 않으므로 동시 호출 유실이 없고 `updated_at`도 바뀌지 않는다
- 백오피스 `GET /admin/notices`, `GET /admin/notices/{id}` 응답에 `viewCount` 추가

## 앱 연동 필요
목록 API가 본문까지 함께 내려주기 때문에 상세 조회 요청이 따로 없다. 앱이 공지 상세를 열 때 `POST /api/notices/{id}/view`를 호출해야 조회수가 쌓인다.

## 범위 제외
회원/기기 단위 중복 제거는 하지 않았다(순수 열람 횟수). 유니크 방문자 수가 필요해지면 `notice_view` 이력 테이블 추가.

## 검증
`./gradlew test --tests "com.toy.nar.app.notice.service.NoticeServiceTest"` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)