### PR TITLE
feat: iOS Live Activity 서버 푸시(APNs 직결) — 기본 OFF

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,11 +76,16 @@ jobs:
         uses: appleboy/ssh-action@v0.1.6
         env:
           FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
+          # iOS Live Activity 푸시용 APNs .p8 (base64). 비어 있으면 설치·마운트를 건너뛰고
+          # APNS_ENABLED 가 false 로 남아 발송 경로 전체가 skip 된다.
+          APNS_KEY_BASE64: ${{ secrets.APNS_KEY_BASE64 }}
+          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID }}
+          APNS_TEAM_ID: ${{ secrets.APNS_TEAM_ID }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: FIREBASE_SERVICE_ACCOUNT_BASE64
+          envs: FIREBASE_SERVICE_ACCOUNT_BASE64,APNS_KEY_BASE64,APNS_KEY_ID,APNS_TEAM_ID
           script: |
             set -eu
 
@@ -96,6 +101,29 @@ jobs:
               | base64 --decode \
               | sudo tee "${FIREBASE_SECRET_FILE}" > /dev/null
             sudo chmod 600 "${FIREBASE_SECRET_FILE}"
+
+            # iOS Live Activity 용 APNs 인증 키(.p8).
+            # 키가 아직 없으면 시크릿이 비어 있고, 그러면 설치·마운트를 건너뛴 채
+            # APNS_ENABLED=false 로 떠서 기존 배포와 동작이 같다(발송 경로 전체 skip).
+            APNS_SECRET_FILE="${FIREBASE_SECRET_DIR}/apns-auth-key.p8"
+            APNS_MOUNT_ARGS=""
+            APNS_ENV_ARGS=""
+            if [ -n "${APNS_KEY_BASE64:-}" ]; then
+              echo "Installing APNs auth key..."
+              printf '%s' "${APNS_KEY_BASE64}" \
+                | base64 --decode \
+                | sudo tee "${APNS_SECRET_FILE}" > /dev/null
+              sudo chmod 600 "${APNS_SECRET_FILE}"
+              APNS_MOUNT_ARGS="-v ${APNS_SECRET_FILE}:/run/secrets/apns-auth-key.p8:ro"
+              APNS_ENV_ARGS="-e APNS_ENABLED=true \
+                -e APNS_KEY_PATH=/run/secrets/apns-auth-key.p8 \
+                -e APNS_KEY_ID=${APNS_KEY_ID:-} \
+                -e APNS_TEAM_ID=${APNS_TEAM_ID:-} \
+                -e APNS_BUNDLE_ID=com.nar.wardingapp"
+            else
+              echo "APNS_KEY_BASE64 not set — Live Activity 푸시 비활성 상태로 배포합니다."
+              sudo rm -f "${APNS_SECRET_FILE}"
+            fi
 
             echo "Checking disk usage before cleanup..."
             df -h
@@ -176,6 +204,8 @@ jobs:
               -e JAVA_TOOL_OPTIONS="-Xmx768m -javaagent:/whatap/${WHATAP_JAR} --add-opens=java.base/java.lang=ALL-UNNAMED -Dwhatap.oname=${NEW_NAME}" \
               -v "${FIREBASE_SECRET_FILE}:/run/secrets/firebase-service-account.json:ro" \
               -v /opt/whatap:/whatap \
+              ${APNS_MOUNT_ARGS} \
+              ${APNS_ENV_ARGS} \
               "${APP_IMAGE}"
 
             # micro+swap 환경은 기동이 느릴 수 있어 상한 120초(60회 x 2초)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,13 @@ DISCORD_ROSTER_WEBHOOK_URL                # LCK 로스터 변동 알림. 비우�
 GOOGLE_DRIVE_CSV_ID
 RIOT_MONITOR_ENABLED, RIOT_API_ENABLED   # feature flags for scheduling
 JWT_SECRET
+
+# iOS Live Activity 서버 푸시 (APNs 직결). 5개가 모두 채워져야 발송한다 — 하나라도 비면 전 구간 skip.
+# FCM 으로는 대체 불가: ActivityKit 푸시 토큰은 FCM 등록 토큰이 아니다.
+APNS_ENABLED                             # 기본 false
+APNS_KEY_PATH                            # Apple Developer 에서 받은 .p8 파일 경로
+APNS_KEY_ID, APNS_TEAM_ID, APNS_BUNDLE_ID
+APNS_HOST                                # 기본 https://api.push.apple.com (개발 빌드는 api.sandbox.push.apple.com)
 ```
 
 ### 스케줄러 전역 스위치

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,8 @@ tasks.register('generateJooq', JavaExec) {
 tasks.named('test') {
 	useJUnitPlatform()
 	systemProperties System.properties.findAll { key, _ ->
-		key.startsWith('benchmark.') || key.startsWith('deadlock.') || key.startsWith('dataintegrity.') || key.startsWith('fullcontext.')
+		key.startsWith('benchmark.') || key.startsWith('deadlock.') || key.startsWith('dataintegrity.')
+				|| key.startsWith('fullcontext.') || key.startsWith('apns.')
 	}
 }
 

--- a/src/main/java/com/toy/nar/api/mobile/liveactivity/MobileLiveActivityController.java
+++ b/src/main/java/com/toy/nar/api/mobile/liveactivity/MobileLiveActivityController.java
@@ -1,0 +1,53 @@
+package com.toy.nar.api.mobile.liveactivity;
+
+import com.toy.nar.app.mobile.liveactivity.LiveActivityTokenService;
+import com.toy.nar.app.mobile.liveactivity.dto.LiveActivityTokenRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mobile. Live Activity", description = "iOS 잠금화면 실시간 경기 카드의 ActivityKit 푸시 토큰 관리 API")
+@RestController
+@RequestMapping("/api/mobile/me/live-activities")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class MobileLiveActivityController {
+
+	private final LiveActivityTokenService tokenService;
+
+	@Operation(
+			summary = "Live Activity 푸시 토큰 등록/갱신",
+			description = "카드를 띄울 때 ActivityKit 이 준 토큰을 올린다. 토큰은 액티비티 단위라 "
+					+ "카드마다 새로 발급되고 수명 중 갱신될 수 있으므로, 받을 때마다 그대로 호출하면 된다. "
+					+ "FCM 기기 토큰(/api/mobile/me/devices)과는 다른 값이다.")
+	@PostMapping
+	public ResponseEntity<Void> register(
+			@AuthenticationPrincipal Long memberId,
+			@Valid @RequestBody LiveActivityTokenRequest request) {
+		tokenService.register(memberId, request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(
+			summary = "Live Activity 푸시 토큰 해제",
+			description = "사용자가 카드를 직접 내렸을 때 호출한다. 매치 종료 시에는 서버가 알아서 정리한다.")
+	@DeleteMapping
+	public ResponseEntity<Void> unregister(
+			@AuthenticationPrincipal Long memberId,
+			@Parameter(description = "등록할 때 올린 ActivityKit 푸시 토큰")
+			@RequestParam String pushToken) {
+		tokenService.unregister(memberId, pushToken);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -375,11 +375,12 @@ public class LivePollingScheduler {
 							activeGame.blueTeamName(),
 							activeGame.redTeamName());
 				}
-				pushLiveActivitySetStart(activeGame);
 			} catch (Exception e) {
 				log.warn("[live-notify] set-start failed gameId={} matchId={}: {}",
 						activeGame.gameId(), activeGame.matchId(), e.getMessage());
 			}
+			// 디스코드·FCM 실패가 카드 갱신까지 막지 않도록 try 밖에서 부른다(SET_END 와 동일).
+			pushLiveActivitySetStart(activeGame);
 		});
 	}
 

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -48,6 +48,7 @@ public class LivePollingScheduler {
 	private final CacheEvictionService cacheEvictionService;
 	private final NotificationService notificationService;
 	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
+	private final com.toy.nar.app.mobile.push.LiveActivityPushService liveActivityPushService;
 	private final LiveFrameStallTracker frameStallTracker;
 	private final com.toy.nar.app.lolesports.repository.LeagueMatchRepository leagueMatchRepository;
 	@org.springframework.beans.factory.annotation.Qualifier("applicationTaskExecutor")
@@ -374,11 +375,32 @@ public class LivePollingScheduler {
 							activeGame.blueTeamName(),
 							activeGame.redTeamName());
 				}
+				pushLiveActivitySetStart(activeGame);
 			} catch (Exception e) {
 				log.warn("[live-notify] set-start failed gameId={} matchId={}: {}",
 						activeGame.gameId(), activeGame.matchId(), e.getMessage());
 			}
 		});
+	}
+
+	/**
+	 * iOS Live Activity 카드를 진행 중으로 바꾼다. 앱 폴링은 백그라운드에서 멈추므로
+	 * 잠금화면 카드는 이 푸시로만 갱신된다. 알림 흐름을 깨지 않게 실패를 흡수한다.
+	 */
+	private void pushLiveActivitySetStart(ActiveLiveGame activeGame) {
+		if (!liveActivityPushService.isEnabled()) {
+			return;
+		}
+		try {
+			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
+			liveActivityPushService.notifySetStart(
+					activeGame.matchId(),
+					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
+					match == null ? null : match.getBlueScore(),
+					match == null ? null : match.getRedScore());
+		} catch (Exception e) {
+			log.warn("[live-activity] set-start 실패 matchId={}: {}", activeGame.matchId(), e.getMessage());
+		}
 	}
 
 	/** window 응답의 마지막 프레임이 gameState=finished 인지. 프레임이 없으면 false. */
@@ -421,7 +443,52 @@ public class LivePollingScheduler {
 				log.warn("[live-notify] set-end FCM failed gameId={} matchId={}: {}",
 						activeGame.gameId(), activeGame.matchId(), e.getMessage());
 			}
+			pushLiveActivitySetEnd(activeGame);
 		});
+	}
+
+	/**
+	 * iOS Live Activity 카드를 세트 종료(또는 매치 종료)로 바꾼다.
+	 *
+	 * <p>SET_END 푸시가 스코어 재조회로 최대 60초 블로킹될 수 있어 그 뒤에 부른다 —
+	 * 그때쯤이면 DB 스코어도 갱신돼 카드와 알림이 같은 값을 보게 된다.</p>
+	 */
+	private void pushLiveActivitySetEnd(ActiveLiveGame activeGame) {
+		if (!liveActivityPushService.isEnabled()) {
+			return;
+		}
+		try {
+			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
+			Integer blue = match == null ? null : match.getBlueScore();
+			Integer red = match == null ? null : match.getRedScore();
+			Integer bestOf = match == null ? null : match.getBestOf();
+			boolean matchEnded = isMatchEnded(bestOf, blue, red);
+			String winner = null;
+			if (matchEnded && match != null) {
+				winner = (blue == null ? 0 : blue) > (red == null ? 0 : red)
+						? match.getBlueTeamCode()
+						: match.getRedTeamCode();
+			}
+			liveActivityPushService.notifySetEnd(
+					activeGame.matchId(),
+					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
+					blue, red, matchEnded, winner);
+		} catch (Exception e) {
+			log.warn("[live-activity] set-end 실패 matchId={}: {}", activeGame.matchId(), e.getMessage());
+		}
+	}
+
+	/**
+	 * 다전제 승리 조건 도달 여부. bestOf 를 모르면 매치 종료로 단정하지 않는다 —
+	 * 잘못 종료로 보내면 카드가 경기 도중에 내려간다.
+	 */
+	static boolean isMatchEnded(Integer bestOf, Integer blueScore, Integer redScore) {
+		if (bestOf == null || bestOf < 1) {
+			return false;
+		}
+		int blue = blueScore == null ? 0 : blueScore;
+		int red = redScore == null ? 0 : redScore;
+		return Math.max(blue, red) >= bestOf / 2 + 1;
 	}
 
 	/**

--- a/src/main/java/com/toy/nar/app/mobile/liveactivity/LiveActivityTokenService.java
+++ b/src/main/java/com/toy/nar/app/mobile/liveactivity/LiveActivityTokenService.java
@@ -1,0 +1,63 @@
+package com.toy.nar.app.mobile.liveactivity;
+
+import com.toy.nar.app.mobile.liveactivity.dto.LiveActivityTokenRequest;
+import com.toy.nar.domain.member.entity.LiveActivityToken;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LiveActivityTokenService {
+
+	private final MemberRepository memberRepository;
+	private final LiveActivityTokenRepository tokenRepository;
+
+	/**
+	 * 토큰 등록 또는 갱신. 같은 토큰이 다시 오면 매치와 활성 여부만 갱신한다
+	 * (앱이 카드를 내렸다가 같은 토큰으로 다시 띄우는 경우).
+	 */
+	@Transactional
+	public void register(Long memberId, LiveActivityTokenRequest request) {
+		Member member = requireMember(memberId);
+		tokenRepository.findByPushToken(request.pushToken())
+				.ifPresentOrElse(
+						token -> token.reactivate(member, request.matchId()),
+						() -> tokenRepository.save(LiveActivityToken.builder()
+								.member(member)
+								.matchId(request.matchId())
+								.pushToken(request.pushToken())
+								.build()));
+	}
+
+	/**
+	 * 앱이 카드를 내렸을 때 호출한다. 매치가 끝나면 서버도 정리하지만,
+	 * 사용자가 직접 카드를 지우는 경로는 앱만 안다.
+	 */
+	@Transactional
+	public void unregister(Long memberId, String pushToken) {
+		requireMemberId(memberId);
+		tokenRepository.findByPushToken(pushToken)
+				.filter(token -> token.getMember().getId().equals(memberId))
+				.ifPresent(LiveActivityToken::deactivate);
+	}
+
+	private Member requireMember(Long memberId) {
+		requireMemberId(memberId);
+		return memberRepository.findById(memberId)
+				.orElseThrow(() -> new ResponseStatusException(
+						HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."));
+	}
+
+	private void requireMemberId(Long memberId) {
+		if (memberId == null) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/liveactivity/dto/LiveActivityTokenRequest.java
+++ b/src/main/java/com/toy/nar/app/mobile/liveactivity/dto/LiveActivityTokenRequest.java
@@ -1,0 +1,17 @@
+package com.toy.nar.app.mobile.liveactivity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * iOS 앱이 Live Activity 를 시작하며 받은 ActivityKit 푸시 토큰 등록 요청.
+ *
+ * <p>토큰은 액티비티 단위라 카드를 띄울 때마다 새로 발급되고, 수명 중에 갱신될 수도 있다
+ * ({@code Activity.pushTokenUpdates}). 받을 때마다 그대로 올리면 된다.</p>
+ */
+public record LiveActivityTokenRequest(
+		@NotBlank(message = "matchId는 필수입니다.")
+		String matchId,
+
+		@NotBlank(message = "pushToken은 필수입니다.")
+		String pushToken) {
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
@@ -1,0 +1,192 @@
+package com.toy.nar.app.mobile.push;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * iOS Live Activity 갱신용 APNs HTTP/2 클라이언트.
+ *
+ * <p>FCM 을 못 쓰는 유일한 경로다 — ActivityKit 푸시 토큰은 FCM 등록 토큰이 아니라서
+ * firebase-admin 으로 보낼 수 없다. 대신 발송량이 작아(경기당 10~20건, 세트/스코어 변화 시에만.
+ * 경과 시간은 위젯이 {@code Text(style: .timer)} 로 자체 갱신한다) 전용 SDK 없이
+ * JDK HttpClient + jjwt 로 충분하다.
+ *
+ * <p>ponytail: 커넥션 풀·재시도·배치를 직접 하지 않는다. HttpClient 가 HTTP/2 멀티플렉싱을
+ * 알아서 하고 발송량이 작아 지금은 이득이 없다. 발송량이 커지거나 부분 실패 재시도가
+ * 필요해지면 pushy(com.eatthepath:pushy)로 갈아탄다.
+ */
+@Slf4j
+@Component
+public class ApnsLiveActivityClient {
+
+	/** APNs 는 인증 토큰 수명을 1시간으로 제한한다. 만료 직전이 아니라 여유를 두고 새로 만든다. */
+	private static final Duration TOKEN_TTL = Duration.ofMinutes(50);
+
+	/**
+	 * Swift {@code Date} 의 기본 Codable 인코딩은 Unix epoch 가 아니라 2001-01-01 기준 초다.
+	 * ActivityKit 이 content-state 를 표준 JSONDecoder 로 읽으므로 여기서 맞춰 보낸다.
+	 */
+	static final long APPLE_REFERENCE_EPOCH_SECONDS = 978_307_200L;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final HttpClient httpClient = HttpClient.newBuilder()
+			.version(HttpClient.Version.HTTP_2)
+			.connectTimeout(Duration.ofSeconds(10))
+			.build();
+
+	@Value("${apns.enabled:false}")
+	private boolean enabled;
+
+	/** Apple Developer 에서 받은 .p8 키 파일 경로. */
+	@Value("${apns.key-path:}")
+	private String keyPath;
+
+	@Value("${apns.key-id:}")
+	private String keyId;
+
+	@Value("${apns.team-id:}")
+	private String teamId;
+
+	/** 앱 번들 id. apns-topic 은 여기에 .push-type.liveactivity 를 붙인 값이다. */
+	@Value("${apns.bundle-id:}")
+	private String bundleId;
+
+	/** 개발 빌드는 sandbox 로 보내야 한다. */
+	@Value("${apns.host:https://api.push.apple.com}")
+	private String host;
+
+	private volatile PrivateKey privateKey;
+	private volatile String cachedJwt;
+	private volatile Instant cachedJwtAt;
+
+	public boolean isAvailable() {
+		return enabled
+				&& !keyPath.isBlank()
+				&& !keyId.isBlank()
+				&& !teamId.isBlank()
+				&& !bundleId.isBlank();
+	}
+
+	/**
+	 * 액티비티 하나를 갱신한다.
+	 *
+	 * @return 토큰이 죽었으면(410 Unregistered / 400 BadDeviceToken) false — 호출측이 비활성화한다.
+	 *         그 외 실패는 예외로 던지지 않고 true 를 돌려 다음 이벤트에 다시 시도하게 둔다.
+	 */
+	public boolean sendUpdate(String pushToken, Map<String, Object> contentState) {
+		return send(pushToken, body("update", contentState, null));
+	}
+
+	/**
+	 * 액티비티를 종료한다. {@code dismissAfter} 뒤에 시스템이 카드를 내린다.
+	 * 앱의 30분 자동 dismiss 타이머를 대신하므로 앱이 안 떠 있어도 카드가 남지 않는다.
+	 */
+	public boolean sendEnd(String pushToken, Map<String, Object> contentState, Duration dismissAfter) {
+		return send(pushToken, body("end", contentState, Instant.now().plus(dismissAfter)));
+	}
+
+	private Map<String, Object> body(String event, Map<String, Object> contentState, Instant dismissalDate) {
+		Map<String, Object> aps = new LinkedHashMap<>();
+		aps.put("timestamp", Instant.now().getEpochSecond());
+		aps.put("event", event);
+		aps.put("content-state", contentState);
+		if (dismissalDate != null) {
+			aps.put("dismissal-date", dismissalDate.getEpochSecond());
+		}
+		return Map.of("aps", aps);
+	}
+
+	private boolean send(String pushToken, Map<String, Object> payload) {
+		if (!isAvailable()) {
+			return true;
+		}
+		try {
+			HttpRequest request = HttpRequest.newBuilder()
+					.uri(URI.create(host + "/3/device/" + pushToken))
+					.header("authorization", "bearer " + authToken())
+					.header("apns-topic", bundleId + ".push-type.liveactivity")
+					.header("apns-push-type", "liveactivity")
+					.header("apns-priority", "10")
+					.header("apns-expiration", "0")
+					.timeout(Duration.ofSeconds(10))
+					.POST(HttpRequest.BodyPublishers.ofByteArray(objectMapper.writeValueAsBytes(payload)))
+					.build();
+
+			HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+			if (response.statusCode() == 200) {
+				return true;
+			}
+			// 410 = 액티비티가 끝났거나 앱이 지워져 토큰이 죽었다. 400 BadDeviceToken 도 재사용 불가.
+			boolean tokenDead = response.statusCode() == 410
+					|| (response.statusCode() == 400 && response.body().contains("BadDeviceToken"));
+			log.warn("APNs Live Activity 발송 실패 status={} body={} tokenDead={}",
+					response.statusCode(), response.body(), tokenDead);
+			return !tokenDead;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return true;
+		} catch (Exception e) {
+			log.warn("APNs Live Activity 발송 오류: {}", e.getMessage());
+			return true;
+		}
+	}
+
+	/** APNs 인증 JWT. 발급이 잦으면 APNs 가 거부하므로 TTL 동안 재사용한다. */
+	private synchronized String authToken() throws IOException {
+		Instant issuedAt = cachedJwtAt;
+		if (cachedJwt != null && issuedAt != null && issuedAt.plus(TOKEN_TTL).isAfter(Instant.now())) {
+			return cachedJwt;
+		}
+		cachedJwt = Jwts.builder()
+				.header().add("kid", keyId).and()
+				.issuer(teamId)
+				.issuedAt(new Date())
+				.signWith(loadPrivateKey(), Jwts.SIG.ES256)
+				.compact();
+		cachedJwtAt = Instant.now();
+		return cachedJwt;
+	}
+
+	private PrivateKey loadPrivateKey() throws IOException {
+		PrivateKey cached = privateKey;
+		if (cached != null) {
+			return cached;
+		}
+		String pem = Files.readString(Path.of(keyPath))
+				.replace("-----BEGIN PRIVATE KEY-----", "")
+				.replace("-----END PRIVATE KEY-----", "")
+				.replaceAll("\\s", "");
+		try {
+			privateKey = KeyFactory.getInstance("EC")
+					.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(pem)));
+			return privateKey;
+		} catch (Exception e) {
+			throw new IOException("APNs .p8 키를 읽지 못했습니다: " + keyPath, e);
+		}
+	}
+
+	/** Unix epoch 초 → Swift {@code Date} 가 기대하는 2001-01-01 기준 초. */
+	static double toAppleReferenceSeconds(Instant instant) {
+		return instant.getEpochSecond() - (double) APPLE_REFERENCE_EPOCH_SECONDS;
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * iOS Live Activity 갱신용 APNs HTTP/2 클라이언트.
@@ -87,7 +88,7 @@ public class ApnsLiveActivityClient {
 	 *         그 외 실패는 예외로 던지지 않고 true 를 돌려 다음 이벤트에 다시 시도하게 둔다.
 	 */
 	public boolean sendUpdate(String pushToken, Map<String, Object> contentState) {
-		return send(pushToken, body("update", contentState, null));
+		return sendUpdateAsync(pushToken, contentState).join();
 	}
 
 	/**
@@ -95,7 +96,25 @@ public class ApnsLiveActivityClient {
 	 * 앱의 30분 자동 dismiss 타이머를 대신하므로 앱이 안 떠 있어도 카드가 남지 않는다.
 	 */
 	public boolean sendEnd(String pushToken, Map<String, Object> contentState, Duration dismissAfter) {
-		return send(pushToken, body("end", contentState, Instant.now().plus(dismissAfter)));
+		return sendEndAsync(pushToken, contentState, dismissAfter).join();
+	}
+
+	/**
+	 * 비동기 발송. 카드가 많은 경기에서는 반드시 이쪽을 써서 한꺼번에 띄워야 한다.
+	 *
+	 * <p>동기 발송을 토큰 수만큼 반복하면 왕복이 직렬로 쌓인다. FCM 쪽에서 같은 모양으로
+	 * 사고가 났다 — 2026-07-29 LCK T1 vs KT 에서 구독자 1,500명 팬아웃이 이벤트당 8~18분
+	 * 걸려 마지막 사람은 세트가 끝난 뒤에 시작 알림을 받았다({@code TeamLiveEventPushService} 참고).
+	 * HTTP/2 는 한 커넥션에 요청을 다중화하므로 비동기로 넘기면 왕복이 겹쳐 전체가 한 번의
+	 * 왕복 시간에 수렴한다.</p>
+	 */
+	public CompletableFuture<Boolean> sendUpdateAsync(String pushToken, Map<String, Object> contentState) {
+		return sendAsync(pushToken, body("update", contentState, null));
+	}
+
+	public CompletableFuture<Boolean> sendEndAsync(
+			String pushToken, Map<String, Object> contentState, Duration dismissAfter) {
+		return sendAsync(pushToken, body("end", contentState, Instant.now().plus(dismissAfter)));
 	}
 
 	private Map<String, Object> body(String event, Map<String, Object> contentState, Instant dismissalDate) {
@@ -109,12 +128,17 @@ public class ApnsLiveActivityClient {
 		return Map.of("aps", aps);
 	}
 
-	private boolean send(String pushToken, Map<String, Object> payload) {
+	/**
+	 * @return 토큰이 살아 있으면 true. 실패해도 예외를 흘리지 않는다 —
+	 *         일시 오류는 true 로 두어 다음 이벤트에 자연히 재시도된다.
+	 */
+	private CompletableFuture<Boolean> sendAsync(String pushToken, Map<String, Object> payload) {
 		if (!isAvailable()) {
-			return true;
+			return CompletableFuture.completedFuture(true);
 		}
+		HttpRequest request;
 		try {
-			HttpRequest request = HttpRequest.newBuilder()
+			request = HttpRequest.newBuilder()
 					.uri(URI.create(host + "/3/device/" + pushToken))
 					.header("authorization", "bearer " + authToken())
 					.header("apns-topic", bundleId + ".push-type.liveactivity")
@@ -124,24 +148,28 @@ public class ApnsLiveActivityClient {
 					.timeout(Duration.ofSeconds(10))
 					.POST(HttpRequest.BodyPublishers.ofByteArray(objectMapper.writeValueAsBytes(payload)))
 					.build();
-
-			HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-			if (response.statusCode() == 200) {
-				return true;
-			}
-			// 410 = 액티비티가 끝났거나 앱이 지워져 토큰이 죽었다. 400 BadDeviceToken 도 재사용 불가.
-			boolean tokenDead = response.statusCode() == 410
-					|| (response.statusCode() == 400 && response.body().contains("BadDeviceToken"));
-			log.warn("APNs Live Activity 발송 실패 status={} body={} tokenDead={}",
-					response.statusCode(), response.body(), tokenDead);
-			return !tokenDead;
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			return true;
 		} catch (Exception e) {
-			log.warn("APNs Live Activity 발송 오류: {}", e.getMessage());
-			return true;
+			// 키 로딩·JSON 직렬화 실패. 토큰 문제가 아니므로 살려 둔다.
+			log.warn("APNs Live Activity 요청 생성 실패: {}", e.getMessage());
+			return CompletableFuture.completedFuture(true);
 		}
+
+		return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+				.handle((response, error) -> {
+					if (error != null) {
+						log.warn("APNs Live Activity 발송 오류: {}", error.getMessage());
+						return true;
+					}
+					if (response.statusCode() == 200) {
+						return true;
+					}
+					// 410 = 액티비티가 끝났거나 앱이 지워져 토큰이 죽었다. 400 BadDeviceToken 도 재사용 불가.
+					boolean tokenDead = response.statusCode() == 410
+							|| (response.statusCode() == 400 && response.body().contains("BadDeviceToken"));
+					log.warn("APNs Live Activity 발송 실패 status={} body={} tokenDead={}",
+							response.statusCode(), response.body(), tokenDead);
+					return !tokenDead;
+				});
 	}
 
 	/** APNs 인증 JWT. 발급이 잦으면 APNs 가 거부하므로 TTL 동안 재사용한다. */

--- a/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
@@ -27,9 +27,8 @@ import java.util.Map;
  * iOS Live Activity 갱신용 APNs HTTP/2 클라이언트.
  *
  * <p>FCM 을 못 쓰는 유일한 경로다 — ActivityKit 푸시 토큰은 FCM 등록 토큰이 아니라서
- * firebase-admin 으로 보낼 수 없다. 대신 발송량이 작아(경기당 10~20건, 세트/스코어 변화 시에만.
- * 경과 시간은 위젯이 {@code Text(style: .timer)} 로 자체 갱신한다) 전용 SDK 없이
- * JDK HttpClient + jjwt 로 충분하다.
+ * firebase-admin 으로 보낼 수 없다. 대신 발송량이 작아(세트/스코어가 바뀔 때만이라 경기당 10~20건)
+ * 전용 SDK 없이 JDK HttpClient + jjwt 로 충분하다.
  *
  * <p>ponytail: 커넥션 풀·재시도·배치를 직접 하지 않는다. HttpClient 가 HTTP/2 멀티플렉싱을
  * 알아서 하고 발송량이 작아 지금은 이득이 없다. 발송량이 커지거나 부분 실패 재시도가
@@ -41,12 +40,6 @@ public class ApnsLiveActivityClient {
 
 	/** APNs 는 인증 토큰 수명을 1시간으로 제한한다. 만료 직전이 아니라 여유를 두고 새로 만든다. */
 	private static final Duration TOKEN_TTL = Duration.ofMinutes(50);
-
-	/**
-	 * Swift {@code Date} 의 기본 Codable 인코딩은 Unix epoch 가 아니라 2001-01-01 기준 초다.
-	 * ActivityKit 이 content-state 를 표준 JSONDecoder 로 읽으므로 여기서 맞춰 보낸다.
-	 */
-	static final long APPLE_REFERENCE_EPOCH_SECONDS = 978_307_200L;
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final HttpClient httpClient = HttpClient.newBuilder()
@@ -183,10 +176,5 @@ public class ApnsLiveActivityClient {
 		} catch (Exception e) {
 			throw new IOException("APNs .p8 키를 읽지 못했습니다: " + keyPath, e);
 		}
-	}
-
-	/** Unix epoch 초 → Swift {@code Date} 가 기대하는 2001-01-01 기준 초. */
-	static double toAppleReferenceSeconds(Instant instant) {
-		return instant.getEpochSecond() - (double) APPLE_REFERENCE_EPOCH_SECONDS;
 	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -1,0 +1,144 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * iOS Live Activity(잠금화면 실시간 경기 카드)를 서버가 직접 갱신한다.
+ *
+ * <p>앱이 30초 폴링으로 카드를 갱신하던 구조는 포그라운드에서만 동작했다 — iOS 가 백그라운드에서
+ * 타이머를 멈추기 때문이다. 잠금화면 카드를 보는 시나리오가 곧 백그라운드라, 실제로는
+ * "앱을 켜 놓고 볼 때만 맞는 위젯"이었다. APNs 로 직접 쏘면 앱 프로세스와 무관하게 갱신된다.</p>
+ *
+ * <p>Android 는 여기 오지 않는다. 진행 중 알림 기반이라 기존 FCM data 메시지
+ * ({@link TeamLiveEventPushService} 가 이미 type/matchId/setNumber/bestOf/스코어를 싣는다)로
+ * 앱을 깨워 알림을 다시 그리면 되고, 백엔드에 추가할 것이 없다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveActivityPushService {
+
+	/** 클라이언트 {@code LiveMatchPhase.wireValue} 와 일치해야 한다. */
+	private static final String PHASE_PLAYING = "playing";
+	private static final String PHASE_SET_ENDED = "setEnded";
+	private static final String PHASE_MATCH_ENDED = "matchEnded";
+
+	/** 경기 종료 카드를 남겨 두는 시간. 앱의 자동 dismiss 타이머와 같은 값. */
+	private static final Duration MATCH_END_DISMISS_AFTER = Duration.ofMinutes(30);
+
+	private final LiveActivityTokenRepository tokenRepository;
+	private final ApnsLiveActivityClient apnsClient;
+
+	public boolean isEnabled() {
+		return apnsClient.isAvailable();
+	}
+
+	/** 세트 시작 — 카드를 진행 중으로 바꾸고 경과 시간 기준점을 지금으로 잡는다. */
+	public void notifySetStart(String matchId, int setNumber, Integer blueScore, Integer redScore) {
+		Map<String, Object> state = contentState(
+				PHASE_PLAYING, setNumber, blueScore, redScore, "", null);
+		// 진행 중일 때만 setStartedAt 을 싣는다. 위젯이 이 값으로 경과 시간을 스스로 흘려
+		// 초 단위 갱신에 푸시가 필요 없다.
+		state.put("setStartedAt", ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.now()));
+		fanOut(matchId, state, false);
+	}
+
+	/**
+	 * 세트 종료 — 매치가 끝났으면 카드를 종료 상태로 바꾸고 시스템이 내리도록 예약한다.
+	 *
+	 * @param winnerTeamCode 매치 종료 시 승리 팀 코드. 진행 중이면 null.
+	 */
+	public void notifySetEnd(
+			String matchId,
+			int setNumber,
+			Integer blueScore,
+			Integer redScore,
+			boolean matchEnded,
+			String winnerTeamCode) {
+		String phase = matchEnded ? PHASE_MATCH_ENDED : PHASE_SET_ENDED;
+		String label = matchEnded ? "경기 종료" : "다음 세트 준비 중";
+		Map<String, Object> state = contentState(
+				phase, setNumber, blueScore, redScore, label, matchEnded ? winnerTeamCode : null);
+		fanOut(matchId, state, matchEnded);
+	}
+
+	/**
+	 * {@code MatchLiveAttributes.ContentState} 와 필드명·타입이 정확히 일치해야 한다.
+	 * 모르는 값은 키를 넣지 않는다 — Swift 쪽이 Optional 이라 없으면 nil 로 읽힌다.
+	 */
+	private Map<String, Object> contentState(
+			String phase,
+			int setNumber,
+			Integer blueScore,
+			Integer redScore,
+			String statusLabel,
+			String winnerTeamCode) {
+		Map<String, Object> state = new LinkedHashMap<>();
+		state.put("phase", phase);
+		state.put("setNumber", setNumber);
+		// 앱은 세트 승자를 세어 스코어를 만들지만(set_winners 가 '?' 면 누락된다), 서버는
+		// 매치 스코어를 그대로 싣는다. SET_END 푸시와 같은 값이라 알림과 카드가 어긋나지 않는다.
+		state.put("scoreA", blueScore == null ? 0 : blueScore);
+		state.put("scoreB", redScore == null ? 0 : redScore);
+		state.put("statusLabel", statusLabel);
+		if (winnerTeamCode != null && !winnerTeamCode.isBlank()) {
+			state.put("winnerTeamCode", winnerTeamCode);
+		}
+		return state;
+	}
+
+	/**
+	 * 이 매치의 살아있는 카드 전부에 보낸다.
+	 *
+	 * <p>발송 실패가 라이브 알림 흐름을 깨면 안 되므로 예외를 흡수한다. 죽은 토큰(410)만
+	 * 비활성화하고, 일시 실패는 다음 이벤트에 자연히 재시도된다.</p>
+	 */
+	private void fanOut(String matchId, Map<String, Object> contentState, boolean end) {
+		if (!isEnabled() || matchId == null || matchId.isBlank()) {
+			return;
+		}
+		List<String> tokens;
+		try {
+			tokens = tokenRepository.findActivePushTokensByMatchId(matchId);
+		} catch (Exception e) {
+			log.warn("Live Activity 토큰 조회 실패 matchId={}: {}", matchId, e.getMessage());
+			return;
+		}
+		if (tokens.isEmpty()) {
+			return;
+		}
+
+		List<String> deadTokens = new ArrayList<>();
+		for (String token : tokens) {
+			boolean alive = end
+					? apnsClient.sendEnd(token, contentState, MATCH_END_DISMISS_AFTER)
+					: apnsClient.sendUpdate(token, contentState);
+			if (!alive) {
+				deadTokens.add(token);
+			}
+		}
+		log.info("[live-activity] matchId={} end={} 발송 {}건, 죽은 토큰 {}건",
+				matchId, end, tokens.size(), deadTokens.size());
+
+		// 매치가 끝났으면 이 카드들은 더 갱신되지 않는다 — 토큰을 함께 정리한다.
+		List<String> toDeactivate = end ? tokens : deadTokens;
+		if (toDeactivate.isEmpty()) {
+			return;
+		}
+		try {
+			tokenRepository.deactivateByPushTokenIn(toDeactivate);
+		} catch (Exception e) {
+			log.warn("Live Activity 토큰 비활성화 실패 matchId={}: {}", matchId, e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -141,12 +141,14 @@ public class LiveActivityPushService {
 				matchId, end, tokens.size(), deadTokens.size());
 
 		// 매치가 끝났으면 이 카드들은 더 갱신되지 않는다 — 토큰을 함께 정리한다.
-		List<String> toDeactivate = end ? tokens : deadTokens;
-		if (toDeactivate.isEmpty()) {
-			return;
-		}
+		// 매치 단위 정리는 조건으로 지우는 편이 낫다. 토큰을 IN 절로 넘기면 카드 수만큼
+		// 문자열이 실려 SQL 이 커지는데, "이 매치 전부"는 인덱스 한 번이면 되는 조건이다.
 		try {
-			tokenRepository.deactivateByPushTokenIn(toDeactivate);
+			if (end) {
+				tokenRepository.deactivateAllByMatchId(matchId);
+			} else if (!deadTokens.isEmpty()) {
+				tokenRepository.deactivateByPushTokenIn(deadTokens);
+			}
 		} catch (Exception e) {
 			log.warn("Live Activity 토큰 비활성화 실패 matchId={}: {}", matchId, e.getMessage());
 		}

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,14 +42,9 @@ public class LiveActivityPushService {
 		return apnsClient.isAvailable();
 	}
 
-	/** 세트 시작 — 카드를 진행 중으로 바꾸고 경과 시간 기준점을 지금으로 잡는다. */
+	/** 세트 시작 — 카드를 진행 중으로 바꾼다. */
 	public void notifySetStart(String matchId, int setNumber, Integer blueScore, Integer redScore) {
-		Map<String, Object> state = contentState(
-				PHASE_PLAYING, setNumber, blueScore, redScore, "", null);
-		// 진행 중일 때만 setStartedAt 을 싣는다. 위젯이 이 값으로 경과 시간을 스스로 흘려
-		// 초 단위 갱신에 푸시가 필요 없다.
-		state.put("setStartedAt", ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.now()));
-		fanOut(matchId, state, false);
+		fanOut(matchId, contentState(PHASE_PLAYING, setNumber, blueScore, redScore, "", null), false);
 	}
 
 	/**

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * iOS Live Activity(잠금화면 실시간 경기 카드)를 서버가 직접 갱신한다.
@@ -39,13 +40,75 @@ public class LiveActivityPushService {
 	private final LiveActivityTokenRepository tokenRepository;
 	private final ApnsLiveActivityClient apnsClient;
 
+	/**
+	 * 매치별로 마지막에 카드에 반영한 진행도. 뒤처진 이벤트를 걸러내는 워터마크다.
+	 *
+	 * <p>업스트림이 이미 끝난 게임 id 를 {@code liveGameIds} 에 계속 실어 보내면 디스커버리가
+	 * 그 게임을 다시 추적하고, stale 제거로 dedup 집합이 비어 있어 세트 종료가 재발화한다
+	 * (2026-07-31 LCK Gen.G vs T1 실측: 1세트 종료가 2세트 진행 중에 5회 추가 발화, 6~7분 주기).
+	 * FCM 은 발송 이력 테이블이 막아 주지만 카드에는 그런 장치가 없어, 2세트를 하는 내내 카드가
+	 * "SET 1 종료 / 다음 세트 준비 중" 으로 덮이고, 더 나쁘게는 낡은 세트 종료가 그 시점의
+	 * 스코어로 매치 종료로 판정돼 카드가 경기 도중 닫힐 수 있다.</p>
+	 *
+	 * <p>발화 경로(프레임 판정·디스커버리 폴백)나 재기동과 무관하게 막으려면 여기서 걸러야 한다.
+	 * ponytail: 매치 종료 시 지우므로 진행 중 매치 수만큼만 남는다. 종료 이벤트를 못 받은
+	 * 매치(bestOf 미상 등)의 항목은 남지만 하루 수십 건이라 무해하다.</p>
+	 */
+	private final Map<String, Long> lastProgressByMatch = new ConcurrentHashMap<>();
+
 	public boolean isEnabled() {
 		return apnsClient.isAvailable();
 	}
 
 	/** 세트 시작 — 카드를 진행 중으로 바꾼다. */
 	public void notifySetStart(String matchId, int setNumber, Integer blueScore, Integer redScore) {
+		if (!accept(matchId, setNumber, PHASE_PLAYING)) {
+			return;
+		}
 		fanOut(matchId, contentState(PHASE_PLAYING, setNumber, blueScore, redScore, "", null), false);
+	}
+
+	/**
+	 * 카드 진행도가 뒤로 가는 이벤트를 버린다.
+	 *
+	 * <p>정상 순서는 (1,playing) → (1,setEnded) → (2,playing) → ... 로 단조 증가한다.
+	 * 같은 값이 다시 오는 것은 통과시킨다 — 같은 상태를 다시 그리는 것뿐이라 무해하고,
+	 * 그 사이 스코어가 갱신됐을 수 있다.</p>
+	 */
+	private boolean accept(String matchId, int setNumber, String phase) {
+		if (matchId == null || matchId.isBlank()) {
+			return false;
+		}
+		if (setNumber < 1) {
+			// 세트 번호를 모르면 카드에 그릴 수도, 순서를 따질 수도 없다.
+			log.debug("[live-activity] 세트 번호 미상이라 카드 갱신을 건너뛴다. matchId={}", matchId);
+			return false;
+		}
+		long key = progressKey(setNumber, phase);
+		// compute 로 검사와 갱신을 한 번에 한다 — 매치가 같은 이벤트가 동시에 들어올 수 있다.
+		boolean[] accepted = { false };
+		lastProgressByMatch.compute(matchId, (id, previous) -> {
+			if (previous != null && key < previous) {
+				return previous;
+			}
+			accepted[0] = true;
+			return key;
+		});
+		if (!accepted[0]) {
+			log.info("[live-activity] 뒤처진 이벤트 무시 matchId={} set={} phase={} (마지막={})",
+					matchId, setNumber, phase, lastProgressByMatch.get(matchId));
+		}
+		return accepted[0];
+	}
+
+	/** 세트 번호가 먼저, 같은 세트면 playing < setEnded < matchEnded 순. */
+	private static long progressKey(int setNumber, String phase) {
+		int phaseRank = switch (phase) {
+			case PHASE_SET_ENDED -> 1;
+			case PHASE_MATCH_ENDED -> 2;
+			default -> 0;
+		};
+		return setNumber * 10L + phaseRank;
 	}
 
 	/**
@@ -61,10 +124,18 @@ public class LiveActivityPushService {
 			boolean matchEnded,
 			String winnerTeamCode) {
 		String phase = matchEnded ? PHASE_MATCH_ENDED : PHASE_SET_ENDED;
+		if (!accept(matchId, setNumber, phase)) {
+			return;
+		}
 		String label = matchEnded ? "경기 종료" : "다음 세트 준비 중";
 		Map<String, Object> state = contentState(
 				phase, setNumber, blueScore, redScore, label, matchEnded ? winnerTeamCode : null);
 		fanOut(matchId, state, matchEnded);
+		if (matchEnded) {
+			// 카드가 닫혔으니 워터마크도 함께 정리한다. 이후 늦게 도착하는 이벤트는
+			// 토큰이 이미 비활성이라 fanOut 에서 자연히 걸러진다.
+			lastProgressByMatch.remove(matchId);
+		}
 	}
 
 	/**

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * iOS Live Activity(잠금화면 실시간 경기 카드)를 서버가 직접 갱신한다.
@@ -112,15 +113,30 @@ public class LiveActivityPushService {
 			return;
 		}
 
-		List<String> deadTokens = new ArrayList<>();
+		// 토큰마다 동기 발송하면 왕복이 직렬로 쌓여, 카드가 많은 경기에서 마지막 사람은
+		// 세트가 끝난 뒤에야 카드가 갱신된다(FCM 쪽 실사고와 같은 모양 — ApnsLiveActivityClient 참고).
+		// HTTP/2 다중화를 살리려면 전부 띄운 뒤 한 번에 기다려야 한다.
+		Map<String, CompletableFuture<Boolean>> inFlight = new LinkedHashMap<>();
 		for (String token : tokens) {
-			boolean alive = end
-					? apnsClient.sendEnd(token, contentState, MATCH_END_DISMISS_AFTER)
-					: apnsClient.sendUpdate(token, contentState);
+			inFlight.put(token, end
+					? apnsClient.sendEndAsync(token, contentState, MATCH_END_DISMISS_AFTER)
+					: apnsClient.sendUpdateAsync(token, contentState));
+		}
+
+		List<String> deadTokens = new ArrayList<>();
+		inFlight.forEach((token, future) -> {
+			// sendAsync 가 예외를 이미 흡수하지만, join 단계의 사고까지 발송 흐름을 깨지 않게 한 번 더 막는다.
+			boolean alive;
+			try {
+				alive = future.join();
+			} catch (Exception e) {
+				log.warn("APNs 발송 결과 수집 실패 matchId={}: {}", matchId, e.getMessage());
+				alive = true;
+			}
 			if (!alive) {
 				deadTokens.add(token);
 			}
-		}
+		});
 		log.info("[live-activity] matchId={} end={} 발송 {}건, 죽은 토큰 {}건",
 				matchId, end, tokens.size(), deadTokens.size());
 

--- a/src/main/java/com/toy/nar/domain/member/entity/LiveActivityToken.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/LiveActivityToken.java
@@ -1,0 +1,95 @@
+package com.toy.nar.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * iOS Live Activity 카드 하나에 붙는 ActivityKit 푸시 토큰.
+ *
+ * <p>{@link MemberDevice} 의 FCM 토큰과 혼동하면 안 된다. 이 토큰은 APNs 가 발급하고
+ * 액티비티 단위라, 같은 기기라도 경기마다 다른 값을 갖고 카드가 끝나면 죽는다.
+ * FCM 으로는 이 토큰에 보낼 수 없어 APNs 직결 경로가 따로 있다.</p>
+ */
+@Entity
+@Table(name = "live_activity_token", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_activity_token_push_token", columnNames = "push_token")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveActivityToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "match_id", nullable = false, length = 64)
+	private String matchId;
+
+	@Column(name = "push_token", nullable = false, length = 512)
+	private String pushToken;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "active", nullable = false)
+	private boolean active;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Builder
+	public LiveActivityToken(Member member, String matchId, String pushToken) {
+		this.member = Objects.requireNonNull(member, "member must not be null");
+		this.matchId = Objects.requireNonNull(matchId, "matchId must not be null");
+		this.pushToken = Objects.requireNonNull(pushToken, "pushToken must not be null");
+		this.active = true;
+	}
+
+	/**
+	 * 같은 토큰이 다시 올라온 경우. 앱이 액티비티를 다시 띄우면 매치가 바뀔 수 있어 함께 갱신한다.
+	 */
+	public void reactivate(Member member, String matchId) {
+		this.member = Objects.requireNonNull(member, "member must not be null");
+		this.matchId = Objects.requireNonNull(matchId, "matchId must not be null");
+		this.active = true;
+	}
+
+	public void deactivate() {
+		this.active = false;
+	}
+
+	@PrePersist
+	void onCreate() {
+		LocalDateTime now = LocalDateTime.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		updatedAt = now;
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
@@ -1,0 +1,31 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.LiveActivityToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveActivityTokenRepository extends JpaRepository<LiveActivityToken, Long> {
+
+	Optional<LiveActivityToken> findByPushToken(String pushToken);
+
+	@Query("select t.pushToken from LiveActivityToken t where t.matchId = :matchId and t.active = true")
+	List<String> findActivePushTokensByMatchId(@Param("matchId") String matchId);
+
+	/**
+	 * APNs 가 410(Unregistered) 등으로 거절한 토큰은 더 쓰지 않는다.
+	 *
+	 * <p>호출측(LiveActivityPushService)이 APNs 왕복 뒤에 부르므로 트랜잭션을 여기 둔다 —
+	 * 서비스 전체를 트랜잭션으로 감싸면 네트워크 I/O 동안 커넥션을 붙들게 된다.</p>
+	 */
+	@Transactional
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("update LiveActivityToken t set t.active = false, t.updatedAt = CURRENT_TIMESTAMP "
+			+ "where t.pushToken in :pushTokens")
+	int deactivateByPushTokenIn(@Param("pushTokens") List<String> pushTokens);
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
@@ -28,4 +28,17 @@ public interface LiveActivityTokenRepository extends JpaRepository<LiveActivityT
 	@Query("update LiveActivityToken t set t.active = false, t.updatedAt = CURRENT_TIMESTAMP "
 			+ "where t.pushToken in :pushTokens")
 	int deactivateByPushTokenIn(@Param("pushTokens") List<String> pushTokens);
+
+	/**
+	 * 매치가 끝나 그 경기의 카드를 전부 정리한다.
+	 *
+	 * <p>토큰 목록을 IN 절로 넘기지 않는다. 카드가 많은 경기면 IN 절에 토큰 수만큼 문자열이
+	 * 실려(1,500장이면 100KB 넘는 SQL) 파싱·플래닝이 목록 크기를 따라 커진다. 매치 종료는
+	 * "이 매치 전부"라 조건을 그대로 쓰면 되고, 그러면 (match_id, active) 인덱스 한 번으로 끝난다.</p>
+	 */
+	@Transactional
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("update LiveActivityToken t set t.active = false, t.updatedAt = CURRENT_TIMESTAMP "
+			+ "where t.matchId = :matchId and t.active = true")
+	int deactivateAllByMatchId(@Param("matchId") String matchId);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -181,3 +181,17 @@ live:
   notification:
     fcm:
       enabled: ${LIVE_NOTIFICATION_FCM_ENABLED:false}
+
+# iOS Live Activity 서버 푸시(APNs 직결). 기본 OFF.
+# 앱 폴링은 백그라운드에서 멈춰 잠금화면 카드가 갱신되지 않으므로 이 경로가 필요하다.
+# FCM 으로는 대체 불가 — ActivityKit 토큰은 FCM 등록 토큰이 아니다.
+# 켜려면 Apple Developer 의 .p8 키를 서버에 두고 아래 4개를 모두 채워야 한다
+# (isAvailable() 이 하나라도 비면 발송을 건너뛴다).
+apns:
+  enabled: ${APNS_ENABLED:false}
+  key-path: ${APNS_KEY_PATH:}
+  key-id: ${APNS_KEY_ID:}
+  team-id: ${APNS_TEAM_ID:}
+  bundle-id: ${APNS_BUNDLE_ID:}
+  # 개발 빌드(Xcode 직접 설치)는 https://api.sandbox.push.apple.com 로 보내야 한다.
+  host: ${APNS_HOST:https://api.push.apple.com}

--- a/src/main/resources/db/migration/V63__Create_live_activity_token.sql
+++ b/src/main/resources/db/migration/V63__Create_live_activity_token.sql
@@ -1,0 +1,19 @@
+-- iOS Live Activity(잠금화면 실시간 경기 카드) 갱신용 ActivityKit 푸시 토큰.
+--
+-- member_device 의 FCM 등록 토큰과 다른 체계라 별도 테이블로 둔다:
+--   - 발급자가 APNs 다. FCM 은 이 토큰으로 못 보낸다.
+--   - 기기가 아니라 액티비티(카드) 하나에 붙는다. 같은 기기가 경기마다 다른 토큰을 갖는다.
+--   - 카드가 끝나면 죽는다. 수명이 기기 등록보다 훨씬 짧다.
+CREATE TABLE live_activity_token (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    match_id   VARCHAR(64)  NOT NULL,
+    push_token VARCHAR(512) NOT NULL,
+    member_id  BIGINT       NOT NULL,
+    active     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_live_activity_token_push_token UNIQUE (push_token),
+    CONSTRAINT fk_live_activity_token_member
+        FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    INDEX idx_live_activity_token_match_active (match_id, active)
+);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -50,6 +50,7 @@ class LivePollingSchedulerTest {
 				cacheEvictionService,
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -94,6 +95,7 @@ class LivePollingSchedulerTest {
 				cacheEvictionService,
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -291,6 +293,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -328,6 +331,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -366,6 +370,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -405,6 +410,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -446,6 +452,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -482,6 +489,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, cacheEvictionService, mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -524,6 +532,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, cacheEvictionService, mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -560,6 +569,7 @@ class LivePollingSchedulerTest {
 				mock(LiveFrameProcessor.class), liveGameMetadataServiceMock(), leagueMatchService,
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -752,6 +762,7 @@ class LivePollingSchedulerTest {
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				pushService,
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				frameStallTracker,
 				leagueMatchRepository,
 				Runnable::run);
@@ -780,6 +791,7 @@ class LivePollingSchedulerTest {
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				pushService,
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -806,6 +818,7 @@ class LivePollingSchedulerTest {
 				mock(CacheEvictionService.class),
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
+				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -816,5 +829,27 @@ class LivePollingSchedulerTest {
 				Instant.parse("2026-05-29T12:00:19Z"));
 
 		assertThat(nextWindow).isEqualTo(Instant.parse("2026-05-29T12:00:20Z"));
+	}
+
+	@Test
+	void 매치_종료_판정은_다전제_승리조건을_따른다() {
+		// Live Activity 카드를 end 로 내릴지 가르는 판정이라, 틀리면 경기 도중에 카드가 사라진다.
+		assertThat(LivePollingScheduler.isMatchEnded(1, 1, 0)).isTrue();
+		assertThat(LivePollingScheduler.isMatchEnded(3, 2, 0)).isTrue();
+		assertThat(LivePollingScheduler.isMatchEnded(3, 1, 1)).isFalse();
+		assertThat(LivePollingScheduler.isMatchEnded(5, 2, 2)).isFalse();
+		assertThat(LivePollingScheduler.isMatchEnded(5, 3, 2)).isTrue();
+	}
+
+	@Test
+	void bestOf_를_모르면_매치_종료로_단정하지_않는다() {
+		// 모르는 채로 종료를 보내면 카드가 경기 중에 내려간다. 모를 땐 유지가 안전하다.
+		assertThat(LivePollingScheduler.isMatchEnded(null, 3, 0)).isFalse();
+		assertThat(LivePollingScheduler.isMatchEnded(0, 3, 0)).isFalse();
+	}
+
+	@Test
+	void 스코어가_null_이면_0으로_보고_종료로_보지_않는다() {
+		assertThat(LivePollingScheduler.isMatchEnded(3, null, null)).isFalse();
 	}
 }

--- a/src/test/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClientLocalSmokeTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClientLocalSmokeTest.java
@@ -1,0 +1,68 @@
+package com.toy.nar.app.mobile.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 실제 APNs 에 붙어 인증만 확인하는 로컬 전용 스모크 테스트.
+ *
+ * <p>다른 테스트는 발송을 전부 mock 으로 덮어서 JWT 서명·헤더·토픽이 맞는지는 검증되지 않는다.
+ * 여기서는 더미 디바이스 토큰으로 한 번 쏴 APNs 의 거절 사유를 본다:</p>
+ * <ul>
+ *   <li>{@code 400 BadDeviceToken} — 인증 통과. 토큰만 가짜라서 거절된 것이므로 키·팀·kid·토픽이 옳다.</li>
+ *   <li>{@code 403 InvalidProviderToken} — JWT 가 틀렸다. 키 파일·keyId·teamId 를 확인해야 한다.</li>
+ *   <li>{@code 403 MissingTopic} / {@code 400 TopicDisallowed} — apns-topic 이 틀렸다.</li>
+ * </ul>
+ *
+ * <p>키 파일 경로가 필요하고 외부 네트워크를 타므로 기본 빌드에서는 건너뛴다. 실행:</p>
+ * <pre>
+ * ./gradlew test --tests "*ApnsLiveActivityClientLocalSmokeTest" -i \
+ *   -Dapns.local.enabled=true \
+ *   -Dapns.key-path=/path/AuthKey_XXXXXXXXXX.p8 \
+ *   -Dapns.key-id=XXXXXXXXXX -Dapns.team-id=YYYYYYYYYY -Dapns.bundle-id=com.nar.wardingapp
+ * </pre>
+ * 결과 판정은 콘솔의 {@code APNs Live Activity 발송 실패 status=... body=...} 로그로 한다.
+ */
+@EnabledIfSystemProperty(named = "apns.local.enabled", matches = "true")
+class ApnsLiveActivityClientLocalSmokeTest {
+
+	@Test
+	void 더미_토큰으로_APNs_인증을_확인한다() {
+		ApnsLiveActivityClient client = new ApnsLiveActivityClient();
+		ReflectionTestUtils.setField(client, "enabled", true);
+		ReflectionTestUtils.setField(client, "keyPath", required("apns.key-path"));
+		ReflectionTestUtils.setField(client, "keyId", required("apns.key-id"));
+		ReflectionTestUtils.setField(client, "teamId", required("apns.team-id"));
+		ReflectionTestUtils.setField(client, "bundleId", required("apns.bundle-id"));
+		ReflectionTestUtils.setField(client, "host",
+				System.getProperty("apns.host", "https://api.push.apple.com"));
+
+		assertThat(client.isAvailable()).isTrue();
+
+		// 실제 액티비티 토큰과 같은 길이(64 hex)의 존재하지 않는 토큰.
+		String dummyToken = "0".repeat(64);
+		Map<String, Object> contentState = new LinkedHashMap<>();
+		contentState.put("phase", "playing");
+		contentState.put("setNumber", 1);
+		contentState.put("scoreA", 0);
+		contentState.put("scoreB", 0);
+		contentState.put("statusLabel", "");
+
+		// 토큰이 가짜라 성공할 수 없다. 예외 없이 돌아오면 요청 자체는 나간 것이고,
+		// 인증 성공/실패는 로그의 status·reason 으로 가린다.
+		client.sendUpdate(dummyToken, contentState);
+	}
+
+	private String required(String key) {
+		String value = System.getProperty(key);
+		if (value == null || value.isBlank()) {
+			throw new IllegalStateException("-D" + key + " 를 지정해야 합니다.");
+		}
+		return value;
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -1,0 +1,153 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LiveActivityPushServiceTest {
+
+	private LiveActivityTokenRepository tokenRepository;
+	private ApnsLiveActivityClient apnsClient;
+	private LiveActivityPushService service;
+
+	@BeforeEach
+	void setUp() {
+		tokenRepository = mock(LiveActivityTokenRepository.class);
+		apnsClient = mock(ApnsLiveActivityClient.class);
+		service = new LiveActivityPushService(tokenRepository, apnsClient);
+		when(apnsClient.isAvailable()).thenReturn(true);
+		when(apnsClient.sendUpdate(anyString(), any())).thenReturn(true);
+		when(apnsClient.sendEnd(anyString(), any(), any())).thenReturn(true);
+	}
+
+	@Test
+	void 세트_시작은_진행중_상태와_경과시간_기준점을_보낸다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 2, 1, 0);
+
+		Map<String, Object> state = captureUpdate();
+		assertThat(state).containsEntry("phase", "playing")
+				.containsEntry("setNumber", 2)
+				.containsEntry("scoreA", 1)
+				.containsEntry("scoreB", 0)
+				// 위젯이 이 기준점으로 경과 시간을 스스로 흘린다(초 단위 푸시 불필요).
+				.containsKey("setStartedAt");
+		assertThat(state).doesNotContainKey("winnerTeamCode");
+	}
+
+	@Test
+	void 스코어가_null_이면_0으로_보낸다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 1, null, null);
+
+		assertThat(captureUpdate()).containsEntry("scoreA", 0).containsEntry("scoreB", 0);
+	}
+
+	@Test
+	void 세트만_끝나면_update_로_보내고_토큰을_유지한다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetEnd("match-1", 1, 1, 0, false, null);
+
+		Map<String, Object> state = captureUpdate();
+		assertThat(state).containsEntry("phase", "setEnded")
+				.containsEntry("statusLabel", "다음 세트 준비 중")
+				.doesNotContainKey("winnerTeamCode");
+		verify(tokenRepository, never()).deactivateByPushTokenIn(any());
+	}
+
+	@Test
+	void 매치가_끝나면_end_로_보내고_토큰을_정리한다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1", "tok-2"));
+
+		service.notifySetEnd("match-1", 3, 2, 1, true, "T1");
+
+		ArgumentCaptor<Map<String, Object>> captor = mapCaptor();
+		verify(apnsClient).sendEnd(eq("tok-1"), captor.capture(), any(Duration.class));
+		assertThat(captor.getValue()).containsEntry("phase", "matchEnded")
+				.containsEntry("statusLabel", "경기 종료")
+				.containsEntry("winnerTeamCode", "T1");
+		// 끝난 카드는 더 갱신되지 않으므로 죽은 토큰 여부와 무관하게 전부 비활성화한다.
+		verify(tokenRepository).deactivateByPushTokenIn(List.of("tok-1", "tok-2"));
+	}
+
+	@Test
+	void APNs_가_죽었다고_한_토큰만_비활성화한다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("live", "dead"));
+		when(apnsClient.sendUpdate(eq("dead"), any())).thenReturn(false);
+
+		service.notifySetStart("match-1", 1, 0, 0);
+
+		verify(tokenRepository).deactivateByPushTokenIn(List.of("dead"));
+	}
+
+	@Test
+	void APNs_설정이_없으면_조회조차_하지_않는다() {
+		when(apnsClient.isAvailable()).thenReturn(false);
+
+		service.notifySetStart("match-1", 1, 0, 0);
+
+		verify(tokenRepository, never()).findActivePushTokensByMatchId(anyString());
+	}
+
+	@Test
+	void 카드가_없는_매치는_발송하지_않는다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of());
+
+		service.notifySetStart("match-1", 1, 0, 0);
+
+		verify(apnsClient, never()).sendUpdate(anyString(), any());
+	}
+
+	@Test
+	void 토큰_조회가_실패해도_예외가_새지_않는다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1"))
+				.thenThrow(new RuntimeException("DB down"));
+
+		service.notifySetStart("match-1", 1, 0, 0);
+
+		verify(apnsClient, never()).sendUpdate(anyString(), any());
+	}
+
+	/**
+	 * Swift {@code Date} 의 기본 Codable 인코딩은 Unix epoch 가 아니라 2001-01-01 기준 초다.
+	 * 여길 틀리면 위젯 경과 시간이 31년 어긋난 채 조용히 표시된다.
+	 */
+	@Test
+	void 애플_기준시_변환은_2001년_기준_초다() {
+		assertThat(ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.parse("2001-01-01T00:00:00Z")))
+				.isZero();
+		assertThat(ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.parse("2001-01-01T00:01:00Z")))
+				.isEqualTo(60.0);
+		assertThat(ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.ofEpochSecond(0)))
+				.isEqualTo(-978_307_200.0);
+	}
+
+	private Map<String, Object> captureUpdate() {
+		ArgumentCaptor<Map<String, Object>> captor = mapCaptor();
+		verify(apnsClient).sendUpdate(anyString(), captor.capture());
+		return captor.getValue();
+	}
+
+	@SuppressWarnings("unchecked")
+	private ArgumentCaptor<Map<String, Object>> mapCaptor() {
+		return ArgumentCaptor.forClass(Map.class);
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -84,8 +84,9 @@ class LiveActivityPushServiceTest {
 		assertThat(captor.getValue()).containsEntry("phase", "matchEnded")
 				.containsEntry("statusLabel", "경기 종료")
 				.containsEntry("winnerTeamCode", "T1");
-		// 끝난 카드는 더 갱신되지 않으므로 죽은 토큰 여부와 무관하게 전부 비활성화한다.
-		verify(tokenRepository).deactivateByPushTokenIn(List.of("tok-1", "tok-2"));
+		// 끝난 카드는 더 갱신되지 않으므로 매치 단위로 한 번에 정리한다(IN 절로 토큰을 나열하지 않는다).
+		verify(tokenRepository).deactivateAllByMatchId("match-1");
+		verify(tokenRepository, never()).deactivateByPushTokenIn(any());
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -156,6 +156,90 @@ class LiveActivityPushServiceTest {
 	}
 
 	@Test
+	void 다음_세트가_시작된_뒤_도착한_이전_세트_종료는_버린다() {
+		// 2026-07-31 LCK Gen.G vs T1 실측: 업스트림이 끝난 게임 id 를 계속 실어 보내
+		// 1세트 종료가 2세트 진행 중에 5회 추가 발화했다. 그대로 두면 2세트를 하는 내내
+		// 카드가 "SET 1 종료 / 다음 세트 준비 중" 으로 덮인다.
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 1, 0, 0);
+		service.notifySetEnd("match-1", 1, 0, 1, false, null);
+		service.notifySetStart("match-1", 2, 0, 1);
+		org.mockito.Mockito.clearInvocations(apnsClient);
+
+		service.notifySetEnd("match-1", 1, 0, 1, false, null);   // 재발화
+		service.notifySetEnd("match-1", 1, 0, 1, false, null);
+
+		verify(apnsClient, never()).sendUpdateAsync(anyString(), any());
+	}
+
+	@Test
+	void 낡은_세트_종료가_매치_종료로_판정돼도_카드를_닫지_않는다() {
+		// 치명 케이스: 재발화한 1세트 종료를 그 시점 스코어(0:2)로 계산하면 matchEnded=true 가 된다.
+		// 그대로 나가면 end 이벤트 + 토큰 전체 비활성화라 남은 세트 동안 카드가 영구히 멈춘다.
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 1, 0, 0);
+		service.notifySetEnd("match-1", 1, 0, 1, false, null);
+		service.notifySetStart("match-1", 2, 0, 1);
+		org.mockito.Mockito.clearInvocations(apnsClient, tokenRepository);
+
+		service.notifySetEnd("match-1", 1, 0, 2, true, "GEN");   // 낡은 세트 번호 + 현재 스코어
+
+		verify(apnsClient, never()).sendEndAsync(anyString(), any(), any());
+		verify(tokenRepository, never()).deactivateAllByMatchId(anyString());
+	}
+
+	@Test
+	void 정상_순서는_모두_통과한다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 1, 0, 0);
+		service.notifySetEnd("match-1", 1, 1, 0, false, null);
+		service.notifySetStart("match-1", 2, 1, 0);
+		service.notifySetEnd("match-1", 2, 1, 1, false, null);
+		service.notifySetStart("match-1", 3, 1, 1);
+
+		verify(apnsClient, org.mockito.Mockito.times(5)).sendUpdateAsync(anyString(), any());
+
+		service.notifySetEnd("match-1", 3, 2, 1, true, "T1");
+		verify(apnsClient).sendEndAsync(anyString(), any(), any());
+	}
+
+	@Test
+	void 같은_상태_재발화는_통과시킨다() {
+		// 같은 세트를 다시 그리는 것뿐이라 무해하고, 그 사이 스코어가 갱신됐을 수 있다.
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 2, 1, 0);
+		service.notifySetStart("match-1", 2, 1, 0);
+
+		verify(apnsClient, org.mockito.Mockito.times(2)).sendUpdateAsync(anyString(), any());
+	}
+
+	@Test
+	void 세트_번호를_모르면_카드를_갱신하지_않는다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 0, 0, 0);
+
+		verify(apnsClient, never()).sendUpdateAsync(anyString(), any());
+	}
+
+	@Test
+	void 매치가_달라지면_진행도가_섞이지_않는다() {
+		when(tokenRepository.findActivePushTokensByMatchId(anyString())).thenReturn(List.of("tok-1"));
+
+		service.notifySetStart("match-1", 3, 1, 1);
+		org.mockito.Mockito.clearInvocations(apnsClient);
+
+		// 다른 경기의 1세트는 match-1 의 3세트와 무관하게 통과해야 한다.
+		service.notifySetStart("match-2", 1, 0, 0);
+
+		verify(apnsClient).sendUpdateAsync(anyString(), any());
+	}
+
+	@Test
 	void 토큰_조회가_실패해도_예외가_새지_않는다() {
 		when(tokenRepository.findActivePushTokensByMatchId("match-1"))
 				.thenThrow(new RuntimeException("DB down"));

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -30,8 +30,8 @@ class LiveActivityPushServiceTest {
 		apnsClient = mock(ApnsLiveActivityClient.class);
 		service = new LiveActivityPushService(tokenRepository, apnsClient);
 		when(apnsClient.isAvailable()).thenReturn(true);
-		when(apnsClient.sendUpdate(anyString(), any())).thenReturn(true);
-		when(apnsClient.sendEnd(anyString(), any(), any())).thenReturn(true);
+		when(apnsClient.sendUpdateAsync(anyString(), any())).thenReturn(alive(true));
+		when(apnsClient.sendEndAsync(anyString(), any(), any())).thenReturn(alive(true));
 	}
 
 	@Test
@@ -80,7 +80,7 @@ class LiveActivityPushServiceTest {
 		service.notifySetEnd("match-1", 3, 2, 1, true, "T1");
 
 		ArgumentCaptor<Map<String, Object>> captor = mapCaptor();
-		verify(apnsClient).sendEnd(eq("tok-1"), captor.capture(), any(Duration.class));
+		verify(apnsClient).sendEndAsync(eq("tok-1"), captor.capture(), any(Duration.class));
 		assertThat(captor.getValue()).containsEntry("phase", "matchEnded")
 				.containsEntry("statusLabel", "경기 종료")
 				.containsEntry("winnerTeamCode", "T1");
@@ -91,7 +91,7 @@ class LiveActivityPushServiceTest {
 	@Test
 	void APNs_가_죽었다고_한_토큰만_비활성화한다() {
 		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("live", "dead"));
-		when(apnsClient.sendUpdate(eq("dead"), any())).thenReturn(false);
+		when(apnsClient.sendUpdateAsync(eq("dead"), any())).thenReturn(alive(false));
 
 		service.notifySetStart("match-1", 1, 0, 0);
 
@@ -113,7 +113,45 @@ class LiveActivityPushServiceTest {
 
 		service.notifySetStart("match-1", 1, 0, 0);
 
-		verify(apnsClient, never()).sendUpdate(anyString(), any());
+		verify(apnsClient, never()).sendUpdateAsync(anyString(), any());
+	}
+
+	@Test
+	void 카드가_많아도_왕복을_직렬로_쌓지_않는다() throws Exception {
+		// 동기 발송을 토큰 수만큼 반복하면 카드가 많은 경기에서 마지막 사람은 세트가 끝난 뒤에
+		// 카드가 갱신된다(FCM 쪽 1,500명 팬아웃 8~18분 실사고와 같은 모양).
+		// 전부 띄운 뒤에 기다려야 하므로, 첫 응답이 늦어도 나머지 발송이 먼저 나가 있어야 한다.
+		int cardCount = 200;
+		List<String> tokens = java.util.stream.IntStream.range(0, cardCount)
+				.mapToObj(i -> "tok-" + i).toList();
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(tokens);
+
+		java.util.concurrent.CountDownLatch allDispatched =
+				new java.util.concurrent.CountDownLatch(cardCount);
+		java.util.concurrent.CompletableFuture<Boolean> blocked = new java.util.concurrent.CompletableFuture<>();
+		when(apnsClient.sendUpdateAsync(anyString(), any())).thenAnswer(invocation -> {
+			allDispatched.countDown();
+			// 첫 토큰만 늦게 끝난다. 직렬이라면 여기서 막혀 나머지가 발송되지 않는다.
+			return "tok-0".equals(invocation.getArgument(0)) ? blocked : alive(true);
+		});
+
+		Thread caller = new Thread(() -> service.notifySetStart("match-1", 1, 0, 0));
+		// 직렬로 회귀하면 caller 가 blocked 에 갇힌다. 데몬으로 두어 실패가 빌드를 멈추지 않게 한다.
+		caller.setDaemon(true);
+		caller.start();
+
+		boolean dispatchedWithoutWaiting;
+		try {
+			dispatchedWithoutWaiting = allDispatched.await(5, java.util.concurrent.TimeUnit.SECONDS);
+		} finally {
+			blocked.complete(true);
+		}
+
+		assertThat(dispatchedWithoutWaiting)
+				.as("느린 토큰 하나가 나머지 발송을 막으면 안 된다")
+				.isTrue();
+		caller.join(5_000);
+		verify(apnsClient, org.mockito.Mockito.times(cardCount)).sendUpdateAsync(anyString(), any());
 	}
 
 	@Test
@@ -123,13 +161,17 @@ class LiveActivityPushServiceTest {
 
 		service.notifySetStart("match-1", 1, 0, 0);
 
-		verify(apnsClient, never()).sendUpdate(anyString(), any());
+		verify(apnsClient, never()).sendUpdateAsync(anyString(), any());
 	}
 
 	private Map<String, Object> captureUpdate() {
 		ArgumentCaptor<Map<String, Object>> captor = mapCaptor();
-		verify(apnsClient).sendUpdate(anyString(), captor.capture());
+		verify(apnsClient).sendUpdateAsync(anyString(), captor.capture());
 		return captor.getValue();
+	}
+
+	private java.util.concurrent.CompletableFuture<Boolean> alive(boolean value) {
+		return java.util.concurrent.CompletableFuture.completedFuture(value);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +35,7 @@ class LiveActivityPushServiceTest {
 	}
 
 	@Test
-	void 세트_시작은_진행중_상태와_경과시간_기준점을_보낸다() {
+	void 세트_시작은_진행중_상태와_스코어만_보낸다() {
 		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
 
 		service.notifySetStart("match-1", 2, 1, 0);
@@ -46,9 +45,10 @@ class LiveActivityPushServiceTest {
 				.containsEntry("setNumber", 2)
 				.containsEntry("scoreA", 1)
 				.containsEntry("scoreB", 0)
-				// 위젯이 이 기준점으로 경과 시간을 스스로 흘린다(초 단위 푸시 불필요).
-				.containsKey("setStartedAt");
-		assertThat(state).doesNotContainKey("winnerTeamCode");
+				.doesNotContainKey("winnerTeamCode")
+				// 카드에서 경과 시간을 뺐다. 시간 관련 필드는 싣지 않는다.
+				.doesNotContainKey("setStartedAt")
+				.doesNotContainKey("frozenTime");
 	}
 
 	@Test
@@ -124,20 +124,6 @@ class LiveActivityPushServiceTest {
 		service.notifySetStart("match-1", 1, 0, 0);
 
 		verify(apnsClient, never()).sendUpdate(anyString(), any());
-	}
-
-	/**
-	 * Swift {@code Date} 의 기본 Codable 인코딩은 Unix epoch 가 아니라 2001-01-01 기준 초다.
-	 * 여길 틀리면 위젯 경과 시간이 31년 어긋난 채 조용히 표시된다.
-	 */
-	@Test
-	void 애플_기준시_변환은_2001년_기준_초다() {
-		assertThat(ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.parse("2001-01-01T00:00:00Z")))
-				.isZero();
-		assertThat(ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.parse("2001-01-01T00:01:00Z")))
-				.isEqualTo(60.0);
-		assertThat(ApnsLiveActivityClient.toAppleReferenceSeconds(Instant.ofEpochSecond(0)))
-				.isEqualTo(-978_307_200.0);
 	}
 
 	private Map<String, Object> captureUpdate() {

--- a/src/test/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepositoryTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepositoryTest.java
@@ -1,0 +1,129 @@
+package com.toy.nar.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Live Activity 토큰 조회/정리 쿼리 검증.
+ *
+ * <p>발송 경로는 전부 mock 으로 덮여 있어 JPQL 자체는 한 번도 실행되지 않는다.
+ * 여기서 실제 EntityManager 로 돌려 쿼리가 파싱되고 의도대로 동작하는지 확인한다
+ * (틀리면 프로덕션에서 리포지토리 빈 생성 시점에 기동이 실패한다).</p>
+ */
+@DataJpaTest(properties = {
+		"spring.flyway.enabled=false",
+		"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+// 이 패키지에 @SpringBootConfiguration 을 품은 MySQL 통합 테스트가 여럿 있어
+// 자동 탐색이 "multiple @SpringBootConfiguration" 으로 실패한다. 설정을 직접 지정한다.
+@ContextConfiguration(classes = LiveActivityTokenRepositoryTest.TestJpaConfiguration.class)
+class LiveActivityTokenRepositoryTest {
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	// 엔티티는 도메인 전체를 스캔한다(서로 물려 있어 일부만 담으면 매핑이 깨진다).
+	// 리포지토리 스캔만 member 로 좁혀 Elasticsearch 리포지토리를 피한다.
+	@EntityScan(basePackages = "com.toy.nar.domain")
+	@EnableJpaRepositories(basePackageClasses = LiveActivityTokenRepository.class)
+	static class TestJpaConfiguration {
+	}
+
+	@Autowired
+	private LiveActivityTokenRepository tokenRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@BeforeEach
+	void seed() {
+		exec("INSERT INTO member (id, name, tag, role, created_at)"
+				+ " VALUES (1, '테스터', '0001', 'USER', CURRENT_TIMESTAMP)");
+		exec("INSERT INTO member (id, name, tag, role, created_at)"
+				+ " VALUES (2, '테스터2', '0002', 'USER', CURRENT_TIMESTAMP)");
+		// match-1: 활성 2개 + 비활성 1개, match-2: 활성 1개
+		insertToken(1L, "match-1", "tok-a", 1L, true);
+		insertToken(2L, "match-1", "tok-b", 2L, true);
+		insertToken(3L, "match-1", "tok-dead", 1L, false);
+		insertToken(4L, "match-2", "tok-other", 1L, true);
+		em.flush();
+		em.clear();
+	}
+
+	@Test
+	void 매치의_활성_토큰만_돌려준다() {
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-1"))
+				.containsExactlyInAnyOrder("tok-a", "tok-b");
+	}
+
+	@Test
+	void 다른_매치의_토큰은_섞이지_않는다() {
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-2"))
+				.containsExactly("tok-other");
+	}
+
+	@Test
+	void 카드가_없는_매치는_빈_목록() {
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-없음")).isEmpty();
+	}
+
+	@Test
+	void 지정한_토큰만_비활성화한다() {
+		int updated = tokenRepository.deactivateByPushTokenIn(java.util.List.of("tok-a"));
+
+		assertThat(updated).isEqualTo(1);
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-1")).containsExactly("tok-b");
+	}
+
+	@Test
+	void 여러_토큰을_한_번에_비활성화한다() {
+		assertThat(tokenRepository.deactivateByPushTokenIn(java.util.List.of("tok-a", "tok-b"))).isEqualTo(2);
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-1")).isEmpty();
+		// 같은 회원의 다른 매치 카드는 살아 있어야 한다.
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-2")).containsExactly("tok-other");
+	}
+
+	@Test
+	void 푸시_토큰으로_단건_조회한다() {
+		assertThat(tokenRepository.findByPushToken("tok-a"))
+				.get()
+				.satisfies(token -> {
+					assertThat(token.getMatchId()).isEqualTo("match-1");
+					assertThat(token.isActive()).isTrue();
+				});
+		assertThat(tokenRepository.findByPushToken("없는토큰")).isEmpty();
+	}
+
+	@Test
+	void 재등록하면_매치가_갱신되고_다시_활성화된다() {
+		var token = tokenRepository.findByPushToken("tok-dead").orElseThrow();
+		token.reactivate(token.getMember(), "match-3");
+		tokenRepository.flush();
+		em.clear();
+
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-3")).containsExactly("tok-dead");
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-1"))
+				.containsExactlyInAnyOrder("tok-a", "tok-b");
+	}
+
+	private void insertToken(long id, String matchId, String pushToken, long memberId, boolean active) {
+		exec("INSERT INTO live_activity_token"
+				+ " (id, match_id, push_token, member_id, active, created_at, updated_at)"
+				+ " VALUES (" + id + ", '" + matchId + "', '" + pushToken + "', " + memberId + ", "
+				+ active + ", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)");
+	}
+
+	private void exec(String sql) {
+		em.createNativeQuery(sql).executeUpdate();
+	}
+}

--- a/src/test/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepositoryTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepositoryTest.java
@@ -94,6 +94,22 @@ class LiveActivityTokenRepositoryTest {
 	}
 
 	@Test
+	void 매치_단위로_한_번에_비활성화한다() {
+		assertThat(tokenRepository.deactivateAllByMatchId("match-1")).isEqualTo(2);
+
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-1")).isEmpty();
+		// 다른 매치는 건드리지 않는다.
+		assertThat(tokenRepository.findActivePushTokensByMatchId("match-2")).containsExactly("tok-other");
+	}
+
+	@Test
+	void 이미_비활성인_토큰은_다시_세지_않는다() {
+		// active = true 조건이 빠지면 이미 죽은 tok-dead 까지 세어 3 이 나온다.
+		assertThat(tokenRepository.deactivateAllByMatchId("match-1")).isEqualTo(2);
+		assertThat(tokenRepository.deactivateAllByMatchId("match-1")).isZero();
+	}
+
+	@Test
 	void 푸시_토큰으로_단건_조회한다() {
 		assertThat(tokenRepository.findByPushToken("tok-a"))
 				.get()


### PR DESCRIPTION
iOS Live Activity(잠금화면 실시간 경기 카드)를 서버가 직접 갱신하는 경로를 만든다. **기본 OFF이고, 이 PR만으로는 기존 동작이 하나도 바뀌지 않는다.**

## 왜 필요한가

현재 앱은 카드가 떠 있는 동안 30초마다 `/api/mobile/matches/{matchId}/games`를 다시 받아 갱신한다. 그런데 iOS는 백그라운드에서 타이머를 멈춘다. 잠금화면 카드를 보는 시나리오가 곧 백그라운드라, 실제로는 "앱을 켜 놓고 볼 때만 맞는 위젯"이었다.

APNs로 직접 쏘면 앱 프로세스와 무관하게 시스템이 위젯에 `content-state`를 적용한다.

**FCM으로는 대체할 수 없다.** ActivityKit 푸시 토큰은 FCM 등록 토큰이 아니라서 firebase-admin이 보낼 수 없다. 그래서 APNs HTTP/2 경로를 따로 뒀다.

## 구성

| 파일 | 역할 |
|---|---|
| `V63__Create_live_activity_token.sql` | 액티비티 단위 토큰 테이블 |
| `LiveActivityToken` + Repository | 매치별 활성 토큰 조회 / 죽은 토큰 비활성화 |
| `MobileLiveActivityController` | `POST`/`DELETE /api/mobile/me/live-activities` |
| `LiveActivityTokenService` | 등록·해제 (같은 토큰 재등록 시 매치 갱신) |
| `ApnsLiveActivityClient` | APNs HTTP/2 발송, ES256 JWT(50분 캐시) |
| `LiveActivityPushService` | content-state 조립 + fan-out + 토큰 정리 |

`member_device`와 별도 테이블인 이유: APNs가 발급하고, 기기가 아니라 **카드 하나**에 귀속되며, 카드가 끝나면 죽는다. 수명이 기기 등록과 전혀 다르다.

### 새 의존성 0개

JDK `HttpClient`(HTTP/2 내장) + 이미 있던 `jjwt 0.12.6`. pushy를 넣지 않았다 — 발송이 세트·스코어 변화 때만이라 경기당 10~20건이고, 그 규모에선 커넥션 풀·배치가 이득이 없다. 코드에 `ponytail:` 주석으로 상한과 전환 시점을 남겼다.

### 새 스케줄러 0개

`LivePollingScheduler`의 기존 프레임 트리거(`fireSetStartNotification` / `fireSetEndNotification`)에 붙였다. SET_END는 스코어 재조회(최대 60초) **뒤에** 보내 카드와 FCM 알림이 같은 스코어를 보게 한다.

카드 스코어는 매치 스코어를 그대로 싣는다. 앱은 세트 승자를 세어 만드는데 `set_winners`가 `'?'`면 누락되던 문제가 이 경로에선 생기지 않는다.

## 검증

**실물로 확인한 것**

- **실제 `.p8`로 APNs 인증 통과** — 더미 토큰에 `400 BadDeviceToken`. JWT ES256 서명·`apns-topic`·`apns-push-type`이 전부 수락됐다는 뜻이다 (`ApnsLiveActivityClientLocalSmokeTest`, 로컬 전용)
- **토큰 JPQL을 실제 EntityManager로** — 기본 빌드에서 풀 컨텍스트 테스트가 꺼져 있어, 쿼리가 틀렸다면 테스트를 다 통과하고 프로덕션 기동에서 터졌을 것이다 (`LiveActivityTokenRepositoryTest`)
- **V63을 로컬 MySQL 8.0에 실제 적용** 후 `SHOW CREATE TABLE` 확인
- **배포 셸 분기** 빈 값/채운 값 양쪽으로 실행

전체 477개 통과.

**아직 미검증 — 하나**

`content-state` JSON이 Swift `ContentState`로 디코드되는지. 어긋나면 APNs는 200을 주고 위젯만 안 바뀐다. 실기기 + 아래 클라 작업이 있어야 확인된다.

## 배포 / 활성화

`apns.*` 5개가 모두 채워져야 발송한다. 하나라도 비면 `isAvailable()=false`로 전 구간 skip이라 라이브 폴링 동작이 기존과 바이트 동일하다.

`.p8`은 Firebase 서비스 계정 키와 같은 경로를 탄다: GitHub Secret(base64) → `/opt/nar/secrets`에 chmod 600 → `/run/secrets`로 read-only 마운트. `APNS_KEY_BASE64`가 비어 있으면 설치·마운트를 건너뛰므로 키 없이도 배포가 깨지지 않는다.

## 지금 머지해도 안전한 이유

시크릿이 등록돼 `APNS_ENABLED=true`로 떠도, 클라가 아직 토큰을 올리지 않아 `findActivePushTokensByMatchId`가 항상 빈 목록이다. 세트 시작/종료마다 DB 조회 1회가 늘 뿐 발송은 0건이다.

---

## 클라 작업 인수 (별도 레포)

백엔드는 여기서 끝이고, 위젯이 실제로 갱신되려면 앱 쪽 작업이 필요하다.

### iOS

1. `LiveActivityPlugin.swift:108,114` — `pushType: nil` → `.token`
2. 같은 파일 — `activity.pushTokenUpdates` 관찰 → hex 문자열로 변환 → Dart로 전달
3. Dart — `POST /api/mobile/me/live-activities` `{matchId, pushToken}`. 액티비티 종료 시 `DELETE ?pushToken=`

토큰은 카드를 띄울 때마다 새로 발급되고 수명 중 갱신될 수 있다. **받을 때마다 그대로 올리면** 서버가 upsert한다.

### Android

`FirebaseMessagingService` 확장 → 백그라운드 data 메시지 수신 → 기존 `LiveActivityPlugin.show()` 호출. **백엔드 추가 작업 없음** — `TeamLiveEventPushService`가 이미 `type`/`matchId`/`setNumber`/`bestOf`/`blueScore`/`redScore`를 data에 싣는다.

함정: Flutter `onBackgroundMessage`는 별도 isolate라 메인 엔진의 MethodChannel에 못 닿는다. 네이티브 Kotlin에서 직접 해야 한다.

### 서버가 보내는 content-state — 이 모양을 그대로 맞춰야 한다

```
phase          : "playing" | "setEnded" | "matchEnded"
setNumber      : Int
scoreA         : Int
scoreB         : Int
statusLabel    : String     // playing "", setEnded "다음 세트 준비 중", matchEnded "경기 종료"
winnerTeamCode : String?    // matchEnded 일 때만
```

`aps.event`는 `update`, 매치 종료 시 `end` + `dismissal-date`(30분 뒤). 서버가 카드를 내리므로 앱의 자동 dismiss 타이머 없이도 정리된다.

### 백엔드가 하지 않는 것

- **push-to-start 없음** — 서버가 카드를 만들 수 없다. 앱이 카드를 띄우는 경로(`scanForLiveMatch()`)를 **유지해야** 한다
- **LIVE_EVENT(킬·오브젝트) 미연결** — 세트 시작/종료만 갱신한다

## 별도로 미뤄둔 것

세트 `status=LIVE`가 라이브 디스커버리 등장(=픽밴 시작) 시점에 붙어, 실제 인게임보다 픽밴 시간(수 분)만큼 이르다. SET_START 푸시는 첫 프레임에 나가므로 그 사이 위젯은 "경기 중"인데 알림은 안 온 상태가 된다.

수정 커밋을 만들어뒀지만 요청에 따라 이 PR에서 제외했다 (`deferred/live-status-frame-gate` 브랜치에 보존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
