### PR TITLE
fix: 대시보드 시간 버킷이 DB 세션 타임존 따라 9시간 밀리던 문제

### DIFF
--- a/src/main/java/com/toy/nar/app/admin/service/AdminStatsService.java
+++ b/src/main/java/com/toy/nar/app/admin/service/AdminStatsService.java
@@ -9,10 +9,8 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -34,6 +32,7 @@ public class AdminStatsService {
     private static final int TOP_LIMIT = 10;
     private static final String HOUR = "HOUR";
     private static final DateTimeFormatter BUCKET_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:00");
+    private static final LocalDateTime EPOCH_DATE = LocalDateTime.of(1970, 1, 1, 0, 0);
 
     private final AdminStatsRepository statsRepository;
 
@@ -83,10 +82,14 @@ public class AdminStatsService {
         return LocalDate.now().minusDays(clampDays(days) - 1L).atStartOfDay();
     }
 
-    /** 에폭 시(정수) → {@code 2026-08-02T13:00}. 포맷을 SQL 이 아니라 여기서 하는 이유는 리포지토리 주석 참고. */
-    private static String bucketLabel(long epochHour) {
-        return LocalDateTime.ofInstant(Instant.ofEpochSecond(epochHour * 3600), ZoneId.systemDefault())
-                .format(BUCKET_FORMAT);
+    /**
+     * 버킷 정수 → {@code 2026-08-02T13:00}. 포맷을 SQL 이 아니라 여기서 하는 이유는 리포지토리 주석 참고.
+     *
+     * <p>정수는 <b>에폭 시각이 아니라</b> 1970-01-01 기준 벽시계 시간 수다(리포지토리의 {@code TIMESTAMPDIFF}).
+     * 그래서 타임존 변환 없이 그대로 되돌린다 — 여기서 {@code ZoneId} 를 끼우면 DB 세션 타임존에 따라 버킷이 밀린다.
+     */
+    private static String bucketLabel(long hoursSinceEpochDate) {
+        return EPOCH_DATE.plusHours(hoursSinceEpochDate).format(BUCKET_FORMAT);
     }
 
     private static List<StatsOverviewResponse.LabelCount> toLabelCounts(

--- a/src/main/java/com/toy/nar/domain/member/repository/AdminStatsRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/AdminStatsRepository.java
@@ -18,13 +18,19 @@ import java.util.List;
  * (일별/24시간 뷰가 쿼리 하나를 공유하고, 24시간 롤링 윈도가 자정을 가로질러도 그대로 만들어진다).
  * 값이 0인 버킷은 행 자체가 없다 — 빈 구간 채우기는 화면 쪽 책임.
  *
- * <p>버킷 키는 <b>에폭 시(epoch hour)</b> 정수다. 문자열({@code DATE_FORMAT})로 그룹핑하면 35만 행짜리
+ * <p>버킷 키는 <b>1970-01-01 부터 흐른 시간(hour)</b> 정수다. 문자열({@code DATE_FORMAT})로 그룹핑하면 35만 행짜리
  * 알림 집계가 프로덕션에서 3,311ms 걸렸고, 같은 쿼리를 정수 키로 바꾸니 1,257ms 였다(2026-08-03 EXPLAIN ANALYZE
  * 실측). 사람이 읽을 포맷 변환은 서비스에서 한다.
+ *
+ * <p><b>{@code UNIX_TIMESTAMP()} 를 쓰지 않는 이유</b>: {@code created_at} 은 타임존 없는 {@code DATETIME}(=KST 벽시계)
+ * 인데 {@code UNIX_TIMESTAMP()} 는 그 값을 <b>MySQL 세션 {@code time_zone} 기준</b>으로 해석한다. JDBC 의
+ * {@code serverTimezone}/{@code connectionTimeZone} 은 클라이언트 변환 옵션일 뿐 세션 타임존을 바꾸지 않으므로,
+ * DB 서버가 UTC 면 버킷이 9시간 밀린다(프로덕션에서 실제로 밀렸다). {@code TIMESTAMPDIFF} 는 벽시계끼리의
+ * 순수 산술이라 세션 타임존과 무관하고, 문자열 시절 {@code DATE_FORMAT} 과 의미가 정확히 같다.
  */
 public interface AdminStatsRepository extends Repository<Member, Long> {
 
-    /** {@code bucket} = 에폭 시(= 유닉스 시각 / 3600), {@code cnt} = 그 1시간 동안의 건수. */
+    /** {@code bucket} = 1970-01-01 00:00 부터 흐른 시간(벽시계 기준), {@code cnt} = 그 1시간 동안의 건수. */
     interface HourCount {
         long getBucket();
 
@@ -58,7 +64,7 @@ public interface AdminStatsRepository extends Repository<Member, Long> {
     }
 
     @Query(value = """
-            SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600) AS bucket, COUNT(*) AS cnt
+            SELECT TIMESTAMPDIFF(HOUR, '1970-01-01', created_at) AS bucket, COUNT(*) AS cnt
             FROM member
             WHERE created_at >= :from
             GROUP BY bucket
@@ -76,13 +82,13 @@ public interface AdminStatsRepository extends Repository<Member, Long> {
                    SUM(t) AS teamCnt,
                    SUM(m) AS matchCnt
             FROM (
-                SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600) AS bucket, COUNT(*) AS p, 0 AS t, 0 AS m
+                SELECT TIMESTAMPDIFF(HOUR, '1970-01-01', created_at) AS bucket, COUNT(*) AS p, 0 AS t, 0 AS m
                 FROM member_favorite_player WHERE created_at >= :from GROUP BY bucket
                 UNION ALL
-                SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600), 0, COUNT(*), 0
+                SELECT TIMESTAMPDIFF(HOUR, '1970-01-01', created_at), 0, COUNT(*), 0
                 FROM member_team_notification_subscription WHERE created_at >= :from GROUP BY 1
                 UNION ALL
-                SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600), 0, 0, COUNT(*)
+                SELECT TIMESTAMPDIFF(HOUR, '1970-01-01', created_at), 0, 0, COUNT(*)
                 FROM member_match_subscription WHERE created_at >= :from GROUP BY 1
             ) x
             GROUP BY bucket
@@ -98,7 +104,7 @@ public interface AdminStatsRepository extends Repository<Member, Long> {
      * 그래서 별도 엔드포인트 + 캐시로 분리해 나머지 카드가 먼저 그려지게 한다.
      */
     @Query(value = """
-            SELECT FLOOR(UNIX_TIMESTAMP(created_at) / 3600) AS bucket, COUNT(*) AS cnt
+            SELECT TIMESTAMPDIFF(HOUR, '1970-01-01', created_at) AS bucket, COUNT(*) AS cnt
             FROM member_notification
             WHERE created_at >= :from
             GROUP BY bucket

--- a/src/test/java/com/toy/nar/domain/member/repository/AdminStatsRepositoryMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/AdminStatsRepositoryMySqlIntegrationTest.java
@@ -125,9 +125,12 @@ class AdminStatsRepositoryMySqlIntegrationTest {
     }
 
     /** 리포지토리는 에폭 시(유닉스 시각/3600) 정수를 버킷 키로 준다. */
+    /**
+     * 버킷 = 1970-01-01 부터 흐른 <b>벽시계</b> 시간 수. 타임존을 끼우면 안 된다 — 끼우는 순간
+     * DB 세션 타임존이 UTC 인 프로덕션에서 버킷이 밀렸던 그 버그를 테스트가 그대로 재현해 통과시킨다.
+     */
     private static long bucketOf(LocalDateTime at) {
-        return at.withMinute(0).withSecond(0).withNano(0)
-                .atZone(java.time.ZoneId.systemDefault()).toEpochSecond() / 3600;
+        return java.time.temporal.ChronoUnit.HOURS.between(LocalDateTime.of(1970, 1, 1, 0, 0), at);
     }
 
     @Test


### PR DESCRIPTION
## 증상

백오피스 대시보드의 **일별 신규 가입**이 회원 목록의 `가입일`과 안 맞았다.

- 막대 하나가 자정~자정이 아니라 **전날 15:00 ~ 당일 15:00** 구간
- 오늘 15시 이후 가입자는 존재하지 않는 *내일* 날짜 버킷으로 밀려 차트에서 통째로 누락
- 가입뿐 아니라 구독·알림 시리즈도 같이 밀림

#343 (`42aeadc`, 8/3) 이후 발생한 리그레션.

## 원인

#343에서 성능을 위해 버킷 키를 문자열에서 정수로 바꿨다.

```sql
-- 전: 저장된 벽시계를 그대로 포맷 → 타임존 무관
DATE_FORMAT(created_at, '%Y-%m-%dT%H:00')
-- 후: 타임존 의존
FLOOR(UNIX_TIMESTAMP(created_at) / 3600)
```

`member.created_at` 은 타임존 없는 `DATETIME`(`V32__Create_member_table.sql`)이고 값은 JVM(KST, `Dockerfile` 의 `TZ=Asia/Seoul`)이 넣은 **KST 벽시계**다. 그런데 `UNIX_TIMESTAMP()` 는 그 값을 **MySQL 세션 `time_zone` 기준**으로 해석한다. JDBC 의 `serverTimezone`/`connectionTimeZone` 은 클라이언트 변환 옵션일 뿐 세션 타임존을 바꾸지 않으므로(`forceConnectionTimeZoneToSession` 미사용), DB 서버가 UTC 면:

```
저장값 08-04 10:00 (실제 KST 10시)
 → UNIX_TIMESTAMP 이 값을 UTC로 해석
 → AdminStatsService.bucketLabel 이 ZoneId.systemDefault()=KST 로 되돌림
 → 라벨 "08-04T19:00"  (+9h)
```

로컬 MySQL 은 `docker-compose.yml` 에서 `TZ: Asia/Seoul` 이라 통합 테스트가 못 잡았다.

## 수정

버킷 키를 벽시계끼리의 순수 산술로 바꾼다.

```sql
TIMESTAMPDIFF(HOUR, '1970-01-01', created_at)
```

- 세션 타임존과 무관
- 문자열 시절 `DATE_FORMAT` 과 의미가 정확히 동일
- 여전히 정수 그룹핑이라 #343 의 성능 이득(3,311ms → 1,257ms) 그대로

서비스의 `bucketLabel` 도 `Instant`/`ZoneId` 를 걷어내고 `1970-01-01` 에 시간을 더하는 방식으로 맞췄다.

## 검증

로컬 MySQL 에서 세션 tz 만 바꿔 같은 값을 조회:

| 세션 tz | `FLOOR(UNIX_TIMESTAMP/3600)` | `TIMESTAMPDIFF` |
|---|---|---|
| UTC | 496066 | 496066 |
| KST | 496057 | **496066** |

`UNIX_TIMESTAMP` 는 9시간 흔들리고 `TIMESTAMPDIFF` 는 불변. UTC 세션의 496066 을 KST 로 되돌리면 `10:00` 이 `19:00` 이 되는 것이 정확히 이 버그다.

- `./gradlew compileJava compileTestJava` 통과
- `AdminStatsRepositoryMySqlIntegrationTest` 실제 MySQL 8 대상 **6/6 통과, skip 0**

통합 테스트의 `bucketOf` 헬퍼도 타임존 없는 계산으로 고쳤다. 기존처럼 `systemDefault()` 로 계산하면 로컬 DB(Asia/Seoul)에서는 버그가 재현되지 않아 회귀해도 그대로 통과한다.

## 배포 메모

- 프론트(`warding-backoffice-fe`)는 변경 없음 — 집계 산수는 정상이었다
- 1분 캐시는 서버 재시작 때 비므로 별도 조치 불필요
- prod DB 세션 타임존이 실제로 UTC 였는지는 `SELECT @@session.time_zone, NOW(), UTC_TIMESTAMP();` 로 확인 가능. 다만 이 패치는 타임존이 무엇이든 정상 동작한다

🤖 Generated with [Claude Code](https://claude.com/claude-code)