### PR TITLE
perf: 대시보드 집계 3.3초 — 알림 분리 + 정수 버킷 + 1분 캐시

### DIFF
--- a/src/main/java/com/toy/nar/api/admin/BackofficeController.java
+++ b/src/main/java/com/toy/nar/api/admin/BackofficeController.java
@@ -1,5 +1,6 @@
 package com.toy.nar.api.admin;
 
+import com.toy.nar.app.admin.dto.StatsNotificationsResponse;
 import com.toy.nar.app.admin.dto.StatsOverviewResponse;
 import com.toy.nar.app.admin.dto.StatsSeriesResponse;
 import com.toy.nar.app.admin.service.AdminStatsService;
@@ -297,12 +298,18 @@ public class BackofficeController {
     }
 
     /**
-     * 대시보드 시계열 — 가입·구독·알림을 1시간 버킷으로. 값 0인 시간대는 행이 없다.
+     * 대시보드 시계열 — 가입·구독을 1시간 버킷으로. 값 0인 시간대는 행이 없다.
      * 일별 화면은 프론트가 시간 버킷을 합쳐 그리고, 24시간 롤링 뷰는 마지막 이틀 버킷으로 만든다.
      */
     @GetMapping("/stats/series")
     public StatsSeriesResponse statsSeries(@RequestParam(defaultValue = "30") int days) {
         return adminStatsService.series(days);
+    }
+
+    /** 알림 발송량만 분리 — 35만 행 집계라 혼자 느리다. 나머지 카드가 먼저 그려지게 한다. */
+    @GetMapping("/stats/notifications")
+    public StatsNotificationsResponse statsNotifications(@RequestParam(defaultValue = "30") int days) {
+        return adminStatsService.notifications(days);
     }
 
     /** 대시보드 퍼널·분포 — 기간과 무관한 값이라 시계열과 분리. */

--- a/src/main/java/com/toy/nar/app/admin/dto/StatsNotificationsResponse.java
+++ b/src/main/java/com/toy/nar/app/admin/dto/StatsNotificationsResponse.java
@@ -1,0 +1,17 @@
+package com.toy.nar.app.admin.dto;
+
+import com.toy.nar.app.admin.dto.StatsSeriesResponse.CountPoint;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 알림 발송량 시계열. 시계열 응답에서 떼어낸 이유는 비용 때문이다 —
+ * 알림은 대량 발송이라 행이 35만 개고 기간을 좁혀도 스캔량이 줄지 않는다(모두 최근 몇 주에 몰려 있음).
+ * 이 카드만 늦게 채워지고 나머지 대시보드는 먼저 그려지도록 분리했다.
+ */
+public record StatsNotificationsResponse(
+        LocalDateTime from,
+        String bucketUnit,
+        List<CountPoint> notifications
+) {}

--- a/src/main/java/com/toy/nar/app/admin/dto/StatsSeriesResponse.java
+++ b/src/main/java/com/toy/nar/app/admin/dto/StatsSeriesResponse.java
@@ -7,15 +7,17 @@ import java.util.List;
  * 백오피스 대시보드 시계열. 전부 <b>1시간 버킷</b>이고 값이 0인 시간대는 행이 없다(sparse).
  * 일별 차트는 프론트가 같은 날짜끼리 합쳐서 그린다.
  *
