### PR TITLE
fix: 업스트림이 완료된 경기를 0:0으로 되돌려도 결과를 지키게

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -238,6 +238,30 @@ public class LeagueMatchService {
 		return String.join(",", winners);
 	}
 
+	/**
+	 * 업스트림이 이미 끝난 경기를 결과 없는 상태로 되돌려 보내는지.
+	 *
+	 * <p>KESPA·EWC 는 경기가 끝나도 state 를 unstarted, 스코어를 0:0 으로 방치한다. 30분 주기
+	 * 전체 동기화는 그 값을 조건 없이 덮어써서 이미 확정한 결과를 지운다. 2026-08-04 KESPA
+	 * T1 vs HLE 가 18:02 에 네이버로 2:1 completed 확정된 뒤 이 경로로 0:0 unstarted 가 됐다.
+	 * 디스커버리의 재확정은 matchId 당 1회라 되돌려진 뒤에는 스스로 복구되지 않는다.</p>
+	 *
+	 * <p>스코어 합이 0인 경우만 막는다. 리메이크나 오기 정정처럼 실제로 값이 바뀌는 갱신은
+	 * 0 이 아닌 스코어로 들어오므로 그대로 통과한다.</p>
+	 */
+	static boolean isResultRegression(LeagueMatch existing, LeagueMatch incoming) {
+		if (!isCompleted(existing) || scoreSum(existing) <= 0) {
+			return false;
+		}
+		return scoreSum(incoming) == 0;
+	}
+
+	private static int scoreSum(LeagueMatch match) {
+		int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
+		int red = match.getRedScore() == null ? 0 : match.getRedScore();
+		return blue + red;
+	}
+
 	private static boolean isCompleted(LeagueMatch match) {
 		return "completed".equalsIgnoreCase(match.getState());
 	}
@@ -916,6 +940,14 @@ public class LeagueMatchService {
 					dirtyMatchIds.add(incoming.getId());
 					inserted++;
 					continue;
+				}
+
+				if (isResultRegression(existing, incoming)) {
+					log.warn("업스트림이 완료된 매치를 결과 없는 상태로 되돌려 기존 결과를 유지한다. "
+									+ "matchId={} 유지={}:{}({}) 수신={}:{}({})",
+							existing.getId(), existing.getBlueScore(), existing.getRedScore(), existing.getState(),
+							incoming.getBlueScore(), incoming.getRedScore(), incoming.getState());
+					incoming.restoreResult(existing.getState(), existing.getBlueScore(), existing.getRedScore());
 				}
 
 				if (!hasRealtimeRelevantChange(existing, incoming)) {

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatch.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatch.java
@@ -97,6 +97,18 @@ public class LeagueMatch {
 		}
 	}
 
+	/**
+	 * 이미 확정한 경기 결과(상태·스코어)를 그대로 옮겨 담는다.
+	 *
+	 * <p>업스트림이 끝난 경기를 미시작·0:0 으로 방치할 때, 그 값으로 덮이지 않도록
+	 * 동기화 대상 엔티티에 기존 결과를 되돌려 놓는 용도다.</p>
+	 */
+	public void restoreResult(String state, Integer blueScore, Integer redScore) {
+		this.state = state;
+		this.blueScore = blueScore;
+		this.redScore = redScore;
+	}
+
 	public void applySeason(Integer seasonYear, String seasonSplit) {
 		this.seasonYear = seasonYear;
 		this.seasonSplit = seasonSplit;

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceResultRegressionTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceResultRegressionTest.java
@@ -1,0 +1,88 @@
+package com.toy.nar.app.lolesports;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 업스트림이 끝난 경기를 결과 없는 상태로 되돌려 보낼 때 기존 결과를 지키는지.
+ *
+ * <p>2026-08-04 KESPA T1 vs HLE 가 18:02 에 네이버로 2:1 completed 확정된 뒤, 30분 주기
+ * 전체 동기화가 unstarted 0:0 으로 덮어써 결과가 사라졌다. 디스커버리의 네이버 재확정은
+ * matchId 당 1회라 되돌려진 뒤에는 스스로 복구되지 않았다.</p>
+ */
+class LeagueMatchServiceResultRegressionTest {
+
+	@Test
+	void 완료된_경기를_미시작_0대0_으로_되돌리면_막는다() {
+		LeagueMatch existing = match("completed", 2, 1);
+		LeagueMatch incoming = match("unstarted", 0, 0);
+
+		assertThat(LeagueMatchService.isResultRegression(existing, incoming)).isTrue();
+	}
+
+	@Test
+	void 완료된_경기를_진행중_0대0_으로_되돌려도_막는다() {
+		// 방치 상태가 unstarted 로만 오는 것은 아니다. 결과가 사라지는 것은 같다.
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 2, 0), match("inProgress", 0, 0))).isTrue();
+	}
+
+	@Test
+	void 스코어가_실제로_바뀌는_갱신은_통과시킨다() {
+		// 리메이크·오기 정정은 0 이 아닌 스코어로 들어온다.
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 2, 1), match("completed", 2, 0))).isFalse();
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 2, 1), match("completed", 1, 2))).isFalse();
+	}
+
+	@Test
+	void 아직_결과가_없는_경기는_대상이_아니다() {
+		// 시작 전 경기에 0:0 이 오는 것은 정상이다.
+		assertThat(LeagueMatchService.isResultRegression(
+				match("unstarted", 0, 0), match("unstarted", 0, 0))).isFalse();
+		assertThat(LeagueMatchService.isResultRegression(
+				match("inProgress", 1, 0), match("inProgress", 0, 0))).isFalse();
+	}
+
+	@Test
+	void 완료됐지만_스코어가_0대0_이면_대상이_아니다() {
+		// 지킬 결과가 없으므로 업스트림 값을 그대로 받는다.
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 0, 0), match("unstarted", 0, 0))).isFalse();
+	}
+
+	@Test
+	void 스코어가_null_이어도_터지지_않는다() {
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", null, null), match("unstarted", null, null))).isFalse();
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 2, null), match("unstarted", null, null))).isTrue();
+	}
+
+	@Test
+	void 되돌림을_막을_때_기존_상태와_스코어를_그대로_옮긴다() {
+		LeagueMatch incoming = match("unstarted", 0, 0);
+
+		incoming.restoreResult("completed", 2, 1);
+
+		assertThat(incoming.getState()).isEqualTo("completed");
+		assertThat(incoming.getBlueScore()).isEqualTo(2);
+		assertThat(incoming.getRedScore()).isEqualTo(1);
+	}
+
+	private LeagueMatch match(String state, Integer blueScore, Integer redScore) {
+		return LeagueMatch.builder()
+				.id("116929376557102172")
+				.leagueName("KESPA")
+				.state(state)
+				.blueTeamCode("T1")
+				.blueScore(blueScore)
+				.redTeamCode("HLE")
+				.redScore(redScore)
+				.bestOf(3)
+				.build();
+	}
+}


