### PR TITLE
fix: 해외 이적 선수 소속팀이 앱에 반영되지 않던 문제

### DIFF
--- a/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
+++ b/src/main/java/com/toy/nar/domain/participant/repository/PlayerRepository.java
@@ -104,13 +104,19 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	 * (라이브 감지는 플랫폼 무관인데 구독 자체가 불가능한 모순). 자격은 {@code enabled}·
 	 * {@code primary_account}만으로 판단한다.
 	 *
-	 * <p>{@code current_team_id}(백오피스 수동 소속팀)가 <b>LCK 1군 팀일 때만</b> 경기 기록 팀을 덮는다.
-	 * 이적한 선수는 새 팀 경기가 CSV에 들어오기 전까지 옛 팀에 남는데, 백오피스에서 고치면 즉시 반영되게
-	 * 하려는 것이다. 1군 코드로 좁히는 이유: {@code current_team_id}는 V54가 "전 리그 최근 경기 팀"으로
-	 * 일괄 백필한 값이라 1군 선수인데도 챌린저스·아카데미 팀을 가리키는 경우가 많다(2026-08 기준 LCK
-	 * 2026 출전자 64명 중 9명). 2군 팀은 {@code team_code}가 없어 온보딩 팀 목록
+	 * <p>{@code current_team_id}(백오피스 수동 소속팀)가 <b>{@code team_code}를 가진 팀일 때만</b> 경기
+	 * 기록 팀을 덮는다. 이적한 선수는 새 팀 경기가 CSV에 들어오기 전까지 옛 팀에 남는데, 백오피스에서
+	 * 고치면 즉시 반영되게 하려는 것이다. 조건을 다는 이유: {@code current_team_id}는 V54가 "전 리그
+	 * 최근 경기 팀"으로 일괄 백필한 값이라 1군 선수인데도 챌린저스·아카데미 팀을 가리키는 경우가 많다
+	 * (2026-08 기준 LCK 2026 출전자 64명 중 9명). 2군 팀은 {@code team_code}가 없어 온보딩 팀 목록
 	 * ({@link LckTeamCatalog#TEAM_CODES})에 없으므로, 조건 없이 덮으면 그 9명이 어느 팀 목록에도
 	 * 안 잡혀 사라진다.
+	 *
+	 * <p>예전엔 이 조건이 {@code team_code IN (LCK 1군 10개)}였다. 그러면 LCK 출전 이력이 있고 지금은
+	 * 해외 1군에 있는 선수(예: Loki — LCK 2026 → Cloud9)의 소속팀을 백오피스에서 고쳐도 앱에는 옛 LCK
+	 * 팀으로 계속 보였다. 2026-08-04 프로덕션 실측으로 챌린저스·아카데미 팀 41개는 전부
+	 * {@code team_code}가 NULL이고, LCK 2026 출전자 중 코드 있는 비-LCK 팀을 가리키는 선수는 0명이라
+	 * NULL 여부만으로 좁혀도 원래 목적(2군 백필 오염 차단)이 유지된다.
 	 */
 	@Query(
 			value = """
@@ -136,7 +142,7 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 						JOIN players p ON gp.player_id = p.player_id
 						JOIN teams t ON gp.team_id = t.team_id
 						LEFT JOIN teams ct ON ct.team_id = p.current_team_id
-						                  AND ct.team_code IN (:firstTeamCodes)
+						                  AND ct.team_code IS NOT NULL
 						WHERE l.league_name = :leagueName
 						  AND l.season_year = :year
 						UNION ALL
@@ -192,7 +198,7 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 						JOIN players p ON gp.player_id = p.player_id
 						JOIN teams t ON gp.team_id = t.team_id
 						LEFT JOIN teams ct ON ct.team_id = p.current_team_id
-						                  AND ct.team_code IN (:firstTeamCodes)
+						                  AND ct.team_code IS NOT NULL
 						WHERE l.league_name = :leagueName
 						  AND l.season_year = :year
 						UNION ALL
@@ -224,15 +230,9 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			@Param("year") int year,
 			@Param("teamId") Long teamId,
 			@Param("query") String query,
-			@Param("firstTeamCodes") List<String> firstTeamCodes,
 			Pageable pageable);
 
-	default Page<LckPlayerOption> findLckPlayerOptions(
-			String leagueName, int year, Long teamId, String query, Pageable pageable) {
-		return findLckPlayerOptions(leagueName, year, teamId, query, LckTeamCatalog.TEAM_CODES, pageable);
-	}
-
-	// 팀 컬럼 override 근거는 findLckPlayerOptions javadoc 참고(1군 코드일 때만 current_team이 이긴다).
+	// 팀 컬럼 override 근거는 findLckPlayerOptions javadoc 참고(team_code가 있는 팀일 때만 current_team이 이긴다).
 	@Query("""
 			SELECT DISTINCT
 				p.id AS playerId,
@@ -248,7 +248,7 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			JOIN gp.team t
 			JOIN gp.game g
 			JOIN g.league l
-			LEFT JOIN Team ct ON ct.id = p.currentTeam.id AND ct.code IN :firstTeamCodes
+			LEFT JOIN Team ct ON ct.id = p.currentTeam.id AND ct.code IS NOT NULL
 			WHERE l.leagueName = :leagueName
 			  AND l.seasonYear = :year
 			  AND g.actualGameStartTime = (
@@ -266,14 +266,9 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	List<LckPlayerOption> findLckPlayerOption(
 			@Param("leagueName") String leagueName,
 			@Param("year") int year,
-			@Param("playerId") Long playerId,
-			@Param("firstTeamCodes") List<String> firstTeamCodes);
+			@Param("playerId") Long playerId);
 
-	default List<LckPlayerOption> findLckPlayerOption(String leagueName, int year, Long playerId) {
-		return findLckPlayerOption(leagueName, year, playerId, LckTeamCatalog.TEAM_CODES);
-	}
-
-	// 팀 컬럼 override 근거는 findLckPlayerOptions javadoc 참고(1군 코드일 때만 current_team이 이긴다).
+	// 팀 컬럼 override 근거는 findLckPlayerOptions javadoc 참고(team_code가 있는 팀일 때만 current_team이 이긴다).
 	@Query("""
 			SELECT DISTINCT
 				p.id AS playerId,
@@ -289,7 +284,7 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 			JOIN gp.team t
 			JOIN gp.game g
 			JOIN g.league l
-			LEFT JOIN Team ct ON ct.id = p.currentTeam.id AND ct.code IN :firstTeamCodes
+			LEFT JOIN Team ct ON ct.id = p.currentTeam.id AND ct.code IS NOT NULL
 			WHERE l.leagueName = :leagueName
 			  AND l.seasonYear = :year
 			  AND g.actualGameStartTime = (
@@ -307,13 +302,7 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
 	List<LckPlayerOption> findLckPlayerOptionsByPlayerIds(
 			@Param("leagueName") String leagueName,
 			@Param("year") int year,
-			@Param("playerIds") Set<Long> playerIds,
-			@Param("firstTeamCodes") List<String> firstTeamCodes);
-
-	default List<LckPlayerOption> findLckPlayerOptionsByPlayerIds(
-			String leagueName, int year, Set<Long> playerIds) {
-		return findLckPlayerOptionsByPlayerIds(leagueName, year, playerIds, LckTeamCatalog.TEAM_CODES);
-	}
+			@Param("playerIds") Set<Long> playerIds);
 
 	// 솔랭 전용 선수(계정 보유, 팀 없음)를 LckPlayerOption으로 투영. 구독 표시/검증 병합용.
 	@Query(value = """

--- a/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
+++ b/src/test/java/com/toy/nar/domain/participant/repository/PlayerRepositoryLckPlayerOptionsTest.java
@@ -261,6 +261,31 @@ class PlayerRepositoryLckPlayerOptionsTest {
 	}
 
 	@Test
+	@DisplayName("current_team_id가 해외 1군 팀(LCK 아님, team_code 있음)이어도 경기 기록 팀을 덮는다")
+	void currentTeamOverridesWithNonLckCodedTeam() {
+		// LCK 출전 후 해외 이적(Loki: LCK 2026 → Cloud9). 백오피스 수정이 앱 목록에도 보여야 한다.
+		exec(team(40, "Cloud9", "C9"));
+		exec("UPDATE players SET current_team_id = 40 WHERE player_id = 6");
+		em.flush();
+		em.clear();
+
+		Page<LckPlayerOption> page = playerRepository.findLckPlayerOptions(
+				LCK, YEAR, null, "GenStar", PageRequest.of(0, 50));
+		assertThat(page.getContent()).singleElement()
+				.extracting(LckPlayerOption::getTeamCode).isEqualTo("C9");
+
+		// 옛 팀 필터에서는 빠져야 한다.
+		assertThat(playerRepository.findLckPlayerOptions(LCK, YEAR, GEN, null, PageRequest.of(0, 50)))
+				.extracting(LckPlayerOption::getPlayerName).doesNotContain("GenStar");
+
+		// 단건·다건(구독 목록) 경로도 동일.
+		assertThat(playerRepository.findLckPlayerOption(LCK, YEAR, 6L))
+				.singleElement().extracting(LckPlayerOption::getTeamCode).isEqualTo("C9");
+		assertThat(playerRepository.findLckPlayerOptionsByPlayerIds(LCK, YEAR, Set.of(6L)))
+				.extracting(LckPlayerOption::getTeamCode).containsExactly("C9");
+	}
+
+	@Test
 	@DisplayName("단건·다건 조회도 1군 current_team_id를 동일하게 반영한다")
 	void byPlayerIdQueriesApplySameOverride() {
 		exec("UPDATE players SET current_team_id = " + T1 + " WHERE player_id = 6");


### PR DESCRIPTION
## 문제

백오피스에서 선수 소속팀(`current_team_id`)을 고쳐도 앱에는 옛 팀이 계속 보이는 경우가 있다.

앱 노출 쿼리(`findLckPlayerOptions`, `findLckPlayerOption`, `findLckPlayerOptionsByPlayerIds`)가
`current_team`을 `team_code IN (LCK 1군 10개)`일 때만 경기 기록 팀 위에 덮도록 되어 있었다.
LCK 출전 이력이 있고 지금은 해외 1군인 선수는 이 화이트리스트에 안 걸려 폴백된다.

실제 사례 — Loki(`player_id=853`): LCK 2026 17경기(BRO) 출전 후 Cloud9로 이적, LCS 2026 진행 중.
솔랭 알림용 계정을 붙였지만 아래 3곳에 여전히 `Hanjin Brion` 로고로 표시됐다.

- `GET /api/auth/onboarding/players` (온보딩 선수 선택)
- `GET /api/mobile/me/player-subscriptions/available-players` (구독 가능 선수)
- `GET /api/mobile/me/player-subscriptions` (내 구독 선수)

## 변경

조건을 `team_code IS NOT NULL`로 바꿨다(네이티브 2곳 + JPQL 2곳). 쓸모가 없어진
`firstTeamCodes` 파라미터와 `default` 래퍼 제거.

원래 화이트리스트의 목적은 V54가 `current_team_id`를 "전 리그 최근 경기 팀"으로 백필해
1군 선수가 챌린저스·아카데미 팀을 가리키는 오염(LCK 2026 출전자 64명 중 9명)을 막는 것이었다.
프로덕션 실측(2026-08-04)으로 그 목적이 NULL 조건만으로 유지됨을 확인했다.

- `Challengers`/`Academy` 팀 41개 → **전부 `team_code IS NULL`**
- LCK 2026 출전자 중 `team_code`가 있는 비-LCK-1군 팀을 가리키는 선수 → **0명**

## 검증

- 신규 테스트: 해외 1군 팀(코드 있음, LCK 아님) override + 옛 팀 필터에서 제외 + 단건·다건 경로
- 기존 테스트 유지: 1군 override, 2군(코드 NULL) 무시
- 전체 `./gradlew test` — 459 tests, 0 failures

## 배포 후 할 일

Loki `current_team_id`를 32(BRO) → 146(C9)로 변경. `PUT /api/admin/players/853`에
**`currentTeamId`만** 보낼 것 — `gameAccounts`를 같이 보내면 region 기본값 KR로 덮여
현재 NA1로 잡혀 있는 라이브 감지가 깨진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)