### PR TITLE
feat: 백오피스 경기별 알림 구독 조회 API

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -15,6 +15,7 @@ import com.toy.nar.app.riot.dto.RiotAccountVerification;
 import com.toy.nar.domain.game.repository.LeagueRepository;
 import com.toy.nar.domain.member.repository.MemberDeviceRepository;
 import com.toy.nar.domain.member.repository.MemberFavoritePlayerRepository;
+import com.toy.nar.domain.member.repository.MemberMatchSubscriptionRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import com.toy.nar.domain.member.repository.MemberTeamNotificationSubscriptionRepository;
 import com.toy.nar.domain.notice.entity.Notice;
@@ -79,6 +80,7 @@ public class BackofficeController {
     private final MemberFavoritePlayerRepository memberFavoritePlayerRepository;
     private final MemberDeviceRepository memberDeviceRepository;
     private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
+    private final MemberMatchSubscriptionRepository matchSubscriptionRepository;
     private final NoticeService noticeService;
     private final NoticeImageStorageService noticeImageStorageService;
 
@@ -207,16 +209,48 @@ public class BackofficeController {
     // 구독 탭 — 특정 팀을 구독한 회원 목록(최근순) + 알림 토글 상태.
     // field(memberId|nickname|email)+q 로 검색. field 없이 q만 오면 닉네임 기준.
     @GetMapping("/subscriptions/teams/{teamId}/subscribers")
-    public Page<TeamSubscriberRow> teamSubscribers(@PathVariable Long teamId,
+    public Page<SubscriberWithTogglesRow> teamSubscribers(@PathVariable Long teamId,
                                                    @RequestParam(required = false) String field,
                                                    @RequestParam(required = false) String q,
                                                    Pageable pageable) {
         String fieldParam = blankToNull(field);
         return teamSubscriptionRepository.findSubscribersByTeamId(
                         teamId, fieldParam == null ? "nickname" : fieldParam, blankToNull(q), pageable)
-                .map(v -> new TeamSubscriberRow(v.getMemberId(), v.getName() + "#" + v.getTag(),
+                .map(v -> new SubscriberWithTogglesRow(v.getMemberId(), v.getName() + "#" + v.getTag(),
                         v.getEmail(), v.getSubscribedAt(), v.getSetStartEnabled(),
                         v.getSetEndEnabled(), v.getLiveEventEnabled()));
+    }
+
+    // 구독 탭 — 구독자가 있는 경기 목록(구독자 수 desc). q로 경기명·팀명 검색.
+    // 정렬은 쿼리에 고정(인기순)이라 클라이언트 sort는 무시(page/size만 사용).
+    @GetMapping("/subscriptions/matches")
+    public Page<SubscribedMatchRow> subscribedMatches(@RequestParam(required = false) String q,
+                                                      Pageable pageable) {
+        Pageable pageOnly = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        return matchSubscriptionRepository.findSubscribedMatches(blankToNull(q), pageOnly)
+                .map(v -> new SubscribedMatchRow(v.getMatchId(), v.getLeagueName(), v.getMatchTitle(),
+                        v.getBlueTeamName(), v.getRedTeamName(), v.getState(), toKst(v.getMatchDate()),
+                        v.getSubscriberCount()));
+    }
+
+    // 구독 탭 — 특정 경기를 구독한 회원 목록(최근순) + 알림 토글 상태. 팀 구독과 동일한 검색 규약.
+    @GetMapping("/subscriptions/matches/{matchId}/subscribers")
+    public Page<SubscriberWithTogglesRow> matchSubscribers(@PathVariable String matchId,
+                                                           @RequestParam(required = false) String field,
+                                                           @RequestParam(required = false) String q,
+                                                           Pageable pageable) {
+        String fieldParam = blankToNull(field);
+        return matchSubscriptionRepository.findSubscribersByMatchId(
+                        matchId, fieldParam == null ? "nickname" : fieldParam, blankToNull(q), pageable)
+                .map(v -> new SubscriberWithTogglesRow(v.getMemberId(), v.getName() + "#" + v.getTag(),
+                        v.getEmail(), v.getSubscribedAt(), v.getSetStartEnabled(),
+                        v.getSetEndEnabled(), v.getLiveEventEnabled()));
+    }
+
+    // league_match 는 UTC 로 저장 → 응답은 모바일과 동일하게 KST.
+    private static LocalDateTime toKst(LocalDateTime utc) {
+        return utc == null ? null
+                : utc.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
     }
 
     // 빈 문자열/공백은 null 로 정규화 → 검색 쿼리의 ":q IS NULL" 분기가 전체 조회로 동작.
@@ -439,9 +473,15 @@ public class BackofficeController {
     public record SubscribableTeamRow(Long id, String teamName, String teamCode, String imageUrl,
                                       long subscriberCount) {}
 
-    public record TeamSubscriberRow(Long id, String nickname, String email, LocalDateTime subscribedAt,
+    // 팀·경기 구독자 공용 행(알림 토글 3종 포함). id 필드는 FE rowKey 용(memberId).
+    public record SubscriberWithTogglesRow(Long id, String nickname, String email, LocalDateTime subscribedAt,
                                     boolean setStartEnabled, boolean setEndEnabled,
                                     boolean liveEventEnabled) {}
+
+    /** id = league_match.id (VARCHAR). matchDate 는 KST 변환 후 값. */
+    public record SubscribedMatchRow(String id, String leagueName, String matchTitle,
+                                     String blueTeamName, String redTeamName, String state,
+                                     LocalDateTime matchDate, long subscriberCount) {}
 
     public record PlayerRow(Long id, String name, String realName, String role, Integer age,
                             String imageUrl, Long currentTeamId, String currentTeamName, boolean imageLocked,
@@ -492,11 +532,6 @@ public class BackofficeController {
                     r.getPlayerName(), r.getChampionName(), r.getRole(),
                     memberNickname, r.getRating(), r.getComment(),
                     r.getCreatedAt());
-        }
-
-        private static LocalDateTime toKst(LocalDateTime utc) {
-            return utc == null ? null
-                    : utc.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         }
     }
 

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionRepository.java
@@ -1,10 +1,13 @@
 package com.toy.nar.domain.member.repository;
 
 import com.toy.nar.domain.member.entity.MemberMatchSubscription;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MemberMatchSubscriptionRepository
@@ -20,4 +23,107 @@ public interface MemberMatchSubscriptionRepository
 			WHERE subscription.member.id = :memberId
 			""")
 	List<String> findMatchIdsByMemberId(@Param("memberId") Long memberId);
+
+	// 백오피스 구독 탭: 구독자가 1명 이상인 경기만(인기순, 동수면 최신 경기 우선).
+	// 전체 경기는 대부분 구독자 0이라 INNER JOIN 으로 걸러낸다. q 는 경기명·팀명 검색.
+	// match_date 는 UTC 저장이라 KST 변환은 컨트롤러에서 한다(리뷰 탭과 동일).
+	@Query(value = """
+			SELECT lm.id AS matchId,
+			       lm.league_name AS leagueName,
+			       lm.match_title AS matchTitle,
+			       lm.blue_team_name AS blueTeamName,
+			       lm.red_team_name AS redTeamName,
+			       lm.state AS state,
+			       lm.match_date AS matchDate,
+			       COUNT(*) AS subscriberCount
+			FROM member_match_subscription mms
+			JOIN league_match lm ON lm.id = mms.match_id
+			WHERE (:q IS NULL
+			       OR LOWER(lm.match_title) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(lm.blue_team_name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(lm.red_team_name) LIKE LOWER(CONCAT('%', :q, '%')))
+			GROUP BY lm.id, lm.league_name, lm.match_title, lm.blue_team_name,
+			         lm.red_team_name, lm.state, lm.match_date
+			ORDER BY subscriberCount DESC, lm.match_date DESC
+			""",
+			countQuery = """
+			SELECT COUNT(DISTINCT mms.match_id)
+			FROM member_match_subscription mms
+			JOIN league_match lm ON lm.id = mms.match_id
+			WHERE (:q IS NULL
+			       OR LOWER(lm.match_title) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(lm.blue_team_name) LIKE LOWER(CONCAT('%', :q, '%'))
+			       OR LOWER(lm.red_team_name) LIKE LOWER(CONCAT('%', :q, '%')))
+			""",
+			nativeQuery = true)
+	Page<SubscribedMatchView> findSubscribedMatches(@Param("q") String q, Pageable pageable);
+
+	// 백오피스 구독 탭: 특정 경기를 구독한 회원 목록(최근 구독순) + 알림 토글 상태. 팀 구독과 동일 패턴.
+	@Query(value = """
+			SELECT m.id AS memberId,
+			       m.name AS name,
+			       m.tag AS tag,
+			       m.email AS email,
+			       mms.set_start_enabled AS setStartEnabled,
+			       mms.set_end_enabled AS setEndEnabled,
+			       mms.live_event_enabled AS liveEventEnabled,
+			       mms.created_at AS subscribedAt
+			FROM member_match_subscription mms
+			JOIN member m ON m.id = mms.member_id
+			WHERE mms.match_id = :matchId
+			  AND (:q IS NULL
+			       OR (:field = 'memberId' AND CAST(m.id AS CHAR) LIKE CONCAT('%', :q, '%'))
+			       OR (:field = 'email' AND LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'nickname' AND LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%'))))
+			ORDER BY mms.created_at DESC
+			""",
+			countQuery = """
+			SELECT COUNT(*)
+			FROM member_match_subscription mms
+			JOIN member m ON m.id = mms.member_id
+			WHERE mms.match_id = :matchId
+			  AND (:q IS NULL
+			       OR (:field = 'memberId' AND CAST(m.id AS CHAR) LIKE CONCAT('%', :q, '%'))
+			       OR (:field = 'email' AND LOWER(m.email) LIKE LOWER(CONCAT('%', :q, '%')))
+			       OR (:field = 'nickname' AND LOWER(CONCAT(m.name, '#', m.tag)) LIKE LOWER(CONCAT('%', :q, '%'))))
+			""",
+			nativeQuery = true)
+	Page<MatchSubscriberView> findSubscribersByMatchId(@Param("matchId") String matchId,
+			@Param("field") String field, @Param("q") String q, Pageable pageable);
+
+	interface SubscribedMatchView {
+		String getMatchId();
+
+		String getLeagueName();
+
+		String getMatchTitle();
+
+		String getBlueTeamName();
+
+		String getRedTeamName();
+
+		String getState();
+
+		LocalDateTime getMatchDate();
+
+		long getSubscriberCount();
+	}
+
+	interface MatchSubscriberView {
+		Long getMemberId();
+
+		String getName();
+
+		String getTag();
+
+		String getEmail();
+
+		Boolean getSetStartEnabled();
+
+		Boolean getSetEndEnabled();
+
+		Boolean getLiveEventEnabled();
+
+		LocalDateTime getSubscribedAt();
+	}
 }

--- a/src/test/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionBackofficeMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionBackofficeMySqlIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberMatchSubscription;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 백오피스 경기 구독 탭 네이티브 쿼리(GROUP BY 집계 + field/q 검색 분기)를 실제 MySQL 8 에서 검증한다.
+ * 집계 정렬(구독자 수 desc)과 ONLY_FULL_GROUP_BY 하의 GROUP BY 컬럼 나열이 런타임에 깨지지 않음을 보장한다.
+ * 로컬 dev MySQL(docker-compose, 3308)의 격리 스키마 nar_match_subscription_test 에 ddl-auto=create-drop 으로 실행한다.
+ * 사전 준비(최초 1회, root 계정):
+ * CREATE DATABASE nar_match_subscription_test; GRANT ALL ON nar_match_subscription_test.* TO 'nar_id'@'%';
+ * 실행: ./gradlew test -Ddataintegrity.local.enabled=true --tests "...MemberMatchSubscriptionBackofficeMySqlIntegrationTest"
+ */
+@EnabledIfSystemProperty(named = "dataintegrity.local.enabled", matches = "true")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MemberMatchSubscriptionBackofficeMySqlIntegrationTest {
+
+	@DynamicPropertySource
+	static void datasource(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url",
+				() -> "jdbc:mysql://localhost:3308/nar_match_subscription_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8");
+		registry.add("spring.datasource.username", () -> "nar_id");
+		registry.add("spring.datasource.password", () -> "nar_pw");
+		registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+		registry.add("spring.flyway.enabled", () -> "false");
+	}
+
+	@Autowired
+	private MemberMatchSubscriptionRepository repository;
+
+	@Autowired
+	private LeagueMatchRepository matchRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@BeforeEach
+	void seed() {
+		// m-hot: 구독자 2명, m-cold: 1명, m-none: 0명(목록에서 빠져야 함).
+		matchRepository.saveAll(List.of(
+				match("m-hot", "LCK", LocalDateTime.of(2026, 7, 10, 9, 0), "T1", "GEN"),
+				match("m-cold", "LCK", LocalDateTime.of(2026, 7, 11, 9, 0), "KT", "DK"),
+				match("m-none", "LEC", LocalDateTime.of(2026, 7, 12, 9, 0), "G2", "FNC")));
+
+		Member alice = new Member("앨리스", "1234", "a@nar.kr");
+		Member bob = new Member("밥", "5678", "b@nar.kr");
+		em.persist(alice);
+		em.persist(bob);
+
+		repository.saveAll(List.of(
+				new MemberMatchSubscription(alice, "m-hot", true, true, true),
+				new MemberMatchSubscription(bob, "m-hot", true, false, true),
+				new MemberMatchSubscription(alice, "m-cold", false, true, true)));
+		em.flush();
+	}
+
+	@Test
+	@DisplayName("구독자가 있는 경기만 구독자 수 내림차순으로 내려준다")
+	void listsOnlySubscribedMatchesOrderedByCount() {
+		var page = repository.findSubscribedMatches(null, PageRequest.of(0, 20));
+
+		assertThat(page.getTotalElements()).isEqualTo(2);
+		assertThat(page.getContent()).extracting(v -> v.getMatchId() + ":" + v.getSubscriberCount())
+				.containsExactly("m-hot:2", "m-cold:1");
+	}
+
+	@Test
+	@DisplayName("q는 경기명·팀명 부분일치로 거른다")
+	void searchMatchesTeamName() {
+		var page = repository.findSubscribedMatches("gen", PageRequest.of(0, 20));
+
+		assertThat(page.getContent()).extracting(v -> v.getMatchId()).containsExactly("m-hot");
+	}
+
+	@Test
+	@DisplayName("경기 구독자 목록은 알림 토글 3종을 함께 내려준다")
+	void listsSubscribersWithToggles() {
+		var page = repository.findSubscribersByMatchId("m-hot", "nickname", null, PageRequest.of(0, 20));
+
+		assertThat(page.getTotalElements()).isEqualTo(2);
+		assertThat(page.getContent()).extracting(v -> v.getName() + "#" + v.getTag())
+				.containsExactlyInAnyOrder("앨리스#1234", "밥#5678");
+		assertThat(page.getContent()).filteredOn(v -> "밥".equals(v.getName()))
+				.allMatch(v -> !v.getSetEndEnabled() && v.getSetStartEnabled());
+	}
+
+	@Test
+	@DisplayName("field=nickname + q 로 구독자를 검색한다")
+	void searchSubscribersByNickname() {
+		var page = repository.findSubscribersByMatchId("m-hot", "nickname", "앨리스", PageRequest.of(0, 20));
+
+		assertThat(page.getContent()).extracting(v -> v.getEmail()).containsExactly("a@nar.kr");
+	}
+
+	private static LeagueMatch match(String id, String league, LocalDateTime date, String blue, String red) {
+		return LeagueMatch.builder()
+				.id(id)
+				.leagueName(league)
+				.matchTitle(blue + " vs " + red)
+				.matchDate(date)
+				.state("completed")
+				.blueTeamName(blue)
+				.redTeamName(red)
+				.build();
+	}
+
+	// NarApplication 을 끌어오면 @EnableElasticsearchRepositories 까지 딸려와 elasticsearchTemplate 이 없어 컨텍스트가 죽는다.
+	// 리뷰 검색 테스트와 동일하게 JPA 만 담은 최소 설정을 쓴다.
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@EntityScan(basePackages = {
+			"com.toy.nar.domain.member.entity",
+			"com.toy.nar.domain.participant.entity",
+			"com.toy.nar.domain.game.entity",
+			"com.toy.nar.app.lolesports.repository"
+	})
+	@EnableJpaRepositories(basePackageClasses = {
+			MemberMatchSubscriptionRepository.class,
+			LeagueMatchRepository.class
+	})
+	static class TestJpaConfiguration {
+	}
+}


### PR DESCRIPTION
## 왜

경기 예약 알림(`member_match_subscription`)을 몇 명이 구독했는지, 누가 구독했는지 운영자가 볼 방법이 없었다. 백오피스 구독 탭에 **경기** 서브탭을 붙이기 위한 API.

## 무엇

| 엔드포인트 | 설명 |
|---|---|
| `GET /api/admin/subscriptions/matches` | 구독자 있는 경기 목록(구독자 수 desc, 동수면 최신 경기 우선). `q` = 경기명·팀명 검색 |
| `GET /api/admin/subscriptions/matches/{matchId}/subscribers` | 구독자 목록(최근순) + 알림 토글 3종. `field`(nickname\|memberId\|email) + `q` 검색 |

- 전체 경기는 대부분 구독자 0이라 목록이 무의미해짐 → **INNER JOIN 으로 구독자 있는 경기만** 노출.
- `league_match.match_date` 는 UTC 저장이라 KST 로 변환해 내린다. `RatingRow` 안에만 있던 `toKst` 를 컨트롤러 레벨로 올려 공유.
- `TeamSubscriberRow` → `SubscriberWithTogglesRow` rename. 팀·경기 구독자 응답 모양이 같아 공용으로 쓴다(JSON 필드 동일 → FE 영향 없음).

정렬·검색 규약은 기존 선수/팀 구독 탭과 동일하게 맞췄다.

## 테스트

MySQL 8 통합 테스트 4건 — 집계·정렬(GROUP BY, 구독자 수 desc), 구독자 0인 경기 제외, 팀명 검색, 토글 값, 닉네임 검색.

```
./gradlew test -Ddataintegrity.local.enabled=true --tests "*MemberMatchSubscriptionBackofficeMySqlIntegrationTest"
# 4 tests, 0 failures
```

최초 1회 스키마 준비: `CREATE DATABASE nar_match_subscription_test; GRANT ALL ON nar_match_subscription_test.* TO 'nar_id'@'%';`

> `@DataJpaTest` 가 `NarApplication` 을 끌면 `@EnableElasticsearchRepositories` 때문에 `elasticsearchTemplate` 없어서 컨텍스트가 죽는다. `LivePlayerRatingSearchTest` 와 동일하게 중첩 `@SpringBootConfiguration` 으로 우회.

## 관련

FE: NAR-GG/warding-backoffice-fe (경기 구독 탭)

🤖 Generated with [Claude Code](https://claude.com/claude-code)