### PR TITLE
chore: 공지 id 1 조회수 백필 (로그 실측 46)

### DIFF
--- a/src/main/resources/db/migration/V62__Backfill_notice_view_count.sql
+++ b/src/main/resources/db/migration/V62__Backfill_notice_view_count.sql
@@ -1,0 +1,5 @@
+-- notice id 1 조회수 백필. view_count 컬럼(V61) 도입 전에 발행된 공지라 집계가 0으로 남아 있다.
+-- 값 46 = 발행(2026-08-01 09:44) 이후 CloudWatch /nar/app 로그의 `GET /api/notices`(공지 목록 화면 진입) 실측 호출 수.
+-- 띠배너 탭 열람은 /api/notices/promoted 응답에 본문이 함께 실려 별도 API 호출이 없어 집계 불가 — 46은 하한이다.
+-- 이미 실집계가 쌓였으면 덮어쓰지 않는다.
+UPDATE notice SET view_count = 46 WHERE id = 1 AND view_count = 0;


### PR DESCRIPTION
## 배경
`view_count`(#338, V61)는 이미 프로덕션에 적용됐지만, 컬럼 도입 전에 발행된 공지 id 1(`[반영완료] 선수 추가 요청 반영 안내`, 2026-08-01 09:44 발행)은 집계가 0으로 남아 있다.

## 값 근거 — CloudWatch `/nar/app` 실측
발행 시각 ~ 2026-08-02 16:27 구간:

| 신호 | 횟수 | 의미 |
|---|---|---|
| `GET /api/notices` | **46** | 공지 목록 화면 진입 (발행 직후 확인 트래픽 포함) |
| `GET /api/notices/promoted` | 2087 | 캘린더 진입마다 호출 = 배너 노출(impression) |
| 배너 탭 → 본문 열람 | 로그 없음 | `promoted` 응답에 본문이 실려 있어 탭 시 API 호출이 없음 |

2087은 노출이라 조회수로 쓰면 과대(활성 회원 1656명이 캘린더를 여러 번 연 것). 그래서 실측 하한인 46을 넣는다.

## 변경
- `V62__Backfill_notice_view_count.sql` — `UPDATE notice SET view_count = 46 WHERE id = 1 AND view_count = 0`
- `view_count = 0` 조건으로 실집계가 쌓인 뒤 배포돼도 덮어쓰지 않는다
- V61은 이미 적용돼 체크섬이 고정이라 수정하지 않고 별도 버전으로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)