### PR DESCRIPTION
KESPA T1 vs HLE(2026-08-04 15:00)가 경기 종료 후 약 5시간 30분 동안 앱에서 0:0으로 보였습니다. 실제 결과는 T1 2:1 승리입니다.

## 원인

업스트림(`esports-api.lolesports.com/persisted/gw/getSchedule`)이 KESPA 결과를 늦게 반영합니다. 그 동안 `state`는 `unstarted`, `gameWins`는 0으로 옵니다. 30분 주기 전체 동기화(`MatchSyncScheduler`)의 `upsertLeagueMatches`가 이 값을 조건 없이 덮어써서, 우리가 이미 확정해 둔 결과를 지웁니다.

프로덕션 로그와 DB로 확인한 시간선입니다.

```
15:15~17:30  Realtime match status synced  0:0 → 0:1 → 1:1  (inProgress)
18:02:46     Naver 종료 확정으로 매치 completed 반영  score=2:1   ← 정답 확보
그 직후       30분 sync 가 업스트림의 unstarted 0:0 으로 덮음
23:33:55     업스트림이 정정 → sync 가 2:1 로 복구
```

우리는 18시에 이미 정답을 알고 있었습니다. 네이버 확정 경로가 그것을 위해 있는데, 그 결과를 업스트림의 빈 값이 덮었습니다.

DB에는 `set_winners=R,B,B`(T1 2승 1패)가 남아 있었습니다. `advanceSetWinners`가 스코어 합이 0이면 기존 목록을 유지하기 때문에, 3세트를 치른 흔적은 있고 스코어만 사라진 상태였습니다. 이 불일치가 진단의 단서였습니다.

## 수정

`upsertLeagueMatches`에서 되돌림을 감지해 기존 상태와 스코어를 유지합니다. 스코어 합이 0인 경우만 막으므로, 리메이크나 오기 정정처럼 값이 실제로 바뀌는 갱신은 그대로 통과합니다.

업스트림이 정정하면 그때 정상적으로 반영됩니다. 이 변경은 "업스트림이 아직 모르는 동안 우리 정답을 지키는 것"이고, 업스트림 값을 영구히 무시하지 않습니다.

## 검증

전체 498개 통과. 신규 테스트 7건이며, 가드를 무력화하면 그중 3건이 실패하는 것을 확인했습니다.

## 자가 복구에 대해

30분 sync는 업스트림이 정정한 뒤에는 스스로 복구합니다. 오늘도 23:33:55에 복구됐고 지금 DB는 정상입니다. 데이터 수동 복구는 필요하지 않습니다.

다만 디스커버리의 네이버 재확정은 `naverFinalizedMatchIds`로 matchId당 1회라, 한 번 덮인 뒤에는 네이버 경로로는 다시 고쳐지지 않습니다. 복구가 전적으로 업스트림 정정 시점에 달려 있고, 오늘은 그게 5시간 30분이었습니다.

## 오늘 배포분과의 관계

무관합니다. #345(Live Activity), #346(대시보드), #347(솔랭 팬아웃) 모두 `LeagueMatchService`와 `MatchSyncScheduler`를 건드리지 않았습니다. 코드 주석에 2026-07-27 KESPA T1 vs DNS, 07-28 KESPA DNS vs BRO 사례가 남아 있어 이전부터 있던 문제입니다.

## 별건으로 확인이 필요한 것

KESPA 동기화가 매 실행마다 `updated=1, skipped=37`을 보고합니다. 값이 수렴하지 않고 계속 한 건이 갱신된다는 뜻입니다. 어느 매치인지, `matchDetailsJson` 같은 필드가 매번 달라지는 것인지 따로 봐야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)