### PR TITLE
perf: 솔랭 푸시 팬아웃을 멀티캐스트·벌크로 묶음

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/MobilePushResult.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/MobilePushResult.java
@@ -13,9 +13,4 @@ public record MobilePushResult(
 		int failureCount,
 		List<String> invalidTokens,
 		List<String> successTokens) {
-
-	/** 토큰별 결과가 필요 없는 호출부(단일 구독자 발송 등)를 위한 생성자. */
-	public MobilePushResult(int successCount, int failureCount, List<String> invalidTokens) {
-		this(successCount, failureCount, invalidTokens, List.of());
-	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -11,9 +11,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -77,16 +81,11 @@ public class PlayerSoloRankPushService {
 		sendToAllSoloRankTopic(player, gameId, message);
 
 		try {
-			List<MemberDevice> devices = deviceRepository.findActiveDevicesBySubscribedPlayerId(player.getId());
-			Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
-					.collect(Collectors.groupingBy(
-							device -> device.getMember().getId(),
-							LinkedHashMap::new,
-							Collectors.toList()));
-
-			for (Map.Entry<Long, List<MemberDevice>> entry : devicesByMember.entrySet()) {
-				sendToMember(entry.getKey(), entry.getValue(), player, gameId, message);
-			}
+			fanOutBatched(
+					deviceRepository.findActiveDevicesBySubscribedPlayerId(player.getId()),
+					player,
+					gameId,
+					message);
 		} catch (Exception e) {
 			log.warn(
 					"Failed to prepare player solo rank pushes playerId={} gameId={}",
@@ -108,40 +107,81 @@ public class PlayerSoloRankPushService {
 		}
 	}
 
-	private void sendToMember(
-			Long memberId,
+	/**
+	 * 구독자 전원에게 한 번의 발송 호출로 보낸다.
+	 *
+	 * <p>예전엔 구독자마다 {@code pushGateway.send} 와 예약·마감 쿼리를 한 건씩 돌았다.
+	 * 실측 2026-08-04 프로덕션: Oner 구독자 1,502명 팬아웃이 472초(1명당 0.31초)였고,
+	 * 이 팬아웃이 솔랭 폴 스레드에서 동기로 돌기 때문에 그 사이 추적 100계정 폴링이 통째로 멈췄다
+	 * (22:27→22:41 동안 신규 게임 감지 0건, 알림이 게임 시작 10분 뒤에 도착).</p>
+	 *
+	 * <p>게이트웨이가 500토큰씩 멀티캐스트하므로 토큰을 모아 한 번에 넘기면 FCM 왕복이
+	 * 구독자 수에서 500토큰 단위로 줄고, 예약·마감도 벌크라 DB 왕복이 상수가 된다.
+	 * 발송 후 토큰별 성공 여부로 구독자를 되돌려 기록한다.</p>
+	 */
+	private void fanOutBatched(
 			List<MemberDevice> devices,
 			Player player,
 			String gameId,
 			MobilePushMessage message) {
+		Map<Long, List<MemberDevice>> devicesByMember = devices.stream()
+				.collect(Collectors.groupingBy(
+						device -> device.getMember().getId(),
+						LinkedHashMap::new,
+						Collectors.toList()));
+		if (devicesByMember.isEmpty()) {
+			return;
+		}
+
+		// dedup: (member, playerId, gameId) 당 1회만 통과한다. 구독자 수만큼 왕복하지 않도록
+		// 한 번에 예약하고 발송 대상만 돌려받는다.
+		List<Long> reservedIds = deliveryRepository.reserveAll(
+				devicesByMember.keySet(), player.getId(), gameId);
+		if (reservedIds.isEmpty()) {
+			return;
+		}
+
+		Map<Long, List<String>> tokensByMember = new LinkedHashMap<>();
+		for (Long memberId : reservedIds) {
+			List<MemberDevice> memberDevices = devicesByMember.get(memberId);
+			if (memberDevices == null) {
+				continue;
+			}
+			tokensByMember.put(memberId, memberDevices.stream().map(MemberDevice::getFcmToken).toList());
+		}
+		if (tokensByMember.isEmpty()) {
+			return;
+		}
+
+		List<String> allTokens = tokensByMember.values().stream().flatMap(List::stream).toList();
+		MobilePushResult result;
 		try {
-			if (!deliveryRepository.reserve(memberId, player.getId(), gameId)) {
-				return;
-			}
-			List<String> tokens = devices.stream().map(MemberDevice::getFcmToken).toList();
-			MobilePushResult result = pushGateway.send(tokens, message);
-			if (!result.invalidTokens().isEmpty()) {
-				deactivateInvalidTokens(result.invalidTokens(), player.getId(), gameId);
-			}
-			if (result.successCount() > 0) {
-				deliveryRepository.markSent(memberId, player.getId(), gameId);
-				recordFeed(memberId, message);
-			} else {
-				deliveryRepository.markFailed(
-						memberId,
-						player.getId(),
-						gameId,
-						"FCM 전송 성공 기기가 없습니다.");
-			}
+			result = pushGateway.send(allTokens, message);
 		} catch (Exception e) {
-			String errorMessage = truncate(e.getMessage());
-			markFailed(memberId, player.getId(), gameId, errorMessage);
+			// 발송 자체가 실패하면 예약한 구독자 전원을 FAILED 로 남긴다(재예약 대상이 된다).
+			markFailedAll(List.copyOf(tokensByMember.keySet()), player.getId(), gameId, truncate(e.getMessage()));
 			log.warn(
-					"Player solo rank push failed memberId={} playerId={} gameId={}",
-					memberId,
+					"Player solo rank multicast failed playerId={} gameId={} members={} tokens={}",
 					player.getId(),
 					gameId,
+					tokensByMember.size(),
+					allTokens.size(),
 					e);
+			return;
+		}
+
+		Set<String> successTokens = new HashSet<>(result.successTokens());
+		List<Long> delivered = new ArrayList<>();
+		List<Long> undelivered = new ArrayList<>();
+		tokensByMember.forEach((memberId, tokens) ->
+				(tokens.stream().anyMatch(successTokens::contains) ? delivered : undelivered).add(memberId));
+
+		markSentAll(delivered, player.getId(), gameId);
+		markFailedAll(undelivered, player.getId(), gameId, "FCM 전송 성공 기기가 없습니다.");
+		recordFeedAll(delivered, message);
+
+		if (!result.invalidTokens().isEmpty()) {
+			deactivateInvalidTokens(result.invalidTokens(), player.getId(), gameId);
 		}
 	}
 
@@ -160,34 +200,56 @@ public class PlayerSoloRankPushService {
 		}
 	}
 
-	private void markFailed(
-			Long memberId,
+	private void markSentAll(Collection<Long> memberIds, Long playerId, String gameId) {
+		if (memberIds.isEmpty()) {
+			return;
+		}
+		try {
+			deliveryRepository.markSentAll(memberIds, playerId, gameId);
+		} catch (Exception e) {
+			log.warn(
+					"Failed to persist player push success playerId={} gameId={} members={}",
+					playerId,
+					gameId,
+					memberIds.size(),
+					e);
+		}
+	}
+
+	private void markFailedAll(
+			Collection<Long> memberIds,
 			Long playerId,
 			String gameId,
 			String errorMessage) {
+		if (memberIds.isEmpty()) {
+			return;
+		}
 		try {
-			deliveryRepository.markFailed(memberId, playerId, gameId, errorMessage);
+			deliveryRepository.markFailedAll(memberIds, playerId, gameId, errorMessage);
 		} catch (Exception persistenceException) {
 			log.warn(
-					"Failed to persist player push failure memberId={} playerId={} gameId={}",
-					memberId,
+					"Failed to persist player push failure playerId={} gameId={} members={}",
 					playerId,
 					gameId,
+					memberIds.size(),
 					persistenceException);
 		}
 	}
 
 	/** 마이구독 알림 피드에 기록한다. 피드 실패가 푸시 흐름을 깨면 안 되므로 예외를 흡수한다. */
-	private void recordFeed(Long memberId, MobilePushMessage message) {
+	private void recordFeedAll(Collection<Long> memberIds, MobilePushMessage message) {
+		if (memberIds.isEmpty()) {
+			return;
+		}
 		try {
-			notificationService.record(
-					memberId,
+			notificationService.recordAll(
+					memberIds,
 					MemberNotificationType.PLAYER_SOLO_RANK_STARTED,
 					message.title(),
 					message.body(),
 					message.data());
 		} catch (Exception e) {
-			log.warn("Failed to record solo rank notification feed memberId={}", memberId, e);
+			log.warn("Failed to record solo rank notification feed members={}", memberIds.size(), e);
 		}
 	}
 

--- a/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepository.java
@@ -2,92 +2,14 @@ package com.toy.nar.domain.member.repository;
 
 import com.toy.nar.domain.member.entity.PlayerSoloRankPushDelivery;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 솔랭 푸시 발송 기록.
+ *
+ * <p>예약·마감은 전부 {@link PlayerSoloRankPushDeliveryRepositoryCustom} 의 벌크 연산으로만 한다.
+ * 구독자 단위 단건 메서드는 두지 않는다 — 예약 판정 규칙(신규·FAILED·PENDING 5분 초과)이 두 곳에
+ * 갈라져 어긋나면 중복 발송이나 누락이 되고, 실제로 그 판정을 잘못 구현해 중복 발송이 난 적이 있다.</p>
+ */
 public interface PlayerSoloRankPushDeliveryRepository
-		extends JpaRepository<PlayerSoloRankPushDelivery, Long> {
-
-/*
-	 * [중복 발송 버그 수정] 기존 reserve 는 ON DUPLICATE KEY UPDATE + IF 패턴이라
-	 * MySQL CLIENT_FOUND_ROWS(커넥터 기본) 모드에서 이미 SENT 인 건도 0이 아닌 값을
-	 * 반환해 dedup 이 무력화됐다. INSERT IGNORE(신규) + WHERE 조건 UPDATE(재예약)로
-	 * 분리해 found-rows 모드에서도 정확하게 동작한다.
-	 */
-
-	/** 신규 예약. 이미 같은 키가 있으면 0. */
-	@Modifying
-	@Transactional
-	@Query(value = """
-			INSERT IGNORE INTO player_solo_rank_push_delivery (
-				member_id, player_id, game_id, status, created_at, updated_at
-			) VALUES (
-				:memberId, :playerId, :gameId, 'PENDING', NOW(), NOW()
-			)
-			""", nativeQuery = true)
-	int insertIfAbsent(
-			@Param("memberId") Long memberId,
-			@Param("playerId") Long playerId,
-			@Param("gameId") String gameId);
-
-	/** 재예약. 실패했거나 5분 넘게 PENDING 으로 방치된 건만 되살린다. SENT 는 재예약되지 않는다. */
-	@Modifying
-	@Transactional
-	@Query(value = """
-			UPDATE player_solo_rank_push_delivery
-			SET status = 'PENDING', error_message = NULL, updated_at = NOW()
-			WHERE member_id = :memberId
-			  AND player_id = :playerId
-			  AND game_id = :gameId
-			  AND (status = 'FAILED'
-					OR (status = 'PENDING' AND updated_at < DATE_SUB(NOW(), INTERVAL 5 MINUTE)))
-			""", nativeQuery = true)
-	int reactivateStale(
-			@Param("memberId") Long memberId,
-			@Param("playerId") Long playerId,
-			@Param("gameId") String gameId);
-
-	/** 발송 예약. 신규이거나 재시도 대상일 때만 true. */
-	default boolean reserve(Long memberId, Long playerId, String gameId) {
-		if (insertIfAbsent(memberId, playerId, gameId) > 0) {
-			return true;
-		}
-		return reactivateStale(memberId, playerId, gameId) > 0;
-	}
-
-	@Modifying
-	@Transactional
-	@Query("""
-			UPDATE PlayerSoloRankPushDelivery delivery
-			SET delivery.status = com.toy.nar.domain.member.entity.PushDeliveryStatus.SENT,
-			    delivery.errorMessage = null,
-			    delivery.sentAt = CURRENT_TIMESTAMP,
-			    delivery.updatedAt = CURRENT_TIMESTAMP
-			WHERE delivery.member.id = :memberId
-			  AND delivery.player.id = :playerId
-			  AND delivery.gameId = :gameId
-			""")
-	int markSent(
-			@Param("memberId") Long memberId,
-			@Param("playerId") Long playerId,
-			@Param("gameId") String gameId);
-
-	@Modifying
-	@Transactional
-	@Query("""
-			UPDATE PlayerSoloRankPushDelivery delivery
-			SET delivery.status = com.toy.nar.domain.member.entity.PushDeliveryStatus.FAILED,
-			    delivery.errorMessage = :errorMessage,
-			    delivery.updatedAt = CURRENT_TIMESTAMP
-			WHERE delivery.member.id = :memberId
-			  AND delivery.player.id = :playerId
-			  AND delivery.gameId = :gameId
-			""")
-	int markFailed(
-			@Param("memberId") Long memberId,
-			@Param("playerId") Long playerId,
-			@Param("gameId") String gameId,
-			@Param("errorMessage") String errorMessage);
+		extends JpaRepository<PlayerSoloRankPushDelivery, Long>, PlayerSoloRankPushDeliveryRepositoryCustom {
 }

--- a/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepositoryCustom.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepositoryCustom.java
@@ -1,0 +1,26 @@
+package com.toy.nar.domain.member.repository;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * 솔랭 푸시 팬아웃용 벌크 연산.
+ *
+ * <p>구독자 단위 쿼리를 돌면 왕복이 구독자 수에 비례한다. 앱(AWS 서울)→DB(Oracle Cloud 춘천)
+ * 왕복이 6.5ms 라 1,500명이면 그것만으로 분 단위가 되고, 팬아웃이 솔랭 폴 스레드에서
+ * 돌기 때문에 그 시간 동안 새 게임 감지가 멈춘다. 팀 라이브 이벤트 경로와 같은 처방이다.</p>
+ */
+public interface PlayerSoloRankPushDeliveryRepositoryCustom {
+
+	/**
+	 * 구독자 전원을 한 번에 예약하고 실제 발송 대상만 돌려준다.
+	 *
+	 * <p>판정 규칙은 신규이거나 FAILED 이거나 PENDING 으로 5분 넘게 방치된 건만 통과이고,
+	 * SENT 는 제외된다(게임당 1회 발송).</p>
+	 */
+	List<Long> reserveAll(Collection<Long> memberIds, Long playerId, String gameId);
+
+	int markSentAll(Collection<Long> memberIds, Long playerId, String gameId);
+
+	int markFailedAll(Collection<Long> memberIds, Long playerId, String gameId, String errorMessage);
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepositoryImpl.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/PlayerSoloRankPushDeliveryRepositoryImpl.java
@@ -1,0 +1,144 @@
+package com.toy.nar.domain.member.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class PlayerSoloRankPushDeliveryRepositoryImpl
+		implements PlayerSoloRankPushDeliveryRepositoryCustom {
+
+	/** IN 절·VALUES 한 번에 넣을 최대 개수. SQL 이 과하게 길어지지 않게 나눈다. */
+	private static final int CHUNK_SIZE = 500;
+
+	/** PENDING 방치 재예약 기준(분). 솔랭은 5분이다 — 팀 이벤트(1분)와 값이 다르니 맞추지 말 것. */
+	private static final String STALE_PENDING_MINUTES = "5";
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Override
+	public List<Long> reserveAll(Collection<Long> memberIds, Long playerId, String gameId) {
+		List<Long> targets = new ArrayList<>();
+		for (List<Long> chunk : chunk(memberIds)) {
+			targets.addAll(reserveChunk(chunk, playerId, gameId));
+		}
+		return targets;
+	}
+
+	private List<Long> reserveChunk(List<Long> memberIds, Long playerId, String gameId) {
+		// 1) 기존 행을 한 번에 읽어 신규/재예약/제외를 자바에서 가른다.
+		//    단건 reserve 의 "INSERT IGNORE 실패 → 조건부 UPDATE" 판정을 그대로 재현한다.
+		List<Object[]> existing = jdbcTemplate.query(
+				"SELECT member_id, status, updated_at < DATE_SUB(NOW(), INTERVAL "
+						+ STALE_PENDING_MINUTES + " MINUTE) AS stale"
+						+ " FROM player_solo_rank_push_delivery"
+						+ " WHERE player_id = ? AND game_id = ?"
+						+ " AND member_id IN (" + placeholders(memberIds.size()) + ")",
+				(rs, rowNum) -> new Object[] { rs.getLong(1), rs.getString(2), rs.getBoolean(3) },
+				args(playerId, gameId, memberIds));
+
+		Set<Long> existingIds = existing.stream()
+				.map(row -> (Long) row[0])
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+		List<Long> reactivateIds = existing.stream()
+				.filter(row -> "FAILED".equals(row[1])
+						|| ("PENDING".equals(row[1]) && Boolean.TRUE.equals(row[2])))
+				.map(row -> (Long) row[0])
+				.toList();
+		List<Long> newIds = memberIds.stream().filter(id -> !existingIds.contains(id)).toList();
+
+		if (!newIds.isEmpty()) {
+			jdbcTemplate.update(
+					"INSERT IGNORE INTO player_solo_rank_push_delivery"
+							+ " (member_id, player_id, game_id, status, created_at, updated_at) VALUES "
+							+ newIds.stream()
+									.map(id -> "(?, ?, ?, 'PENDING', NOW(), NOW())")
+									.collect(Collectors.joining(", ")),
+					newIds.stream()
+							.flatMap(id -> List.of((Object) id, playerId, gameId).stream())
+							.toArray());
+		}
+		if (!reactivateIds.isEmpty()) {
+			jdbcTemplate.update(
+					"UPDATE player_solo_rank_push_delivery"
+							+ " SET status = 'PENDING', error_message = NULL, updated_at = NOW()"
+							+ " WHERE player_id = ? AND game_id = ?"
+							+ " AND member_id IN (" + placeholders(reactivateIds.size()) + ")",
+					args(playerId, gameId, reactivateIds));
+		}
+
+		List<Long> targets = new ArrayList<>(newIds);
+		targets.addAll(reactivateIds);
+		return targets;
+	}
+
+	@Override
+	public int markSentAll(Collection<Long> memberIds, Long playerId, String gameId) {
+		int updated = 0;
+		for (List<Long> chunk : chunk(memberIds)) {
+			updated += jdbcTemplate.update(
+					"UPDATE player_solo_rank_push_delivery"
+							+ " SET status = 'SENT', error_message = NULL,"
+							+ "     sent_at = NOW(), updated_at = NOW()"
+							+ " WHERE player_id = ? AND game_id = ?"
+							+ " AND member_id IN (" + placeholders(chunk.size()) + ")",
+					args(playerId, gameId, chunk));
+		}
+		return updated;
+	}
+
+	@Override
+	public int markFailedAll(
+			Collection<Long> memberIds,
+			Long playerId,
+			String gameId,
+			String errorMessage) {
+		int updated = 0;
+		for (List<Long> chunk : chunk(memberIds)) {
+			List<Object> params = new ArrayList<>();
+			params.add(errorMessage);
+			params.add(playerId);
+			params.add(gameId);
+			params.addAll(chunk);
+			updated += jdbcTemplate.update(
+					"UPDATE player_solo_rank_push_delivery"
+							+ " SET status = 'FAILED', error_message = ?, updated_at = NOW()"
+							+ " WHERE player_id = ? AND game_id = ?"
+							+ " AND member_id IN (" + placeholders(chunk.size()) + ")",
+					params.toArray());
+		}
+		return updated;
+	}
+
+	private List<List<Long>> chunk(Collection<Long> memberIds) {
+		if (memberIds == null || memberIds.isEmpty()) {
+			return List.of();
+		}
+		List<Long> distinct = memberIds.stream().filter(Objects::nonNull).distinct().toList();
+		List<List<Long>> chunks = new ArrayList<>();
+		for (int start = 0; start < distinct.size(); start += CHUNK_SIZE) {
+			chunks.add(distinct.subList(start, Math.min(start + CHUNK_SIZE, distinct.size())));
+		}
+		return chunks;
+	}
+
+	private String placeholders(int count) {
+		return String.join(", ", Collections.nCopies(count, "?"));
+	}
+
+	private Object[] args(Long playerId, String gameId, List<Long> memberIds) {
+		List<Object> params = new ArrayList<>();
+		params.add(playerId);
+		params.add(gameId);
+		params.addAll(memberIds);
+		return params.toArray();
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushFanOutBatchTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushFanOutBatchTest.java
@@ -1,0 +1,188 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberDevice;
+import com.toy.nar.domain.member.entity.MobileDevicePlatform;
+import com.toy.nar.domain.member.repository.MemberDeviceRepository;
+import com.toy.nar.domain.member.repository.PlayerSoloRankPushDeliveryRepository;
+import com.toy.nar.domain.participant.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 솔랭 푸시 팬아웃이 발송·DB 왕복을 구독자 수와 무관한 상수로 묶는지 지키는 회귀 테스트.
+ *
+ * <p>구독자마다 {@code pushGateway.send} 와 {@code reserve}/{@code markSent} 를 한 건씩 돌던 탓에
+ * 팬아웃이 폴 스레드를 분 단위로 점유했다. 실측 2026-08-04 프로덕션: Oner 구독자 1,502명 팬아웃
+ * 472초(1명당 0.31초), 그 사이 100계정 폴링이 완전히 멈춰 22:27→22:41 동안 새 게임을 못 봤다.
+ * 같은 문제를 팀 라이브 이벤트 경로에서 먼저 고쳤고(#323·#325), 이 테스트는 솔랭 경로가
+ * 그 상태로 되돌아가지 않게 막는다.</p>
+ */
+class PlayerSoloRankPushFanOutBatchTest {
+
+	private static final Long PLAYER_ID = 10L;
+	private static final String GAME_ID = "game-1";
+	private static final String OPGG_URL = "https://www.op.gg/summoners/kr/Faker-KR1";
+
+	private final MemberDeviceRepository deviceRepository = mock(MemberDeviceRepository.class);
+	private final PlayerSoloRankPushDeliveryRepository deliveryRepository =
+			mock(PlayerSoloRankPushDeliveryRepository.class);
+	private final MobilePushGateway pushGateway = mock(MobilePushGateway.class);
+	private final MemberNotificationService notificationService = mock(MemberNotificationService.class);
+
+	private PlayerSoloRankPushService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new PlayerSoloRankPushService(
+				deviceRepository, deliveryRepository, pushGateway, notificationService);
+		when(pushGateway.isAvailable()).thenReturn(true);
+	}
+
+	@Test
+	@DisplayName("구독자 3명이어도 발송 1회·예약 1회·마감 1회로 끝낸다")
+	void 구독자_수와_무관하게_호출_횟수가_상수다() {
+		givenSubscribers(device(1L, member(7L), "token-1"),
+				device(2L, member(8L), "token-2"),
+				device(3L, member(9L), "token-3"));
+		when(deliveryRepository.reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID)))
+				.thenReturn(List.of(7L, 8L, 9L));
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(3, 0, List.of(), List.of("token-1", "token-2", "token-3")));
+
+		notifyGame();
+
+		ArgumentCaptor<List<String>> tokens = ArgumentCaptor.forClass(List.class);
+		verify(pushGateway, times(1)).send(tokens.capture(), any());
+		assertThat(tokens.getValue()).containsExactly("token-1", "token-2", "token-3");
+
+		verify(deliveryRepository, times(1)).reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID));
+		verify(deliveryRepository, times(1)).markSentAll(any(), eq(PLAYER_ID), eq(GAME_ID));
+		verify(notificationService, times(1)).recordAll(any(), any(), anyString(), any(), any());
+	}
+
+	@Test
+	@DisplayName("토큰별 결과로 구독자를 갈라 마감한다")
+	void 성공한_토큰의_구독자만_발송_기록한다() {
+		givenSubscribers(device(1L, member(7L), "token-1"), device(2L, member(8L), "token-2"));
+		when(deliveryRepository.reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID))).thenReturn(List.of(7L, 8L));
+		// token-2 만 성공
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(1, 1, List.of(), List.of("token-2")));
+
+		notifyGame();
+
+		assertThat(capturedIds(sentCaptor())).containsExactly(8L);
+		assertThat(capturedIds(failedCaptor())).containsExactly(7L);
+		// 발송 기록도 성공한 구독자만
+		ArgumentCaptor<Collection<Long>> recorded = ArgumentCaptor.forClass(Collection.class);
+		verify(notificationService).recordAll(recorded.capture(), any(), anyString(), any(), any());
+		assertThat(recorded.getValue()).containsExactly(8L);
+	}
+
+	@Test
+	@DisplayName("예약에서 빠진 구독자는 토큰에 포함하지 않는다")
+	void 예약되지_않은_구독자는_발송_대상에서_빠진다() {
+		givenSubscribers(device(1L, member(7L), "token-1"), device(2L, member(8L), "token-2"));
+		when(deliveryRepository.reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID))).thenReturn(List.of(8L));
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(1, 0, List.of(), List.of("token-2")));
+
+		notifyGame();
+
+		ArgumentCaptor<List<String>> tokens = ArgumentCaptor.forClass(List.class);
+		verify(pushGateway).send(tokens.capture(), any());
+		assertThat(tokens.getValue()).containsExactly("token-2");
+	}
+
+	@Test
+	@DisplayName("예약 대상이 없으면 발송하지 않는다")
+	void 예약_대상이_없으면_발송하지_않는다() {
+		givenSubscribers(device(1L, member(7L), "token-1"));
+		when(deliveryRepository.reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID))).thenReturn(List.of());
+
+		notifyGame();
+
+		verify(pushGateway, never()).send(any(), any());
+	}
+
+	@Test
+	@DisplayName("발송 자체가 실패하면 예약한 구독자 전원을 FAILED 로 남긴다")
+	void 발송_예외시_예약자_전원을_실패로_남긴다() {
+		givenSubscribers(device(1L, member(7L), "token-1"), device(2L, member(8L), "token-2"));
+		when(deliveryRepository.reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID))).thenReturn(List.of(7L, 8L));
+		when(pushGateway.send(any(), any())).thenThrow(new IllegalStateException("firebase down"));
+
+		notifyGame();
+
+		ArgumentCaptor<Collection<Long>> failed = ArgumentCaptor.forClass(Collection.class);
+		verify(deliveryRepository)
+				.markFailedAll(failed.capture(), eq(PLAYER_ID), eq(GAME_ID), eq("firebase down"));
+		assertThat(failed.getValue()).containsExactly(7L, 8L);
+		verify(deliveryRepository, never()).markSentAll(any(), anyLong(), anyString());
+	}
+
+	private void notifyGame() {
+		service.notifySubscribers(player(), GAME_ID, "아리", "ahri.png", "솔로 랭크", OPGG_URL);
+	}
+
+	private void givenSubscribers(MemberDevice... devices) {
+		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(PLAYER_ID)).thenReturn(List.of(devices));
+	}
+
+	private ArgumentCaptor<Collection<Long>> sentCaptor() {
+		ArgumentCaptor<Collection<Long>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(deliveryRepository).markSentAll(captor.capture(), eq(PLAYER_ID), eq(GAME_ID));
+		return captor;
+	}
+
+	private ArgumentCaptor<Collection<Long>> failedCaptor() {
+		ArgumentCaptor<Collection<Long>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(deliveryRepository).markFailedAll(captor.capture(), eq(PLAYER_ID), eq(GAME_ID), anyString());
+		return captor;
+	}
+
+	private List<Long> capturedIds(ArgumentCaptor<Collection<Long>> captor) {
+		return List.copyOf(captor.getValue());
+	}
+
+	private Member member(Long id) {
+		Member member = Member.builder().name("member-" + id).tag("0000").email("test@example.com").build();
+		ReflectionTestUtils.setField(member, "id", id);
+		return member;
+	}
+
+	private Player player() {
+		Player player = Player.builder().name("Faker").imageUrl("faker.png").build();
+		ReflectionTestUtils.setField(player, "id", PLAYER_ID);
+		return player;
+	}
+
+	private MemberDevice device(Long id, Member member, String token) {
+		MemberDevice device = MemberDevice.builder()
+				.member(member)
+				.fcmToken(token)
+				.platform(MobileDevicePlatform.ANDROID)
+				.build();
+		ReflectionTestUtils.setField(device, "id", id);
+		return device;
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushServiceTest.java
@@ -52,22 +52,19 @@ class PlayerSoloRankPushServiceTest {
 	@Test
 	void sendsOncePerSubscribedMemberAndDeactivatesInvalidTokens() {
 		Player player = player(10L, "Faker");
-		Member firstMember = member(7L);
-		Member secondMember = member(8L);
-		MemberDevice first = device(1L, firstMember, "token-1");
-		MemberDevice second = device(2L, secondMember, "token-2");
+		MemberDevice first = device(1L, member(7L), "token-1");
+		MemberDevice second = device(2L, member(8L), "token-2");
 
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L))
 				.thenReturn(List.of(first, second));
-		when(deliveryRepository.reserve(any(), eq(10L), eq("game-1"))).thenReturn(true);
+		when(deliveryRepository.reserveAll(any(), eq(10L), eq("game-1"))).thenReturn(List.of(7L, 8L));
 		when(pushGateway.send(any(), any()))
-				.thenReturn(new MobilePushResult(1, 0, List.of()))
-				.thenReturn(new MobilePushResult(0, 1, List.of("token-2")));
+				.thenReturn(new MobilePushResult(1, 1, List.of("token-2"), List.of("token-1")));
 
 		service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1");
 
-		verify(deliveryRepository).markSent(7L, 10L, "game-1");
-		verify(deliveryRepository).markFailed(8L, 10L, "game-1", "FCM 전송 성공 기기가 없습니다.");
+		verify(deliveryRepository).markSentAll(List.of(7L), 10L, "game-1");
+		verify(deliveryRepository).markFailedAll(List.of(8L), 10L, "game-1", "FCM 전송 성공 기기가 없습니다.");
 		verify(deviceRepository).deactivateByFcmTokenIn(List.of("token-2"));
 	}
 
