### PR TITLE
feat: 백오피스 대시보드 집계 API + 경기 구독 상태 필터 (#342 포함)

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -1,5 +1,8 @@
 package com.toy.nar.api.admin;
 
+import com.toy.nar.app.admin.dto.StatsOverviewResponse;
+import com.toy.nar.app.admin.dto.StatsSeriesResponse;
+import com.toy.nar.app.admin.service.AdminStatsService;
 import com.toy.nar.app.lolesports.LeagueConfigService;
 import com.toy.nar.app.lolesports.repository.LeagueMatch;
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
@@ -81,6 +84,7 @@ public class BackofficeController {
     private final MemberDeviceRepository memberDeviceRepository;
     private final MemberTeamNotificationSubscriptionRepository teamSubscriptionRepository;
     private final MemberMatchSubscriptionRepository matchSubscriptionRepository;
+    private final AdminStatsService adminStatsService;
     private final NoticeService noticeService;
     private final NoticeImageStorageService noticeImageStorageService;
 
@@ -289,6 +293,21 @@ public class BackofficeController {
             throw new NoSuchElementException("리뷰를 찾을 수 없습니다: " + id);
         }
         livePlayerRatingRepository.deleteById(id);
+    }
+
+    /**
+     * 대시보드 시계열 — 가입·구독·알림을 1시간 버킷으로. 값 0인 시간대는 행이 없다.
+     * 일별 화면은 프론트가 시간 버킷을 합쳐 그리고, 24시간 롤링 뷰는 마지막 이틀 버킷으로 만든다.
+     */
+    @GetMapping("/stats/series")
+    public StatsSeriesResponse statsSeries(@RequestParam(defaultValue = "30") int days) {
+        return adminStatsService.series(days);
+    }
+
+    /** 대시보드 퍼널·분포 — 기간과 무관한 값이라 시계열과 분리. */
+    @GetMapping("/stats/overview")
+    public StatsOverviewResponse statsOverview() {
+        return adminStatsService.overview();
     }
 
     @GetMapping("/cron-jobs")

--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -221,13 +221,14 @@ public class BackofficeController {
                         v.getSetEndEnabled(), v.getLiveEventEnabled()));
     }
 
