### PR TITLE
fix: 솔랭 모니터가 백오피스 계정 교체를 옛 값으로 되돌리던 문제

### DIFF
--- a/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
+++ b/src/main/java/com/toy/nar/app/riot/PlayerSoloRankMonitorService.java
@@ -195,10 +195,15 @@ public class PlayerSoloRankMonitorService {
 
 	/**
 	 * 계정 상태 변경만 짧은 트랜잭션으로 커밋한다. 외부 API 호출은 절대 이 안에 두지 않는다.
-	 * 계정은 detached 라 save(merge)로 반영한다.
+	 *
+	 * <p>detached 스냅샷을 {@code save}(merge)하면 전체 컬럼 UPDATE라 사이클 도중 백오피스에서 바뀐
+	 * {@code riot_id}·{@code platform}·{@code puuid}가 스냅샷 값으로 되돌아간다. 그래서 트랜잭션
+	 * 안에서 현재 행을 다시 읽고 라이브 상태 컬럼만 옮긴다(managed 엔티티라 별도 save 불필요).
 	 */
 	private void persist(PlayerRiotAccount account) {
-		transactionTemplate.executeWithoutResult(status -> playerRiotAccountRepository.save(account));
+		transactionTemplate.executeWithoutResult(status ->
+				playerRiotAccountRepository.findById(account.getId())
+						.ifPresent(current -> current.copyLiveStateFrom(account)));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/toy/nar/domain/participant/entity/PlayerRiotAccount.java
+++ b/src/main/java/com/toy/nar/domain/participant/entity/PlayerRiotAccount.java
@@ -166,6 +166,21 @@ public class PlayerRiotAccount {
 		this.lastAlertedMatchId = matchId;
 	}
 
+	/**
+	 * 폴링 스냅샷(detached)의 라이브 상태만 이 엔티티로 옮긴다.
+	 *
+	 * <p>모니터가 사이클 시작에 읽어둔 엔티티를 그대로 {@code save}(merge)하면 전체 컬럼 UPDATE라
+	 * {@code riot_id}·{@code platform}·{@code puuid}까지 스냅샷 시점 값으로 되돌아간다. 그 사이
+	 * 백오피스에서 계정을 교체했다면(2026-08-04 Loki: C9loki#kr3/NA1 → 옛 Loki#zxc/KR로 롤백)
+	 * 엉뚱한 계정을 폴링해 솔랭 알림이 끊긴다. 그래서 상태 컬럼만 골라 옮긴다.
+	 */
+	public void copyLiveStateFrom(PlayerRiotAccount snapshot) {
+		this.liveStatus = snapshot.liveStatus;
+		this.lastCheckedMatchId = snapshot.lastCheckedMatchId;
+		this.lastAlertedMatchId = snapshot.lastAlertedMatchId;
+		this.lastMatchCheckedAt = snapshot.lastMatchCheckedAt;
+	}
+
 	@PrePersist
 	public void onCreate() {
 		LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMonitorAccountWriteTest.java
+++ b/src/test/java/com/toy/nar/app/riot/PlayerSoloRankMonitorAccountWriteTest.java
@@ -1,0 +1,121 @@
+package com.toy.nar.app.riot;
+
+import com.toy.nar.app.data.source.ChampionDataService;
+import com.toy.nar.app.data.source.NotificationService;
+import com.toy.nar.app.mobile.push.PlayerSoloRankPushService;
+import com.toy.nar.app.monitor.SchedulerAlertService;
+import com.toy.nar.domain.participant.entity.Player;
+import com.toy.nar.domain.participant.entity.PlayerRiotAccount;
+import com.toy.nar.domain.participant.entity.PlayerRiotAccountLiveStatus;
+import com.toy.nar.domain.participant.repository.PlayerRiotAccountRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 폴링 write가 계정 식별자를 되돌리지 않는지 지키는 회귀 테스트.
+ *
+ * <p>모니터는 사이클 시작에 계정 전체를 읽고(detached) 계정마다 상태를 커밋한다. 예전엔 그 스냅샷을
+ * {@code save}(merge)해서 전체 컬럼을 UPDATE했다. 그래서 사이클 도중 백오피스에서 계정을 교체하면
+ * {@code riot_id}·{@code platform}·{@code puuid}가 스냅샷 값으로 롤백됐다 — 2026-08-04에 Loki
+ * (853)의 C9loki#kr3/NA1 부착이 옛 Loki#zxc/KR로 되돌아가 NA 솔랭 게임을 감지하지 못했다.
+ */
+class PlayerSoloRankMonitorAccountWriteTest {
+
+	private static final long ACCOUNT_ID = 78L;
+
+	private final PlayerRiotAccountRepository accountRepository = mock(PlayerRiotAccountRepository.class);
+	private final RiotApiClient riotApiClient = mock(RiotApiClient.class);
+	private final TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+
+	private final PlayerSoloRankMonitorService service = new PlayerSoloRankMonitorService(
+			accountRepository,
+			mock(ChampionDataService.class),
+			riotApiClient,
+			pacingDisabledProperties(),
+			mock(NotificationService.class),
+			mock(PlayerSoloRankPushService.class),
+			mock(SchedulerAlertService.class),
+			mock(SoloRankGameHistoryRecorder.class),
+			transactionTemplate);
+
+	@Test
+	@DisplayName("폴링 write는 DB 현재 행에 라이브 상태만 쓰고 riot_id·platform·puuid는 건드리지 않는다")
+	void 폴링_write는_계정_식별자를_되돌리지_않는다() {
+		// 사이클 시작 스냅샷: 아직 옛 KR 계정
+		PlayerRiotAccount snapshot = account("Loki#zxc", "KR", "puuid-old");
+		// 스냅샷 이후 백오피스가 NA 계정으로 교체한 DB 현재 행
+		PlayerRiotAccount inDatabase = account("C9loki#kr3", "NA1", "puuid-new");
+
+		when(accountRepository.findAllTrackedAccounts()).thenReturn(List.of(snapshot));
+		when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(inDatabase));
+		// 진행 중 게임 없음 → markNoRecentMatch 후 상태 커밋만 타는 최단 경로
+		when(riotApiClient.getActiveGameByPuuid(anyString(), any())).thenReturn(Optional.empty());
+		executeCallbacksImmediately();
+
+		service.pollTrackedAccounts();
+
+		assertThat(inDatabase.getRiotId()).isEqualTo("C9loki#kr3");
+		assertThat(inDatabase.getPlatform()).isEqualTo("NA1");
+		assertThat(inDatabase.getPuuid()).isEqualTo("puuid-new");
+		// 상태는 정상 반영돼야 한다(그냥 안 쓰는 것과 구분).
+		assertThat(inDatabase.getLiveStatus()).isEqualTo(PlayerRiotAccountLiveStatus.OFFLINE);
+		assertThat(inDatabase.getLastMatchCheckedAt()).isNotNull();
+		// managed 엔티티 변경이라 save 호출 자체가 없어야 한다(merge 하면 다시 전체 컬럼 UPDATE).
+		verify(accountRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("행이 사라진 계정은 조용히 넘어간다")
+	void 삭제된_계정은_예외없이_스킵된다() {
+		when(accountRepository.findAllTrackedAccounts()).thenReturn(List.of(account("Loki#zxc", "KR", "puuid-old")));
+		when(accountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+		when(riotApiClient.getActiveGameByPuuid(anyString(), any())).thenReturn(Optional.empty());
+		executeCallbacksImmediately();
+
+		assertThat(service.pollTrackedAccounts().checkedCount()).isEqualTo(1);
+	}
+
+	private void executeCallbacksImmediately() {
+		doAnswer(invocation -> {
+			invocation.getArgument(0, Consumer.class).accept(null);
+			return null;
+		}).when(transactionTemplate).executeWithoutResult(any());
+	}
+
+	private RiotMonitorProperties pacingDisabledProperties() {
+		RiotMonitorProperties properties = new RiotMonitorProperties();
+		properties.setMaxRequestsPerSecond(0);
+		return properties;
+	}
+
+	private PlayerRiotAccount account(String riotId, String platform, String puuid) {
+		PlayerRiotAccount account = PlayerRiotAccount.builder()
+				.player(Player.builder().name("Loki").build())
+				.riotId(riotId)
+				.gameName(riotId.split("#")[0])
+				.tagLine(riotId.split("#")[1])
+				.platform(platform)
+				.puuid(puuid)
+				.primaryAccount(true)
+				.enabled(true)
+				.liveStatus(PlayerRiotAccountLiveStatus.IN_RANKED_SOLO)
+				.build();
+		ReflectionTestUtils.setField(account, "id", ACCOUNT_ID);
+		return account;
+	}
+}


### PR DESCRIPTION
## 문제

`PlayerSoloRankMonitorService`는 사이클 시작에 추적 계정 전체를 읽고(트랜잭션 종료 → 엔티티 detached),
계정마다 상태 변경만 짧은 트랜잭션으로 커밋한다. 그 커밋이

```java
private void persist(PlayerRiotAccount account) {
    transactionTemplate.executeWithoutResult(status -> playerRiotAccountRepository.save(account));
}
```

`save(detached)` = `em.merge` → 전체 컬럼 UPDATE(`@DynamicUpdate` 없음). 그래서 **스냅샷 이후
백오피스에서 바뀐 `riot_id`·`platform`·`puuid`가 스냅샷 값으로 되돌아간다.**

`gameAccountsLocked`·`imageLocked`는 `players` 테이블 컬럼만 지킨다. `player_riot_account`에는
잠금 필드가 없어서 이 경로를 못 막는다. 실제 라이브 감지가 쓰는 값은 이 테이블 쪽이다.

### 실측 (2026-08-04, prod)

| 시각 | 사건 | `player_riot_account` |
|---|---|---|
| T0 | 모니터 사이클 스냅샷 | `Loki#zxc` / KR / puuid 옛 값 |
| 23:08 | 백오피스 계정 부착 | `C9loki#kr3` / NA1 / puuid 신규 |
| T1 | 해당 계정 persist → merge | **`Loki#zxc` / KR 로 롤백** |
| 23:47 | 재부착 | `C9loki#kr3` / NA1 |
| 23:48:52 | 다음 사이클 write | 유지(스냅샷이 부착 이후) |

`players.game_accounts`는 `[{"region":"NA","riotId":"C9loki#kr3"}]` 그대로였다 — 정상 sync로는
설명되지 않는 되돌림이라 이 경로가 특정됐다. 롤백된 동안 KR 서버를 폴링하므로 NA 솔랭 게임을
감지하지 못하고, 다음 06:00 계정 sync까지 구독자 알림이 끊긴다(당시 구독자 6명).

## 변경

```java
private void persist(PlayerRiotAccount account) {
    transactionTemplate.executeWithoutResult(status ->
            playerRiotAccountRepository.findById(account.getId())
                    .ifPresent(current -> current.copyLiveStateFrom(account)));
}
```

- `PlayerRiotAccount.copyLiveStateFrom` — `liveStatus`, `lastCheckedMatchId`, `lastAlertedMatchId`, `lastMatchCheckedAt` 만 옮긴다
- managed 엔티티라 `save` 호출 없이 dirty checking으로 반영. 행이 사라진 계정은 조용히 스킵
- 계정 식별자는 이제 sync·백오피스 경로만 쓴다

## 검증

- 신규 회귀 테스트 2개: 스냅샷은 옛 KR 계정, DB 현재 행은 NA 계정인 상태로 폴링 → 식별자 3개 유지 + 상태 컬럼 반영 + `save` 미호출 / 삭제된 계정 스킵
- 옛 코드(`save(account)`)로 되돌려 첫 테스트가 실제로 실패하는 것 확인
- 전체 `./gradlew test` — 460 tests, 0 failures

프로덕션 데이터는 재부착으로 이미 복구했다(`C9loki#kr3` / NA1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)