- * @param from   조회 시작 시각(이 시각 이후 데이터만)
+ * <p>알림 발송량은 여기 없다 — 35만 행 집계라 혼자 초 단위로 걸려서 {@code /stats/notifications} 로 떼어 놨다.
+ * 나머지 카드가 먼저 그려지게 하려는 것.
+ *
+ * @param from       조회 시작 시각(이 시각 이후 데이터만)
  * @param bucketUnit 버킷 단위. 지금은 항상 {@code HOUR}
  */
 public record StatsSeriesResponse(
         LocalDateTime from,
         String bucketUnit,
         List<CountPoint> signups,
-        List<SubscriptionPoint> subscriptions,
-        List<CountPoint> notifications
+        List<SubscriptionPoint> subscriptions
 ) {
     /** @param bucket {@code 2026-08-02T13:00} (서버 로컬시각) */
     public record CountPoint(String bucket, long count) {}

--- a/src/main/java/com/toy/nar/app/admin/service/AdminStatsService.java
+++ b/src/main/java/com/toy/nar/app/admin/service/AdminStatsService.java
@@ -1,14 +1,19 @@
 package com.toy.nar.app.admin.service;
 
+import com.toy.nar.app.admin.dto.StatsNotificationsResponse;
 import com.toy.nar.app.admin.dto.StatsOverviewResponse;
 import com.toy.nar.app.admin.dto.StatsSeriesResponse;
 import com.toy.nar.domain.member.repository.AdminStatsRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
@@ -16,6 +21,9 @@ import java.util.List;
  *
  * <p>기간은 <b>일 단위로 잘라 자정부터</b> 읽는다. 화면의 24시간 롤링 윈도는 마지막 이틀치 시간 버킷에서
  * 프론트가 만들어 쓴다(그래서 최소 조회 기간이 2일).
+ *
+ * <p>세 응답 모두 1분 캐시다. 운영 지표라 1분 지연은 무해하고, 대신 기간 토글·새로고침·다른 관리자 접속이
+ * 전부 캐시 히트가 된다. 특히 알림 집계는 프로덕션에서 초 단위로 걸리는 쿼리다.
  */
 @Service
 @RequiredArgsConstructor
@@ -24,27 +32,40 @@ public class AdminStatsService {
     private static final int MIN_DAYS = 2;
     private static final int MAX_DAYS = 90;
     private static final int TOP_LIMIT = 10;
+    private static final String HOUR = "HOUR";
+    private static final DateTimeFormatter BUCKET_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:00");
 
     private final AdminStatsRepository statsRepository;
 
+    @Cacheable(cacheNames = "adminStatsSeries", key = "#days")
     @Transactional(readOnly = true)
     public StatsSeriesResponse series(int days) {
-        LocalDateTime from = LocalDate.now().minusDays(clampDays(days) - 1L).atStartOfDay();
+        LocalDateTime from = fromOf(days);
 
         List<StatsSeriesResponse.CountPoint> signups = statsRepository.signupsByHour(from).stream()
-                .map(row -> new StatsSeriesResponse.CountPoint(row.getBucket(), row.getCnt()))
+                .map(row -> new StatsSeriesResponse.CountPoint(bucketLabel(row.getBucket()), row.getCnt()))
                 .toList();
         List<StatsSeriesResponse.SubscriptionPoint> subscriptions = statsRepository.subscriptionsByHour(from).stream()
-                .map(row -> new StatsSeriesResponse.SubscriptionPoint(
-                        row.getBucket(), row.getPlayerCnt(), row.getTeamCnt(), row.getMatchCnt()))
-                .toList();
-        List<StatsSeriesResponse.CountPoint> notifications = statsRepository.notificationsByHour(from).stream()
-                .map(row -> new StatsSeriesResponse.CountPoint(row.getBucket(), row.getCnt()))
+                .map(row -> new StatsSeriesResponse.SubscriptionPoint(bucketLabel(row.getBucket()),
+                        row.getPlayerCnt(), row.getTeamCnt(), row.getMatchCnt()))
                 .toList();
 
-        return new StatsSeriesResponse(from, "HOUR", signups, subscriptions, notifications);
+        return new StatsSeriesResponse(from, HOUR, signups, subscriptions);
     }
 
+    @Cacheable(cacheNames = "adminStatsNotifications", key = "#days")
+    @Transactional(readOnly = true)
+    public StatsNotificationsResponse notifications(int days) {
+        LocalDateTime from = fromOf(days);
+
+        List<StatsSeriesResponse.CountPoint> points = statsRepository.notificationsByHour(from).stream()
+                .map(row -> new StatsSeriesResponse.CountPoint(bucketLabel(row.getBucket()), row.getCnt()))
+                .toList();
+
+        return new StatsNotificationsResponse(from, HOUR, points);
+    }
+
+    @Cacheable(cacheNames = "adminStatsOverview", key = "'all'")
     @Transactional(readOnly = true)
     public StatsOverviewResponse overview() {
         var totals = statsRepository.memberTotals();
@@ -56,6 +77,16 @@ public class AdminStatsService {
                 toLabelCounts(statsRepository.membersByFavoriteLeague()),
                 toLabelCounts(statsRepository.topSubscribedTeams(TOP_LIMIT)),
                 toLabelCounts(statsRepository.topSubscribedPlayers(TOP_LIMIT)));
+    }
+
+    private static LocalDateTime fromOf(int days) {
+        return LocalDate.now().minusDays(clampDays(days) - 1L).atStartOfDay();
+    }
+
+    /** 에폭 시(정수) → {@code 2026-08-02T13:00}. 포맷을 SQL 이 아니라 여기서 하는 이유는 리포지토리 주석 참고. */
+    private static String bucketLabel(long epochHour) {
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(epochHour * 3600), ZoneId.systemDefault())
+                .format(BUCKET_FORMAT);
     }
 
     private static List<StatsOverviewResponse.LabelCount> toLabelCounts(

--- a/src/main/java/com/toy/nar/config/CacheConfig.java
+++ b/src/main/java/com/toy/nar/config/CacheConfig.java
@@ -19,6 +19,7 @@ public class CacheConfig {
 	private static final long SCHEDULE_MAX_SIZE = 8192;    // 1MB
 	private static final long MATCH_DETAIL_MAX_SIZE = 9892; // 4MB
 	private static final long GAME_RECORD_MAX_SIZE = 10347; // 6MB
+	private static final long ADMIN_STATS_MAX_SIZE = 16;   // 기간(days) 조합 몇 개뿐
 
 	@Bean
 	public CacheManager cacheManager() {
@@ -30,7 +31,13 @@ public class CacheConfig {
 			// 불변 데이터 → TTL 제거, size limit만 적용 (LRU 정책)
 			createCacheNoTTL("dailySchedules", SCHEDULE_MAX_SIZE),
 			createCacheNoTTL("matchDetails", MATCH_DETAIL_MAX_SIZE),
-			createCacheNoTTL("gameRecords", GAME_RECORD_MAX_SIZE)
+			createCacheNoTTL("gameRecords", GAME_RECORD_MAX_SIZE),
+
+			// 백오피스 대시보드 집계. 알림 시계열이 35만 행 스캔이라 매 로드마다 초 단위로 걸린다.
+			// 운영 지표라 1분 지연은 무해 → 첫 로드만 값을 치르고 기간 토글·다른 관리자는 캐시 히트.
+			createCacheWithTTL("adminStatsSeries", 1, TimeUnit.MINUTES, ADMIN_STATS_MAX_SIZE),
+			createCacheWithTTL("adminStatsNotifications", 1, TimeUnit.MINUTES, ADMIN_STATS_MAX_SIZE),
+			createCacheWithTTL("adminStatsOverview", 1, TimeUnit.MINUTES, ADMIN_STATS_MAX_SIZE)
 		);
 
 		SimpleCacheManager cacheManager = new SimpleCacheManager();

--- a/src/main/java/com/toy/nar/domain/member/repository/AdminStatsRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/AdminStatsRepository.java
@@ -17,18 +17,22 @@ import java.util.List;
  * <p>시간 버킷은 <b>1시간</b> 단위로만 내려준다. 일별 화면은 프론트에서 시간 버킷을 합쳐 쓴다
  * (일별/24시간 뷰가 쿼리 하나를 공유하고, 24시간 롤링 윈도가 자정을 가로질러도 그대로 만들어진다).
  * 값이 0인 버킷은 행 자체가 없다 — 빈 구간 채우기는 화면 쪽 책임.
+ *
+ * <p>버킷 키는 <b>에폭 시(epoch hour)</b> 정수다. 문자열({@code DATE_FORMAT})로 그룹핑하면 35만 행짜리
+ * 알림 집계가 프로덕션에서 3,311ms 걸렸고, 같은 쿼리를 정수 키로 바꾸니 1,257ms 였다(2026-08-03 EXPLAIN ANALYZE
+ * 실측). 사람이 읽을 포맷 변환은 서비스에서 한다.
  */
 public interface AdminStatsRepository extends Repository<Member, Long> {
 
-    /** {@code bucket} = {@code 2026-08-02T13:00} 형식(서버 로컬시각), {@code cnt} = 그 1시간 동안의 건수. */
+    /** {@code bucket} = 에폭 시(= 유닉스 시각 / 3600), {@code cnt} = 그 1시간 동안의 건수. */
     interface HourCount {
-        String getBucket();
+        long getBucket();
 
         long getCnt();
     }
 
     interface SubscriptionHourCount {
-        String getBucket();
+        long getBucket();
 
         long getPlayerCnt();
 
@@ -54,7 +58,7 @@ public interface AdminStatsRepository extends Repository<Member, Long> {
     }
 
     @Query(value = """
-            SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00') AS bucket, COUNT(*) AS cnt
+            SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600) AS bucket, COUNT(*) AS cnt
             FROM member
             WHERE created_at >= :from
             GROUP BY bucket
@@ -72,13 +76,13 @@ public interface AdminStatsRepository extends Repository<Member, Long> {
                    SUM(t) AS teamCnt,
                    SUM(m) AS matchCnt
             FROM (
-                SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00') AS bucket, COUNT(*) AS p, 0 AS t, 0 AS m
+                SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600) AS bucket, COUNT(*) AS p, 0 AS t, 0 AS m
                 FROM member_favorite_player WHERE created_at >= :from GROUP BY bucket
                 UNION ALL
-                SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00'), 0, COUNT(*), 0
+                SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600), 0, COUNT(*), 0
                 FROM member_team_notification_subscription WHERE created_at >= :from GROUP BY 1
                 UNION ALL
-                SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00'), 0, 0, COUNT(*)
+                SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600), 0, 0, COUNT(*)
                 FROM member_match_subscription WHERE created_at >= :from GROUP BY 1
             ) x
             GROUP BY bucket
@@ -86,9 +90,15 @@ public interface AdminStatsRepository extends Repository<Member, Long> {
             """, nativeQuery = true)
     List<SubscriptionHourCount> subscriptionsByHour(@Param("from") LocalDateTime from);
 
-    /** 인앱 알림 생성 건수 = 발송량. 푸시 전송 결과 테이블(delivery)이 아니라 알림함 기준이다. */
+    /**
+     * 인앱 알림 생성 건수 = 발송량. 푸시 전송 결과 테이블(delivery)이 아니라 알림함 기준이다.
+     *
+     * <p>대시보드에서 제일 비싼 쿼리. 알림은 대량 발송이라 35만 행이 최근 몇 주에 몰려 있어
+     * 기간을 좁혀도 스캔량이 줄지 않고(30일·60일 모두 전량), 모든 행이 조건에 걸려 인덱스 seek 도 의미가 없다.
+     * 그래서 별도 엔드포인트 + 캐시로 분리해 나머지 카드가 먼저 그려지게 한다.
+     */
     @Query(value = """
-            SELECT DATE_FORMAT(created_at, '%Y-%m-%dT%H:00') AS bucket, COUNT(*) AS cnt
+            SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600) AS bucket, COUNT(*) AS cnt
             FROM member_notification
             WHERE created_at >= :from
             GROUP BY bucket

--- a/src/test/java/com/toy/nar/domain/member/repository/AdminStatsRepositoryMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/AdminStatsRepositoryMySqlIntegrationTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 대시보드 집계 네이티브 쿼리를 실제 MySQL 8 에서 검증한다.
- * {@code DATE_FORMAT} 시간 버킷, 세 구독 테이블 UNION, {@code FROM dual} 서브쿼리 묶음, {@code LIMIT :limit} 바인딩은
+ * 정수(에폭 시) 시간 버킷, 세 구독 테이블 UNION, {@code FROM dual} 서브쿼리 묶음, {@code LIMIT :limit} 바인딩은
  * H2 나 JPQL 로는 검증이 안 되고 런타임에야 깨지는 것들이라 MySQL 대상 테스트가 필요하다.
  *
  * <p>로컬 dev MySQL(docker-compose, 3308)의 격리 스키마 nar_admin_stats_test 에 ddl-auto=create-drop 으로 실행한다.
@@ -67,8 +67,8 @@ class AdminStatsRepositoryMySqlIntegrationTest {
     private static final LocalDateTime HOUR_B = LocalDateTime.now().minusDays(1).withHour(21).withMinute(5).withSecond(0).withNano(0);
     private static final LocalDateTime FROM = LocalDateTime.now().minusDays(3).withHour(0).withMinute(0).withSecond(0).withNano(0);
 
-    private String bucketA;
-    private String bucketB;
+    private long bucketA;
+    private long bucketB;
 
     @BeforeEach
     void setUp() {
@@ -124,8 +124,10 @@ class AdminStatsRepositoryMySqlIntegrationTest {
     static class TestJpaConfiguration {
     }
 
-    private static String bucketOf(LocalDateTime at) {
-        return "%04d-%02d-%02dT%02d:00".formatted(at.getYear(), at.getMonthValue(), at.getDayOfMonth(), at.getHour());
+    /** 리포지토리는 에폭 시(유닉스 시각/3600) 정수를 버킷 키로 준다. */
+    private static long bucketOf(LocalDateTime at) {
+        return at.withMinute(0).withSecond(0).withNano(0)
+                .atZone(java.time.ZoneId.systemDefault()).toEpochSecond() / 3600;
     }
 
     @Test


### PR DESCRIPTION
## 측정

프로덕션 DB 에서 `EXPLAIN ANALYZE` 로 대시보드 쿼리를 하나씩 재봤다(읽기만 수행).

| 쿼리 | 실측 |
|---|---|
| **알림 시계열** | **3,311ms** |
| 가입 시계열 | 60ms |
| 퍼널·분포(overview) | ~5ms |

지연은 전부 알림 한 쿼리다.

```
-> Aggregate using temporary table (actual time=3311..3311 rows=347)
   -> Filter: created_at >= now()-60day (actual time=0.05..296 rows=356572)
      -> Covering index scan using idx_member_notification_member_created (actual time=0.04..182 rows=356572)
```

## 왜 인덱스로는 안 되는가

`member_notification` 은 35.7만 행인데 **그중 34.4만 행이 최근 7일**에 몰려 있다(대량 발송). 그래서

- 조회 기간을 30일로 좁혀도 스캔 대상이 그대로다(30일도 60일도 전량).
- 모든 행이 `WHERE` 를 통과하므로 `created_at` 인덱스를 추가해도 range seek 이 성립하지 않는다.
- 실제 비용도 스캔(182ms)이 아니라 **35만 행을 `DATE_FORMAT` 문자열 키로 temp table 에 그룹핑**하는 3.1초다.

## 무엇을 했나

1. **버킷 키 문자열 → 정수(에폭 시).** 같은 쿼리 **3,311ms → 1,257ms** (프로덕션 실측). 사람이 읽을 `2026-08-02T13:00` 포맷 변환은 서비스에서 한다.
2. **알림 집계를 `GET /api/admin/stats/notifications` 로 분리.** 가입·구독·퍼널이 먼저 그려지고 느린 카드만 나중에 채워진다. 프론트도 별도 쿼리로 붙는다.
3. **Caffeine 1분 캐시** 3종(`adminStatsSeries` / `adminStatsNotifications` / `adminStatsOverview`). 운영 지표라 1분 지연은 무해하고, 기간 토글·새로고침·다른 관리자 접속이 전부 캐시 히트가 된다.

결과적으로 첫 로드는 대시보드 뼈대 ~100ms + 알림 카드 ~1.3초, 이후 1분간은 전부 캐시.

## 안 한 것

시간별 롤업 테이블. 지금 규모에서는 위 세 가지로 충분하다. 알림이 지금 속도(월 35만)로 쌓여 연 400만 행이 되면 그때 크론 집계 테이블을 도입하는 게 맞다.

## 호환성

`/stats/series` 응답에서 `notifications` 필드가 빠진다. 프론트 PR 과 함께 배포해야 알림 카드가 채워진다(백엔드 먼저). 프론트가 먼저 올라가도 나머지 카드는 정상 동작하고 알림 카드만 비어 보인다.

## 테스트

`AdminStatsRepositoryMySqlIntegrationTest` 6건 — 버킷 키가 정수로 바뀐 만큼 단언도 정수로 수정. 로컬 MySQL 8 대상 재실행 통과.

```
./gradlew test -Ddataintegrity.local.enabled=true --tests "*AdminStatsRepositoryMySqlIntegrationTest*"
BUILD SUCCESSFUL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)