-    // 구독 탭 — 구독자가 있는 경기 목록(구독자 수 desc). q로 경기명·팀명 검색.
+    // 구독 탭 — 구독자가 있는 경기 목록(구독자 수 desc). q로 경기명·팀명 검색, state로 진행 상태 필터.
     // 정렬은 쿼리에 고정(인기순)이라 클라이언트 sort는 무시(page/size만 사용).
     @GetMapping("/subscriptions/matches")
     public Page<SubscribedMatchRow> subscribedMatches(@RequestParam(required = false) String q,
+                                                      @RequestParam(required = false) String state,
                                                       Pageable pageable) {
         Pageable pageOnly = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        return matchSubscriptionRepository.findSubscribedMatches(blankToNull(q), pageOnly)
+        return matchSubscriptionRepository.findSubscribedMatches(blankToNull(q), blankToNull(state), pageOnly)
                 .map(v -> new SubscribedMatchRow(v.getMatchId(), v.getLeagueName(), v.getMatchTitle(),
                         v.getBlueTeamName(), v.getRedTeamName(), v.getState(), toKst(v.getMatchDate()),
                         v.getSubscriberCount()));

--- a/src/main/java/com/toy/nar/app/admin/dto/StatsOverviewResponse.java
+++ b/src/main/java/com/toy/nar/app/admin/dto/StatsOverviewResponse.java
@@ -1,0 +1,23 @@
+package com.toy.nar.app.admin.dto;
+
+import java.util.List;
+
+/**
+ * 시간축이 없는 대시보드 값 — 퍼널 4단계 + 분포. 기간 필터와 무관하므로 시계열과 분리했다.
+ *
+ * @param totalMembers      전체 회원
+ * @param onboardedMembers  온보딩 완료(onboarded_at 있음)
+ * @param subscribedMembers 선수·팀·경기 중 하나라도 구독한 회원
+ * @param ratedMembers      평점을 한 번이라도 남긴 회원
+ */
+public record StatsOverviewResponse(
+        long totalMembers,
+        long onboardedMembers,
+        long subscribedMembers,
+        long ratedMembers,
+        List<LabelCount> leagues,
+        List<LabelCount> teams,
+        List<LabelCount> players
+) {
+    public record LabelCount(String label, long count) {}
+}

--- a/src/main/java/com/toy/nar/app/admin/dto/StatsSeriesResponse.java
+++ b/src/main/java/com/toy/nar/app/admin/dto/StatsSeriesResponse.java
@@ -1,0 +1,24 @@
+package com.toy.nar.app.admin.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 백오피스 대시보드 시계열. 전부 <b>1시간 버킷</b>이고 값이 0인 시간대는 행이 없다(sparse).
+ * 일별 차트는 프론트가 같은 날짜끼리 합쳐서 그린다.
+ *
+ * @param from   조회 시작 시각(이 시각 이후 데이터만)
+ * @param bucketUnit 버킷 단위. 지금은 항상 {@code HOUR}
+ */
+public record StatsSeriesResponse(
+        LocalDateTime from,
+        String bucketUnit,
+        List<CountPoint> signups,
+        List<SubscriptionPoint> subscriptions,
+        List<CountPoint> notifications
+) {
+    /** @param bucket {@code 2026-08-02T13:00} (서버 로컬시각) */
+    public record CountPoint(String bucket, long count) {}
+
+    public record SubscriptionPoint(String bucket, long player, long team, long match) {}
+}

--- a/src/main/java/com/toy/nar/app/admin/service/AdminStatsService.java
+++ b/src/main/java/com/toy/nar/app/admin/service/AdminStatsService.java
@@ -1,0 +1,71 @@
+package com.toy.nar.app.admin.service;
+
+import com.toy.nar.app.admin.dto.StatsOverviewResponse;
+import com.toy.nar.app.admin.dto.StatsSeriesResponse;
+import com.toy.nar.domain.member.repository.AdminStatsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 백오피스 대시보드 집계. 조회 전용이라 쓰기 트랜잭션이 없다.
+ *
+ * <p>기간은 <b>일 단위로 잘라 자정부터</b> 읽는다. 화면의 24시간 롤링 윈도는 마지막 이틀치 시간 버킷에서
+ * 프론트가 만들어 쓴다(그래서 최소 조회 기간이 2일).
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminStatsService {
+
+    private static final int MIN_DAYS = 2;
+    private static final int MAX_DAYS = 90;
+    private static final int TOP_LIMIT = 10;
+
+    private final AdminStatsRepository statsRepository;
+
+    @Transactional(readOnly = true)
+    public StatsSeriesResponse series(int days) {
+        LocalDateTime from = LocalDate.now().minusDays(clampDays(days) - 1L).atStartOfDay();
+
+        List<StatsSeriesResponse.CountPoint> signups = statsRepository.signupsByHour(from).stream()
+                .map(row -> new StatsSeriesResponse.CountPoint(row.getBucket(), row.getCnt()))
+                .toList();
+        List<StatsSeriesResponse.SubscriptionPoint> subscriptions = statsRepository.subscriptionsByHour(from).stream()
+                .map(row -> new StatsSeriesResponse.SubscriptionPoint(
+                        row.getBucket(), row.getPlayerCnt(), row.getTeamCnt(), row.getMatchCnt()))
+                .toList();
+        List<StatsSeriesResponse.CountPoint> notifications = statsRepository.notificationsByHour(from).stream()
+                .map(row -> new StatsSeriesResponse.CountPoint(row.getBucket(), row.getCnt()))
+                .toList();
+
+        return new StatsSeriesResponse(from, "HOUR", signups, subscriptions, notifications);
+    }
+
+    @Transactional(readOnly = true)
+    public StatsOverviewResponse overview() {
+        var totals = statsRepository.memberTotals();
+        return new StatsOverviewResponse(
+                totals.getTotalMembers(),
+                totals.getOnboardedMembers(),
+                totals.getSubscribedMembers(),
+                totals.getRatedMembers(),
+                toLabelCounts(statsRepository.membersByFavoriteLeague()),
+                toLabelCounts(statsRepository.topSubscribedTeams(TOP_LIMIT)),
+                toLabelCounts(statsRepository.topSubscribedPlayers(TOP_LIMIT)));
+    }
+
+    private static List<StatsOverviewResponse.LabelCount> toLabelCounts(
+            List<AdminStatsRepository.LabelCount> rows) {
+        return rows.stream()
+                .map(row -> new StatsOverviewResponse.LabelCount(row.getLabel(), row.getCnt()))
+                .toList();
+    }
+
+    private static int clampDays(int days) {
+        return Math.min(MAX_DAYS, Math.max(MIN_DAYS, days));
+    }
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/AdminStatsRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/AdminStatsRepository.java
@@ -1,0 +1,141 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 백오피스 대시보드 집계 전용 리포지토리.
+ *
+ * <p>회원·구독·알림·평점 네 도메인을 가로지르는 집계라 엔티티별 리포지토리에 흩어놓지 않고 여기 모았다.
+ * 루트 엔티티는 {@link Member} 지만 실제 쿼리는 전부 네이티브라 테이블을 직접 읽는다.
+ *
+ * <p>시간 버킷은 <b>1시간</b> 단위로만 내려준다. 일별 화면은 프론트에서 시간 버킷을 합쳐 쓴다
+ * (일별/24시간 뷰가 쿼리 하나를 공유하고, 24시간 롤링 윈도가 자정을 가로질러도 그대로 만들어진다).
+ * 값이 0인 버킷은 행 자체가 없다 — 빈 구간 채우기는 화면 쪽 책임.
+ */
+public interface AdminStatsRepository extends Repository<Member, Long> {
+
+    /** {@code bucket} = {@code 2026-08-02T13:00} 형식(서버 로컬시각), {@code cnt} = 그 1시간 동안의 건수. */
+    interface HourCount {
+        String getBucket();
+
+        long getCnt();
+    }
+
+    interface SubscriptionHourCount {
+        String getBucket();
+
+        long getPlayerCnt();
+
+        long getTeamCnt();
+
+        long getMatchCnt();
+    }
+
+    interface LabelCount {
+        String getLabel();
+
+        long getCnt();
+    }
+
+    interface MemberTotals {
+        long getTotalMembers();
+
+        long getOnboardedMembers();
+
+        long getSubscribedMembers();
+
+        long getRatedMembers();
+    }
+
+    @Query(value = """
+            SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00') AS bucket, COUNT(*) AS cnt
+            FROM member
+            WHERE created_at >= :from
+            GROUP BY bucket
+            ORDER BY bucket
+            """, nativeQuery = true)
+    List<HourCount> signupsByHour(@Param("from") LocalDateTime from);
+
+    /**
+     * 선수·팀·경기 구독 세 테이블을 한 쿼리로. 각 테이블에서 먼저 시간별로 접은 뒤 UNION 하므로
+     * 스캔은 테이블당 한 번, UNION 에 올라오는 행은 최대 (구간 시간 수 × 3) 개다.
+     */
+    @Query(value = """
+            SELECT bucket,
+                   SUM(p) AS playerCnt,
+                   SUM(t) AS teamCnt,
+                   SUM(m) AS matchCnt
+            FROM (
+                SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00') AS bucket, COUNT(*) AS p, 0 AS t, 0 AS m
+                FROM member_favorite_player WHERE created_at >= :from GROUP BY bucket
+                UNION ALL
+                SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00'), 0, COUNT(*), 0
+                FROM member_team_notification_subscription WHERE created_at >= :from GROUP BY 1
+                UNION ALL
+                SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00'), 0, 0, COUNT(*)
+                FROM member_match_subscription WHERE created_at >= :from GROUP BY 1
+            ) x
+            GROUP BY bucket
+            ORDER BY bucket
+            """, nativeQuery = true)
+    List<SubscriptionHourCount> subscriptionsByHour(@Param("from") LocalDateTime from);
+
+    /** 인앱 알림 생성 건수 = 발송량. 푸시 전송 결과 테이블(delivery)이 아니라 알림함 기준이다. */
+    @Query(value = """
+            SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00') AS bucket, COUNT(*) AS cnt
+            FROM member_notification
+            WHERE created_at >= :from
+            GROUP BY bucket
+            ORDER BY bucket
+            """, nativeQuery = true)
+    List<HourCount> notificationsByHour(@Param("from") LocalDateTime from);
+
+    /** 퍼널 4단계(가입 → 온보딩 → 구독 → 평점)를 한 방에. 각 단계는 회원 수(중복 없음)다. */
+    @Query(value = """
+            SELECT (SELECT COUNT(*) FROM member) AS totalMembers,
+                   (SELECT COUNT(*) FROM member WHERE onboarded_at IS NOT NULL) AS onboardedMembers,
+                   (SELECT COUNT(*) FROM (
+                        SELECT member_id FROM member_favorite_player
+                        UNION
+                        SELECT member_id FROM member_team_notification_subscription
+                        UNION
+                        SELECT member_id FROM member_match_subscription) s) AS subscribedMembers,
+                   (SELECT COUNT(DISTINCT member_id) FROM live_player_rating) AS ratedMembers
+            FROM dual
+            """, nativeQuery = true)
+    MemberTotals memberTotals();
+
+    @Query(value = """
+            SELECT COALESCE(favorite_league_name, '미설정') AS label, COUNT(*) AS cnt
+            FROM member
+            GROUP BY label
+            ORDER BY cnt DESC
+            """, nativeQuery = true)
+    List<LabelCount> membersByFavoriteLeague();
+
+    @Query(value = """
+            SELECT t.team_name AS label, COUNT(*) AS cnt
+            FROM member_team_notification_subscription s
+            JOIN teams t ON t.team_id = s.team_id
+            GROUP BY t.team_id, t.team_name
+            ORDER BY cnt DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<LabelCount> topSubscribedTeams(@Param("limit") int limit);
+
+    @Query(value = """
+            SELECT p.player_name AS label, COUNT(*) AS cnt
+            FROM member_favorite_player f
+            JOIN players p ON p.player_id = f.player_id
+            GROUP BY p.player_id, p.player_name
+            ORDER BY cnt DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<LabelCount> topSubscribedPlayers(@Param("limit") int limit);
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionRepository.java
@@ -25,7 +25,8 @@ public interface MemberMatchSubscriptionRepository
 	List<String> findMatchIdsByMemberId(@Param("memberId") Long memberId);
 
 	// 백오피스 구독 탭: 구독자가 1명 이상인 경기만(인기순, 동수면 최신 경기 우선).
-	// 전체 경기는 대부분 구독자 0이라 INNER JOIN 으로 걸러낸다. q 는 경기명·팀명 검색.
+	// 전체 경기는 대부분 구독자 0이라 INNER JOIN 으로 걸러낸다. q 는 경기명·팀명 검색,
+	// state 는 업스트림 값(unstarted/inProgress/completed) 정확일치.
 	// match_date 는 UTC 저장이라 KST 변환은 컨트롤러에서 한다(리뷰 탭과 동일).
 	@Query(value = """
 			SELECT lm.id AS matchId,
@@ -42,6 +43,7 @@ public interface MemberMatchSubscriptionRepository
 			       OR LOWER(lm.match_title) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(lm.blue_team_name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(lm.red_team_name) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND (:state IS NULL OR lm.state = :state)
 			GROUP BY lm.id, lm.league_name, lm.match_title, lm.blue_team_name,
 			         lm.red_team_name, lm.state, lm.match_date
 			ORDER BY subscriberCount DESC, lm.match_date DESC
@@ -54,9 +56,11 @@ public interface MemberMatchSubscriptionRepository
 			       OR LOWER(lm.match_title) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(lm.blue_team_name) LIKE LOWER(CONCAT('%', :q, '%'))
 			       OR LOWER(lm.red_team_name) LIKE LOWER(CONCAT('%', :q, '%')))
+			  AND (:state IS NULL OR lm.state = :state)
 			""",
 			nativeQuery = true)
-	Page<SubscribedMatchView> findSubscribedMatches(@Param("q") String q, Pageable pageable);
+	Page<SubscribedMatchView> findSubscribedMatches(@Param("q") String q, @Param("state") String state,
+			Pageable pageable);
 
 	// 백오피스 구독 탭: 특정 경기를 구독한 회원 목록(최근 구독순) + 알림 토글 상태. 팀 구독과 동일 패턴.
 	@Query(value = """

--- a/src/test/java/com/toy/nar/domain/member/repository/AdminStatsRepositoryMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/AdminStatsRepositoryMySqlIntegrationTest.java
@@ -1,0 +1,198 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberMatchSubscription;
+import com.toy.nar.domain.member.entity.MemberNotification;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import com.toy.nar.domain.member.entity.MemberTeamNotificationSubscription;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.Team;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 대시보드 집계 네이티브 쿼리를 실제 MySQL 8 에서 검증한다.
+ * {@code DATE_FORMAT} 시간 버킷, 세 구독 테이블 UNION, {@code FROM dual} 서브쿼리 묶음, {@code LIMIT :limit} 바인딩은
+ * H2 나 JPQL 로는 검증이 안 되고 런타임에야 깨지는 것들이라 MySQL 대상 테스트가 필요하다.
+ *
+ * <p>로컬 dev MySQL(docker-compose, 3308)의 격리 스키마 nar_admin_stats_test 에 ddl-auto=create-drop 으로 실행한다.
+ * 사전 준비(최초 1회): CREATE DATABASE nar_admin_stats_test; GRANT ALL ON nar_admin_stats_test.* TO 'nar_id'@'%';
+ * 실행: ./gradlew test -Ddataintegrity.local.enabled=true --tests "...AdminStatsRepositoryMySqlIntegrationTest"
+ */
+@EnabledIfSystemProperty(named = "dataintegrity.local.enabled", matches = "true")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AdminStatsRepositoryMySqlIntegrationTest {
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url",
+                () -> "jdbc:mysql://localhost:3308/nar_admin_stats_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8");
+        registry.add("spring.datasource.username", () -> "nar_id");
+        registry.add("spring.datasource.password", () -> "nar_pw");
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.flyway.enabled", () -> "false");
+    }
+
+    @Autowired
+    private AdminStatsRepository repository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    // 가입 2건은 같은 시간 버킷, 1건은 다른 버킷으로 몰아 넣는다.
+    private static final LocalDateTime HOUR_A = LocalDateTime.now().minusDays(1).withHour(13).withMinute(20).withSecond(0).withNano(0);
+    private static final LocalDateTime HOUR_B = LocalDateTime.now().minusDays(1).withHour(21).withMinute(5).withSecond(0).withNano(0);
+    private static final LocalDateTime FROM = LocalDateTime.now().minusDays(3).withHour(0).withMinute(0).withSecond(0).withNano(0);
+
+    private String bucketA;
+    private String bucketB;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.execute("DELETE FROM member_favorite_player");
+        jdbc.execute("DELETE FROM member_team_notification_subscription");
+        jdbc.execute("DELETE FROM member_match_subscription");
+        jdbc.execute("DELETE FROM member_notification");
+        jdbc.execute("DELETE FROM member");
+
+        Team team = em.persist(Team.builder().name("T1").code("T1").build());
+        Player player = em.persist(Player.builder().name("Faker").build());
+
+        Member a = em.persist(Member.builder().name("가입자A").tag("0001").email("a@nar.kr").build());
+        Member b = em.persist(Member.builder().name("가입자B").tag("0002").email("b@nar.kr").build());
+        Member c = em.persist(Member.builder().name("가입자C").tag("0003").email("c@nar.kr").build());
+
+        // A: 온보딩(=선수 구독 1건 생성) + 팀·경기 구독. B: 온보딩만(관심 선수 없음). C: 아무것도 안 함.
+        a.completeOnboarding("LCK", team, List.of(player));
+        b.completeOnboarding("LPL", null, List.of());
+
+        em.persist(new MemberTeamNotificationSubscription(a, team));
+        em.persist(new MemberMatchSubscription(a, "match-1", true, true, false));
+        em.persist(new MemberNotification(a, MemberNotificationType.SET_START, "경기 시작", "T1 vs GEN", Map.of()));
+        em.persist(new MemberNotification(b, MemberNotificationType.SET_END, "경기 종료", "T1 승", Map.of()));
+        em.flush();
+
+        // 엔티티가 created_at 을 now() 로 박으므로 버킷 검증을 위해 뒤로 돌린다.
+        backdate("member", List.of(a.getId(), b.getId()), HOUR_A);
+        backdate("member", List.of(c.getId()), HOUR_B);
+        jdbc.update("UPDATE member_favorite_player SET created_at = ?", HOUR_A);
+        jdbc.update("UPDATE member_team_notification_subscription SET created_at = ?", HOUR_A);
+        jdbc.update("UPDATE member_match_subscription SET created_at = ?", HOUR_B);
+        jdbc.update("UPDATE member_notification SET created_at = ?", HOUR_B);
+        em.clear();
+
+        bucketA = bucketOf(HOUR_A);
+        bucketB = bucketOf(HOUR_B);
+    }
+
+    private void backdate(String table, List<Long> ids, LocalDateTime at) {
+        ids.forEach(id -> jdbc.update("UPDATE " + table + " SET created_at = ? WHERE id = ?", at, id));
+    }
+
+    /**
+     * 전체 앱을 띄우면 Elasticsearch 빈을 요구해 슬라이스가 뜨지 않는다 — 저장소의 다른 리포지토리 테스트와 같은 방식으로 범위를 좁힌다.
+     */
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    // 엔티티는 도메인 전체를 스캔한다(participant → game 처럼 서로 물려 있어 일부만 담으면 매핑이 깨진다).
+    // 리포지토리 스캔만 member 로 좁혀 Elasticsearch 리포지토리를 피한다.
+    @EntityScan(basePackages = "com.toy.nar.domain")
+    @EnableJpaRepositories(basePackageClasses = AdminStatsRepository.class)
+    static class TestJpaConfiguration {
+    }
+
+    private static String bucketOf(LocalDateTime at) {
+        return "%04d-%02d-%02dT%02d:00".formatted(at.getYear(), at.getMonthValue(), at.getDayOfMonth(), at.getHour());
+    }
+
+    @Test
+    void 가입은_시간_버킷으로_묶인다() {
+        var rows = repository.signupsByHour(FROM);
+
+        assertThat(rows).extracting(AdminStatsRepository.HourCount::getBucket)
+                .containsExactly(bucketA, bucketB);
+        assertThat(rows).extracting(AdminStatsRepository.HourCount::getCnt)
+                .containsExactly(2L, 1L);
+    }
+
+    @Test
+    void 구독_세_테이블이_한_버킷으로_합쳐진다() {
+        var rows = repository.subscriptionsByHour(FROM);
+
+        assertThat(rows).hasSize(2);
+        var first = rows.get(0);
+        assertThat(first.getBucket()).isEqualTo(bucketA);
+        assertThat(first.getPlayerCnt()).isEqualTo(1);
+        assertThat(first.getTeamCnt()).isEqualTo(1);
+        assertThat(first.getMatchCnt()).isZero();
+
+        var second = rows.get(1);
+        assertThat(second.getBucket()).isEqualTo(bucketB);
+        assertThat(second.getMatchCnt()).isEqualTo(1);
+    }
+
+    @Test
+    void 알림_발송량도_시간_버킷으로_나온다() {
+        var rows = repository.notificationsByHour(FROM);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getBucket()).isEqualTo(bucketB);
+        assertThat(rows.get(0).getCnt()).isEqualTo(2);
+    }
+
+    @Test
+    void 시작시각_이전_데이터는_빠진다() {
+        assertThat(repository.signupsByHour(LocalDateTime.now().plusDays(1))).isEmpty();
+    }
+
+    @Test
+    void 퍼널_네_단계가_회원_수로_집계된다() {
+        var totals = repository.memberTotals();
+
+        assertThat(totals.getTotalMembers()).isEqualTo(3);
+        assertThat(totals.getOnboardedMembers()).isEqualTo(2);
+        assertThat(totals.getSubscribedMembers()).isEqualTo(1); // A 는 세 종류 구독해도 1명
+        assertThat(totals.getRatedMembers()).isZero();
+    }
+
+    @Test
+    void 분포_쿼리는_상위부터_정렬해_내려준다() {
+        assertThat(repository.membersByFavoriteLeague())
+                .extracting(AdminStatsRepository.LabelCount::getLabel)
+                .containsExactlyInAnyOrder("LCK", "LPL", "미설정");
+
+        assertThat(repository.topSubscribedTeams(10))
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getLabel()).isEqualTo("T1");
+                    assertThat(row.getCnt()).isEqualTo(1);
+                });
+
+        assertThat(repository.topSubscribedPlayers(10))
+                .singleElement()
+                .satisfies(row -> assertThat(row.getLabel()).isEqualTo("Faker"));
+    }
+}

--- a/src/test/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionBackofficeMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/MemberMatchSubscriptionBackofficeMySqlIntegrationTest.java
@@ -62,10 +62,11 @@ class MemberMatchSubscriptionBackofficeMySqlIntegrationTest {
 	@BeforeEach
 	void seed() {
 		// m-hot: 구독자 2명, m-cold: 1명, m-none: 0명(목록에서 빠져야 함).
+		// m-cold 만 unstarted — state 필터 검증용.
 		matchRepository.saveAll(List.of(
-				match("m-hot", "LCK", LocalDateTime.of(2026, 7, 10, 9, 0), "T1", "GEN"),
-				match("m-cold", "LCK", LocalDateTime.of(2026, 7, 11, 9, 0), "KT", "DK"),
-				match("m-none", "LEC", LocalDateTime.of(2026, 7, 12, 9, 0), "G2", "FNC")));
+				match("m-hot", "LCK", LocalDateTime.of(2026, 7, 10, 9, 0), "T1", "GEN", "completed"),
+				match("m-cold", "LCK", LocalDateTime.of(2026, 7, 11, 9, 0), "KT", "DK", "unstarted"),
+				match("m-none", "LEC", LocalDateTime.of(2026, 7, 12, 9, 0), "G2", "FNC", "unstarted")));
 
 		Member alice = new Member("앨리스", "1234", "a@nar.kr");
 		Member bob = new Member("밥", "5678", "b@nar.kr");
@@ -82,7 +83,7 @@ class MemberMatchSubscriptionBackofficeMySqlIntegrationTest {
 	@Test
 	@DisplayName("구독자가 있는 경기만 구독자 수 내림차순으로 내려준다")
 	void listsOnlySubscribedMatchesOrderedByCount() {
-		var page = repository.findSubscribedMatches(null, PageRequest.of(0, 20));
+		var page = repository.findSubscribedMatches(null, null, PageRequest.of(0, 20));
 
 		assertThat(page.getTotalElements()).isEqualTo(2);
 		assertThat(page.getContent()).extracting(v -> v.getMatchId() + ":" + v.getSubscriberCount())
@@ -92,9 +93,18 @@ class MemberMatchSubscriptionBackofficeMySqlIntegrationTest {
 	@Test
 	@DisplayName("q는 경기명·팀명 부분일치로 거른다")
 	void searchMatchesTeamName() {
-		var page = repository.findSubscribedMatches("gen", PageRequest.of(0, 20));
+		var page = repository.findSubscribedMatches("gen", null, PageRequest.of(0, 20));
 
 		assertThat(page.getContent()).extracting(v -> v.getMatchId()).containsExactly("m-hot");
+	}
+
+	@Test
+	@DisplayName("state 는 진행 상태 정확일치로 거른다")
+	void filtersByState() {
+		var page = repository.findSubscribedMatches(null, "unstarted", PageRequest.of(0, 20));
+
+		assertThat(page.getTotalElements()).isEqualTo(1);
+		assertThat(page.getContent()).extracting(v -> v.getMatchId()).containsExactly("m-cold");
 	}
 
 	@Test
@@ -117,13 +127,14 @@ class MemberMatchSubscriptionBackofficeMySqlIntegrationTest {
 		assertThat(page.getContent()).extracting(v -> v.getEmail()).containsExactly("a@nar.kr");
 	}
 
-	private static LeagueMatch match(String id, String league, LocalDateTime date, String blue, String red) {
+	private static LeagueMatch match(String id, String league, LocalDateTime date, String blue, String red,
+			String state) {
 		return LeagueMatch.builder()
 				.id(id)
 				.leagueName(league)
 				.matchTitle(blue + " vs " + red)
 				.matchDate(date)
-				.state("completed")
+				.state(state)
 				.blueTeamName(blue)
 				.redTeamName(red)
 				.build();


### PR DESCRIPTION
## 무엇

한 번에 배포하려고 **#342(경기 구독 목록 진행 상태 필터)를 이 브랜치에 머지해 묶었다.** 두 변경이 모두 `BackofficeController` 를 건드려서, 따로 머지하면 나중 것이 매번 충돌한다.

- (a) 대시보드 집계 API — 이 PR 원래 내용
- (b) #342 경기 구독 상태 필터 — `origin/feat/match-state-filter` 머지 커밋으로 포함

> #342 는 내용이 여기 들어왔으므로, 이 PR 머지 후 닫으면 된다(squash 머지면 자동으로 닫히지 않는다).

## (a) 대시보드 집계 API

지금 `/api/admin/*` 는 전부 목록(Page) 조회라 집계가 없어서, 프론트가 전체 목록을 받아 세는 것 말고는 방법이 없었다.

```
GET /api/admin/stats/series?days=30
  → { from, bucketUnit: "HOUR",
      signups:       [{ bucket: "2026-08-02T13:00", count }],
      subscriptions: [{ bucket, player, team, match }],
      notifications: [{ bucket, count }] }

GET /api/admin/stats/overview
  → { totalMembers, onboardedMembers, subscribedMembers, ratedMembers,
      leagues[], teams[](TOP 10), players[](TOP 10) }   // { label, count }
```

### 설계 결정

1. **시계열은 1시간 버킷으로만 내려준다.** 일별 차트는 프론트가 같은 날짜끼리 합치고, "현재 시각 기준 직전 24시간" 롤링 뷰는 마지막 이틀 버킷으로 조립한다. 두 화면이 쿼리 하나를 공유하고, 롤링 윈도가 자정을 가로질러도 그대로 만들어진다.
2. **값이 0인 버킷은 행을 만들지 않는다(sparse).** 빈 구간 채우기는 화면 쪽 책임.
3. **구독 세 테이블은 한 쿼리.** 선수·팀·경기 각각 시간별로 접은 뒤 UNION ALL → 스캔은 테이블당 한 번, UNION 에 올라오는 행은 (구간 시간 수 × 3).
4. **퍼널·분포는 시계열과 분리.** 기간 필터와 무관한 값이라 기간 바꿀 때마다 다시 계산할 이유가 없다.
5. 집계 쿼리는 회원·구독·알림·평점 네 도메인을 가로질러서, 엔티티별 리포지토리에 흩지 않고 `AdminStatsRepository` 한 곳에 모았다.

## 테스트

로컬 MySQL 8(docker-compose 3308, 격리 스키마 `nar_admin_stats_test`) 대상 통합 테스트. 네이티브 SQL(DATE_FORMAT 버킷, UNION 파생 테이블, `FROM dual` 서브쿼리 묶음, `LIMIT :limit` 바인딩)은 JPQL·H2 로 검증이 안 되고 런타임에야 깨진다. 기존 리포지토리 테스트와 동일하게 `-Ddataintegrity.local.enabled=true` 로 게이팅.

묶은 상태에서 두 PR 테스트를 함께 재실행(`--rerun-tasks`)해 확인했다.

```
AdminStatsRepositoryMySqlIntegrationTest              6 tests
MemberMatchSubscriptionBackofficeMySqlIntegrationTest 5 tests
BUILD SUCCESSFUL
```

사전 준비(최초 1회): `CREATE DATABASE nar_admin_stats_test; GRANT ALL ON nar_admin_stats_test.* TO 'nar_id'@'%';`

## 남는 것 / 주의

- `member_notification` 에는 `(member_id, created_at)` 복합 인덱스만 있어 기간 스캔이 인덱스를 타지 않는다. 현재 데이터량(회원 3.3k)에선 무시 가능해 인덱스 마이그레이션은 넣지 않았다. 알림 행이 수십만을 넘어가면 `created_at` 단일 인덱스 추가 필요.
- `ratedMembers` 는 `live_player_rating` 의 distinct 회원 수. 테스트에서는 0건 경로만 확인했다(엔티티 NOT NULL 컬럼이 많아 픽스처 생략).
- 보안: `/api/admin/**` 가 이미 `hasRole("ADMIN")` 이라 새 엔드포인트도 그대로 보호된다.
- 프론트 대시보드 화면은 NAR-GG/warding-backoffice-fe#27. **이 PR 이 배포된 뒤** 머지해야 화면이 실데이터로 뜬다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)