@@ -86,14 +83,15 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		MemberDevice device = device(1L, member(7L), "token");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
-		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(true);
-		when(pushGateway.send(any(), any())).thenReturn(new MobilePushResult(1, 0, List.of()));
+		when(deliveryRepository.reserveAll(any(), eq(10L), eq("game-1"))).thenReturn(List.of(7L));
+		when(pushGateway.send(any(), any()))
+				.thenReturn(new MobilePushResult(1, 0, List.of(), List.of("token")));
 		doThrow(new IllegalStateException("topic down"))
 				.when(pushGateway).sendToTopic(any(), any());
 
 		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1"))
 				.doesNotThrowAnyException();
-		verify(deliveryRepository).markSent(7L, 10L, "game-1");
+		verify(deliveryRepository).markSentAll(List.of(7L), 10L, "game-1");
 	}
 
 	@Test
@@ -101,7 +99,7 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		MemberDevice device = device(1L, member(7L), "token");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
-		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(false);
+		when(deliveryRepository.reserveAll(any(), eq(10L), eq("game-1"))).thenReturn(List.of());
 
 		service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1");
 
@@ -113,12 +111,12 @@ class PlayerSoloRankPushServiceTest {
 		Player player = player(10L, "Faker");
 		MemberDevice device = device(1L, member(7L), "token");
 		when(deviceRepository.findActiveDevicesBySubscribedPlayerId(10L)).thenReturn(List.of(device));
-		when(deliveryRepository.reserve(7L, 10L, "game-1")).thenReturn(true);
+		when(deliveryRepository.reserveAll(any(), eq(10L), eq("game-1"))).thenReturn(List.of(7L));
 		when(pushGateway.send(any(), any())).thenThrow(new IllegalStateException("firebase down"));
 
 		assertThatCode(() -> service.notifySubscribers(player, "game-1", "아리", "ahri.png", "솔로 랭크", "https://www.op.gg/summoners/kr/Faker-KR1"))
 				.doesNotThrowAnyException();
-		verify(deliveryRepository).markFailed(7L, 10L, "game-1", "firebase down");
+		verify(deliveryRepository).markFailedAll(List.of(7L), 10L, "game-1", "firebase down");
 	}
 
 	private Member member(Long id) {


### PR DESCRIPTION
## 문제

솔랭 알림이 게임 시작 10분 넘어 도착했다. 원인은 감지 지연이고, 감지가 늦은 이유는 푸시 팬아웃이 폴 스레드를 점유해서다.

실측 2026-08-04 프로덕션 (`player_solo_rank_push_delivery`, KST):

| 시각 | 선수 | 구독자 | 소요 |
|---|---|---|---|
| 22:10~22:19 | Doran | 1,680 | 531초 |
| 22:19~22:23 | Faker | 750 | 266초 |
| 22:27~22:36 | Peyz | 1,617 | 516초 |
| 22:41~22:49 | **Oner** | 1,502 | **472초** |

팬아웃 8건이 22:05~22:51 동안 사이 공백 0~2초로 연속 실행됐다. 이 팬아웃은 솔랭 폴 스레드에서 동기로 돌기 때문에(`PlayerSoloRankMonitorService:142`) 그 시간 내내 추적 100계정 폴링이 멈췄다. `last_match_checked_at` 갱신이 22:27:10(43계정)·22:36:01(30)·22:37:14(20)·22:41:25(5) 네 번뿐인데, 100계정 한 바퀴는 원래 14초면 끝난다.

Oner 계정의 직전 점검이 22:27이라 감지가 최대 14분 늦고, 거기에 팬아웃 8분이 더 붙었다. EUW1 2계정은 22:05 이후 46분간 미점검이었다.

DB는 결백했다(락 대기 0, 연결 11/151). Riot 429도, 백엔드 예외도 없었다.

## 원인

팬아웃이 구독자를 멤버 단위로 쪼개 순차 처리한다. 멤버당 FCM 멀티캐스트 1회(토큰 1~2개) + `reserve`/`markSent`/피드기록으로 DB 왕복 3~4회 → 1,502명이면 FCM 1,502콜 · DB 약 5,000왕복. 게이트웨이는 이미 500토큰 멀티캐스트를 지원하는데 호출부가 쪼개서 그 배치가 무의미했다.

팀 라이브 이벤트 경로에서 같은 문제를 먼저 고쳤고(#323 멀티캐스트, #325 벌크 SQL), 그때 솔랭 경로는 의도적으로 손대지 않았다. 이 PR이 같은 처방을 솔랭에 적용한다.

## 수정

- **`PlayerSoloRankPushService`**: 구독자 루프를 `fanOutBatched` 로 통합. 예약을 한 번에 돌려 통과한 구독자의 토큰만 모아 발송하고, 토큰별 성공 여부로 구독자를 갈라 기록한다. 발송 호출 1,502회 → 4회.
- **`PlayerSoloRankPushDeliveryRepositoryCustom`/`Impl` 추가**(JdbcTemplate): `reserveAll` 은 기존 행을 한 번에 조회해 신규/재예약/제외를 자바에서 가르고, 신규는 다중 VALUES `INSERT IGNORE`, 재예약은 IN 절 UPDATE. `markSentAll`/`markFailedAll` 도 IN 절 벌크. 500개씩 분할.
- **단건 메서드 삭제**(`reserve`·`insertIfAbsent`·`reactivateStale`·`markSent`·`markFailed`): 예약 판정이 단건과 벌크로 갈리면 어긋나 중복 발송·누락이 된다. 실제로 그 판정을 잘못 구현해 중복 발송이 난 적이 있다(#239). 호출부는 이 서비스뿐이었다.
- **`MobilePushResult`**: 3인자 생성자 삭제. #323 에서 솔랭 호출부 때문에 남겨 뒀던 것이고 이제 호출부가 없다.

> 예약 판정 규칙은 삭제한 단건과 동일하다 — 신규이거나 FAILED 이거나 PENDING **5분** 초과만 통과, SENT 제외. 팀 경로는 1분이라 값이 다르니 맞추지 말 것(Impl 에 주석으로 남김).

## 검증

- 회귀 테스트 5개 추가(`PlayerSoloRankPushFanOutBatchTest`): 호출 횟수 상수, 토큰별 결과로 구독자 갈라 기록, 예약에 막힌 구독자 제외, 예약 대상 0이면 발송 안 함, 발송 예외 시 예약자 전원 FAILED.
- 기존 `PlayerSoloRankPushServiceTest` 를 벌크 API로 갱신.
- `./gradlew test` 전체 통과.
- `reserveAll` 의 SELECT·UPDATE 가 `uk_player_solo_rank_push_delivery(member_id, player_id, game_id)` 를 `range` 로 타는 것을 프로덕션 EXPLAIN 으로 확인.

## 기대 효과와 남는 것

고친 경로(`member_team_event_push_delivery`)의 오늘 실측이 구독자 649명 9~10초, 2,813명 124초다. Oner 1,502명이면 **472초 → 20~60초**로 떨어져 60초 폴 주기 안에 들어온다.

남은 비용은 delivery 행 INSERT 자체이고, 그건 DB VM(RAM 1GB, buffer pool 128MB) 쪽 한계다. 코드로 더 내리려면 멤버별 dedup 행을 포기하거나 VM을 올려야 한다.

**스레드 분리는 하지 않았다.** 팬아웃이 수십 초로 줄면 폴 루프에서 동기로 돌려도 주기 안에 들어온다. 분리하면 동시 팬아웃이 Hikari 풀(기본 10, `application-prod.yml` 에 미설정)을 놓고 웹 요청과 경합하고, 단일 DB VM 이 병목이라 병렬화가 처리량을 늘리지도 못한다. DB VM 을 올린 뒤 재검토할 일이다.

별건으로 관측: `LIVE_EVENT` 가 10~12초마다 발생하고 매번 9~10초 걸린다(듀티사이클 90%). 경기 중 솔랭 팬아웃이 겹치면 라이브 알림도 밀린다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)