### PR TITLE
feat: Live Activity push-to-start — 서버가 잠금화면 카드를 생성 (기본 OFF)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ APNS_ENABLED                             # 기본 false
 APNS_KEY_PATH                            # Apple Developer 에서 받은 .p8 파일 경로
 APNS_KEY_ID, APNS_TEAM_ID, APNS_BUNDLE_ID
 APNS_HOST                                # 기본 https://api.push.apple.com (개발 빌드는 api.sandbox.push.apple.com)
+APNS_PUSH_TO_START_ENABLED               # 서버가 잠금화면 카드를 생성(push-to-start, iOS 17.2+). 기본 false
 ```
 
 ### 스케줄러 전역 스위치

--- a/src/main/java/com/toy/nar/api/mobile/liveactivity/MobileLiveActivityController.java
+++ b/src/main/java/com/toy/nar/api/mobile/liveactivity/MobileLiveActivityController.java
@@ -1,6 +1,7 @@
 package com.toy.nar.api.mobile.liveactivity;
 
 import com.toy.nar.app.mobile.liveactivity.LiveActivityTokenService;
+import com.toy.nar.app.mobile.liveactivity.dto.LiveActivityStartTokenRequest;
 import com.toy.nar.app.mobile.liveactivity.dto.LiveActivityTokenRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,6 +37,31 @@ public class MobileLiveActivityController {
 			@AuthenticationPrincipal Long memberId,
 			@Valid @RequestBody LiveActivityTokenRequest request) {
 		tokenService.register(memberId, request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(
+			summary = "push-to-start 토큰 등록/갱신",
+			description = "앱이 실행 중이 아닐 때도 서버가 잠금화면 카드를 만들 수 있게 하는 앱 단위 토큰입니다. "
+					+ "iOS 17.2 이상에서 Activity.pushToStartTokenUpdates 로 받습니다. "
+					+ "카드 단위 토큰(POST /)과 다른 값이라 따로 올려야 합니다.")
+	@PostMapping("/start-token")
+	public ResponseEntity<Void> registerStartToken(
+			@AuthenticationPrincipal Long memberId,
+			@Valid @RequestBody LiveActivityStartTokenRequest request) {
+		tokenService.registerStartToken(memberId, request.pushToken());
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(
+			summary = "push-to-start 토큰 해제",
+			description = "사용자가 실시간 활동을 끄거나 로그아웃할 때 호출합니다.")
+	@DeleteMapping("/start-token")
+	public ResponseEntity<Void> unregisterStartToken(
+			@AuthenticationPrincipal Long memberId,
+			@Parameter(description = "등록할 때 올린 push-to-start 토큰")
+			@RequestParam String pushToken) {
+		tokenService.unregisterStartToken(memberId, pushToken);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -49,6 +49,7 @@ public class LivePollingScheduler {
 	private final NotificationService notificationService;
 	private final com.toy.nar.app.mobile.push.TeamLiveEventPushService teamLiveEventPushService;
 	private final com.toy.nar.app.mobile.push.LiveActivityPushService liveActivityPushService;
+	private final com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository teamExternalIdentityRepository;
 	private final LiveFrameStallTracker frameStallTracker;
 	private final com.toy.nar.app.lolesports.repository.LeagueMatchRepository leagueMatchRepository;
 	@org.springframework.beans.factory.annotation.Qualifier("applicationTaskExecutor")
@@ -394,13 +395,45 @@ public class LivePollingScheduler {
 		}
 		try {
 			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
-			liveActivityPushService.notifySetStart(
-					activeGame.matchId(),
-					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
-					match == null ? null : match.getBlueScore(),
-					match == null ? null : match.getRedScore());
+			int setNumber = activeGame.setNumber() != null ? activeGame.setNumber() : 0;
+			Integer blueScore = match == null ? null : match.getBlueScore();
+			Integer redScore = match == null ? null : match.getRedScore();
+
+			// 이미 카드를 띄운 사람들 갱신.
+			liveActivityPushService.notifySetStart(activeGame.matchId(), setNumber, blueScore, redScore);
+
+			// 아직 카드가 없는 구독자에게는 카드를 새로 만들어 준다.
+			// 세트마다 진영이 스왑되므로 팀 표기는 세트 기준(ActiveLiveGame)이 아니라
+			// 매치 기준(LeagueMatch)을 쓴다 — 앱도 매치 기준으로 A/B 를 잡는다.
+			if (match != null) {
+				liveActivityPushService.startCards(
+						activeGame.matchId(), setNumber, blueScore, redScore,
+						resolveTeamId(match.getBlueExternalTeamId()),
+						resolveTeamId(match.getRedExternalTeamId()),
+						new com.toy.nar.app.mobile.push.LiveActivityPushService.MatchCardAttributes(
+								match.getId(),
+								match.getBlueTeamName(), match.getBlueTeamCode(),
+								match.getRedTeamName(), match.getRedTeamCode(),
+								match.getLeagueName()));
+			}
 		} catch (Exception e) {
 			log.warn("[live-activity] set-start 실패 matchId={}: {}", activeGame.matchId(), e.getMessage());
+		}
+	}
+
+	/** 팀 구독 매칭용 내부 팀 id. 해석 실패하면 null 이고, 그 팀 구독자는 대상에서 빠진다. */
+	private Long resolveTeamId(String externalTeamId) {
+		if (externalTeamId == null || externalTeamId.isBlank()) {
+			return null;
+		}
+		try {
+			return teamExternalIdentityRepository
+					.findBySourceAndExternalTeamId("LOLESPORTS", externalTeamId)
+					.map(identity -> identity.getTeam().getId())
+					.orElse(null);
+		} catch (Exception e) {
+			log.warn("[live-activity] 팀 id 해석 실패 externalTeamId={}: {}", externalTeamId, e.getMessage());
+			return null;
 		}
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/liveactivity/LiveActivityTokenService.java
+++ b/src/main/java/com/toy/nar/app/mobile/liveactivity/LiveActivityTokenService.java
@@ -1,8 +1,10 @@
 package com.toy.nar.app.mobile.liveactivity;
 
 import com.toy.nar.app.mobile.liveactivity.dto.LiveActivityTokenRequest;
+import com.toy.nar.domain.member.entity.LiveActivityStartToken;
 import com.toy.nar.domain.member.entity.LiveActivityToken;
 import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.repository.LiveActivityStartTokenRepository;
 import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
 import com.toy.nar.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ public class LiveActivityTokenService {
 
 	private final MemberRepository memberRepository;
 	private final LiveActivityTokenRepository tokenRepository;
+	private final LiveActivityStartTokenRepository startTokenRepository;
 
 	/**
 	 * 토큰 등록 또는 갱신. 같은 토큰이 다시 오면 매치와 활성 여부만 갱신한다
@@ -34,6 +37,33 @@ public class LiveActivityTokenService {
 								.matchId(request.matchId())
 								.pushToken(request.pushToken())
 								.build()));
+	}
+
+	/**
+	 * push-to-start 토큰 등록 또는 갱신.
+	 *
+	 * <p>카드 단위 토큰과 달리 앱 단위라 매치를 받지 않는다. 이 토큰이 있어야 서버가 카드를
+	 * 새로 만들 수 있다({@code Activity.pushToStartTokenUpdates}, iOS 17.2+).</p>
+	 */
+	@Transactional
+	public void registerStartToken(Long memberId, String pushToken) {
+		Member member = requireMember(memberId);
+		startTokenRepository.findByPushToken(pushToken)
+				.ifPresentOrElse(
+						token -> token.reactivate(member),
+						() -> startTokenRepository.save(LiveActivityStartToken.builder()
+								.member(member)
+								.pushToken(pushToken)
+								.build()));
+	}
+
+	/** 사용자가 실시간 활동을 끄거나 로그아웃할 때 호출한다. */
+	@Transactional
+	public void unregisterStartToken(Long memberId, String pushToken) {
+		requireMemberId(memberId);
+		startTokenRepository.findByPushToken(pushToken)
+				.filter(token -> token.getMember().getId().equals(memberId))
+				.ifPresent(LiveActivityStartToken::deactivate);
 	}
 
 	/**

--- a/src/main/java/com/toy/nar/app/mobile/liveactivity/dto/LiveActivityStartTokenRequest.java
+++ b/src/main/java/com/toy/nar/app/mobile/liveactivity/dto/LiveActivityStartTokenRequest.java
@@ -1,0 +1,14 @@
+package com.toy.nar.app.mobile.liveactivity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * push-to-start 토큰 등록 요청.
+ *
+ * <p>카드 단위 토큰과 달리 앱 단위라 matchId 가 없다. 이 토큰이 있어야 서버가
+ * 앱 실행 없이 잠금화면 카드를 만들 수 있다.</p>
+ */
+public record LiveActivityStartTokenRequest(
+		@NotBlank(message = "pushToken은 필수입니다.")
+		String pushToken) {
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
@@ -117,6 +117,30 @@ public class ApnsLiveActivityClient {
 		return sendAsync(pushToken, body("end", contentState, Instant.now().plus(dismissAfter)));
 	}
 
+	/**
+	 * 카드를 새로 만든다(push-to-start, iOS 17.2+).
+	 *
+	 * <p>갱신과 달리 정적 속성까지 실어 보낸다. {@code attributes-type} 은 앱의
+	 * ActivityAttributes 타입 이름과 정확히 같아야 하고, {@code attributes} 는 그 타입의
+	 * 필드 구성과 일치해야 한다. 어긋나면 APNs 는 200 을 주고 카드만 안 뜬다.</p>
+	 *
+	 * <p>토큰도 다르다 — 여기 넘기는 것은 액티비티 토큰이 아니라 앱 단위
+	 * push-to-start 토큰이다.</p>
+	 */
+	public CompletableFuture<Boolean> sendStartAsync(
+			String pushToStartToken,
+			String attributesType,
+			Map<String, Object> attributes,
+			Map<String, Object> contentState) {
+		Map<String, Object> aps = new LinkedHashMap<>();
+		aps.put("timestamp", Instant.now().getEpochSecond());
+		aps.put("event", "start");
+		aps.put("attributes-type", attributesType);
+		aps.put("attributes", attributes);
+		aps.put("content-state", contentState);
+		return sendAsync(pushToStartToken, Map.of("aps", aps));
+	}
+
 	private Map<String, Object> body(String event, Map<String, Object> contentState, Instant dismissalDate) {
 		Map<String, Object> aps = new LinkedHashMap<>();
 		aps.put("timestamp", Instant.now().getEpochSecond());

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -1,8 +1,10 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.domain.member.repository.LiveActivityStartTokenRepository;
 import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -37,8 +39,19 @@ public class LiveActivityPushService {
 	/** 경기 종료 카드를 남겨 두는 시간. 앱의 자동 dismiss 타이머와 같은 값. */
 	private static final Duration MATCH_END_DISMISS_AFTER = Duration.ofMinutes(30);
 
+	/** 앱의 ActivityAttributes 타입 이름. 다르면 APNs 는 200 을 주고 카드만 안 뜬다. */
+	private static final String ATTRIBUTES_TYPE = "MatchLiveAttributes";
+
 	private final LiveActivityTokenRepository tokenRepository;
+	private final LiveActivityStartTokenRepository startTokenRepository;
 	private final ApnsLiveActivityClient apnsClient;
+
+	/**
+	 * push-to-start 별도 스위치. 카드를 "갱신"하는 것과 달리 사용자가 띄우지 않은 카드를
+	 * 잠금화면에 만들어 내는 동작이라, APNs 전체를 켠 뒤에도 이것만 따로 끌 수 있게 둔다.
+	 */
+	@Value("${apns.push-to-start.enabled:false}")
+	private boolean pushToStartEnabled;
 
 	/**
 	 * 매치별로 마지막에 카드에 반영한 진행도. 뒤처진 이벤트를 걸러내는 워터마크다.
@@ -66,6 +79,117 @@ public class LiveActivityPushService {
 			return;
 		}
 		fanOut(matchId, contentState(PHASE_PLAYING, setNumber, blueScore, redScore, "", null), false);
+	}
+
+	/**
+	 * 구독자에게 카드를 새로 띄운다(push-to-start).
+	 *
+	 * <p>지금까지 카드는 앱이 실행돼야만 떴다. 잠금화면 카드를 보는 상황이 곧 앱이 안 떠 있는
+	 * 상황이라, 정작 필요한 때에 카드가 없었다. 세트 시작 시점에 서버가 만들어 준다.</p>
+	 *
+	 * <p>{@code notifySetStart} 와 대상이 다르다. 그쪽은 이미 카드를 띄운 토큰에 보내고,
+	 * 이쪽은 이 경기를 구독한 회원 중 아직 카드가 없는 사람에게 보낸다. 두 경로는 겹치지 않는다.</p>
+	 *
+	 * @param blueTeamId 팀 구독 매칭용 내부 팀 id. 해석 실패 시 null (경기 구독자만 대상이 된다)
+	 */
+	public void startCards(
+			String matchId,
+			int setNumber,
+			Integer blueScore,
+			Integer redScore,
+			Long blueTeamId,
+			Long redTeamId,
+			MatchCardAttributes attributes) {
+		if (!isEnabled() || !pushToStartEnabled || matchId == null || matchId.isBlank()) {
+			return;
+		}
+		List<LiveActivityStartTokenRepository.StartTargetRow> targets;
+		try {
+			targets = startTokenRepository.findStartTargets(matchId, blueTeamId, redTeamId);
+		} catch (Exception e) {
+			log.warn("push-to-start 대상 조회 실패 matchId={}: {}", matchId, e.getMessage());
+			return;
+		}
+		if (targets.isEmpty()) {
+			return;
+		}
+
+		Map<String, Object> state = contentState(PHASE_PLAYING, setNumber, blueScore, redScore, "", null);
+		Map<String, CompletableFuture<Boolean>> inFlight = new LinkedHashMap<>();
+		for (LiveActivityStartTokenRepository.StartTargetRow target : targets) {
+			// 응원 팀 하트는 회원마다 달라 payload 를 회원별로 만든다.
+			inFlight.put(target.getPushToken(), apnsClient.sendStartAsync(
+					target.getPushToken(),
+					ATTRIBUTES_TYPE,
+					attributes.toPayload(target.getFavoriteTeamCode()),
+					state));
+		}
+
+		List<String> deadTokens = new ArrayList<>();
+		inFlight.forEach((token, future) -> {
+			boolean alive;
+			try {
+				alive = future.join();
+			} catch (Exception e) {
+				log.warn("push-to-start 결과 수집 실패 matchId={}: {}", matchId, e.getMessage());
+				alive = true;
+			}
+			if (!alive) {
+				deadTokens.add(token);
+			}
+		});
+		log.info("[live-activity] push-to-start matchId={} set={} 발송 {}건, 죽은 토큰 {}건",
+				matchId, setNumber, targets.size(), deadTokens.size());
+
+		if (!deadTokens.isEmpty()) {
+			try {
+				startTokenRepository.deactivateByPushTokenIn(deadTokens);
+			} catch (Exception e) {
+				log.warn("push-to-start 토큰 비활성화 실패 matchId={}: {}", matchId, e.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * 카드의 정적 속성. Swift {@code MatchLiveAttributes} 의 필드 구성과 정확히 맞아야 한다.
+	 *
+	 * <p>로고는 파일명만 넘긴다. 앱이 App Group 에 미리 캐싱해 둔 파일을 위젯이 읽는 구조라
+	 * (확장은 렌더 시점에 네트워크를 못 쓴다), 파일이 없으면 로고 없이 그려진다.</p>
+	 */
+	public record MatchCardAttributes(
+			String matchId,
+			String teamAName,
+			String teamACode,
+			String teamBName,
+			String teamBCode,
+			String leagueName) {
+
+		Map<String, Object> toPayload(String favoriteTeamCode) {
+			Map<String, Object> payload = new LinkedHashMap<>();
+			payload.put("matchId", nullToEmpty(matchId));
+			payload.put("teamAName", nullToEmpty(teamAName));
+			payload.put("teamACode", nullToEmpty(teamACode));
+			payload.put("teamBName", nullToEmpty(teamBName));
+			payload.put("teamBCode", nullToEmpty(teamBCode));
+			payload.put("leagueName", nullToEmpty(leagueName));
+			// 앱과 합의한 캐시 파일명 규칙: <팀코드>.png
+			logoFile(teamACode).ifPresent(file -> payload.put("teamALogoFile", file));
+			logoFile(teamBCode).ifPresent(file -> payload.put("teamBLogoFile", file));
+			if (favoriteTeamCode != null && !favoriteTeamCode.isBlank()) {
+				payload.put("favoriteTeamCode", favoriteTeamCode);
+			}
+			return payload;
+		}
+
+		private static java.util.Optional<String> logoFile(String teamCode) {
+			return teamCode == null || teamCode.isBlank()
+					? java.util.Optional.empty()
+					: java.util.Optional.of(teamCode + ".png");
+		}
+
+		private static String nullToEmpty(String value) {
+			return value == null ? "" : value;
+		}
 	}
 
 	/**

--- a/src/main/java/com/toy/nar/domain/member/entity/LiveActivityStartToken.java
+++ b/src/main/java/com/toy/nar/domain/member/entity/LiveActivityStartToken.java
@@ -1,0 +1,88 @@
+package com.toy.nar.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * iOS push-to-start 토큰 (iOS 17.2+).
+ *
+ * <p>{@link LiveActivityToken} 과 헷갈리면 안 된다. 그쪽은 이미 떠 있는 카드 하나를 가리키는
+ * 액티비티 단위 토큰이고, 이쪽은 앱 단위라 카드가 없어도 존재한다. 이 토큰으로만 서버가
+ * 카드를 새로 만들 수 있다.</p>
+ */
+@Entity
+@Table(name = "live_activity_start_token", uniqueConstraints = {
+		@UniqueConstraint(name = "uk_live_activity_start_token_push_token", columnNames = "push_token")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LiveActivityStartToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "push_token", nullable = false, length = 512)
+	private String pushToken;
+
+	@Column(name = "active", nullable = false)
+	private boolean active;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Builder
+	public LiveActivityStartToken(Member member, String pushToken) {
+		this.member = Objects.requireNonNull(member, "member must not be null");
+		this.pushToken = Objects.requireNonNull(pushToken, "pushToken must not be null");
+		this.active = true;
+	}
+
+	/** 앱이 같은 토큰을 다시 올린 경우(재설치·기기 이전 등)에 소유자를 갱신하고 되살린다. */
+	public void reactivate(Member member) {
+		this.member = Objects.requireNonNull(member, "member must not be null");
+		this.active = true;
+	}
+
+	public void deactivate() {
+		this.active = false;
+	}
+
+	@PrePersist
+	void onCreate() {
+		LocalDateTime now = LocalDateTime.now();
+		if (createdAt == null) {
+			createdAt = now;
+		}
+		updatedAt = now;
+	}
+
+	@PreUpdate
+	void onUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/LiveActivityStartTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/LiveActivityStartTokenRepository.java
@@ -1,0 +1,73 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.LiveActivityStartToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveActivityStartTokenRepository extends JpaRepository<LiveActivityStartToken, Long> {
+
+	Optional<LiveActivityStartToken> findByPushToken(String pushToken);
+
+	/** 발송에 필요한 것만 뽑는다. 응원 팀은 회원마다 달라 카드 payload 도 회원별로 만든다. */
+	interface StartTargetRow {
+		String getPushToken();
+
+		Long getMemberId();
+
+		String getFavoriteTeamCode();
+	}
+
+	/**
+	 * 이 경기의 카드를 새로 띄워 줄 대상.
+	 *
+	 * <p>대상 산정이 기존 갱신 발송과 반대다. 갱신은 "이미 카드를 띄운 토큰"에 보내지만,
+	 * 생성은 "이 경기를 구독한 회원"에게 보내야 한다. 그래서 팀 구독·경기 구독을 그대로 따라간다
+	 * (세트 시작 토글이 켜진 경우만 — 알림을 끈 사람에게 카드를 띄우지 않는다).</p>
+	 *
+	 * <p>이미 카드가 떠 있는 회원은 제외한다. 앱이 먼저 띄운 카드가 있는데 서버가 또 만들면
+	 * 잠금화면에 같은 경기 카드가 두 장 뜬다.</p>
+	 */
+	@Query("""
+			SELECT t.pushToken AS pushToken, m.id AS memberId, ft.code AS favoriteTeamCode
+			FROM LiveActivityStartToken t
+			JOIN t.member m
+			LEFT JOIN m.favoriteTeam ft
+			WHERE t.active = true
+			  AND (
+				  EXISTS (
+					  SELECT ts.id FROM MemberTeamNotificationSubscription ts
+					  WHERE ts.member = m
+					    AND ts.setStartEnabled = true
+					    AND ((:blueTeamId IS NOT NULL AND ts.team.id = :blueTeamId)
+					      OR (:redTeamId IS NOT NULL AND ts.team.id = :redTeamId))
+				  )
+				  OR EXISTS (
+					  SELECT ms.id FROM MemberMatchSubscription ms
+					  WHERE ms.member = m
+					    AND ms.matchId = :matchId
+					    AND ms.setStartEnabled = true
+				  )
+			  )
+			  AND NOT EXISTS (
+				  SELECT a.id FROM LiveActivityToken a
+				  WHERE a.member = m AND a.matchId = :matchId AND a.active = true
+			  )
+			""")
+	List<StartTargetRow> findStartTargets(
+			@Param("matchId") String matchId,
+			@Param("blueTeamId") Long blueTeamId,
+			@Param("redTeamId") Long redTeamId);
+
+	/** APNs 가 거절한(410 등) 토큰은 더 쓰지 않는다. */
+	@Transactional
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("update LiveActivityStartToken t set t.active = false, t.updatedAt = CURRENT_TIMESTAMP "
+			+ "where t.pushToken in :pushTokens")
+	int deactivateByPushTokenIn(@Param("pushTokens") List<String> pushTokens);
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -195,3 +195,7 @@ apns:
   bundle-id: ${APNS_BUNDLE_ID:}
   # 개발 빌드(Xcode 직접 설치)는 https://api.sandbox.push.apple.com 로 보내야 한다.
   host: ${APNS_HOST:https://api.push.apple.com}
+  push-to-start:
+    # 사용자가 띄우지 않은 카드를 서버가 잠금화면에 만들어 내는 동작이라 별도 스위치로 둔다.
+    # 앱이 push-to-start 토큰을 올리기 시작한 뒤에 켠다(iOS 17.2+).
+    enabled: ${APNS_PUSH_TO_START_ENABLED:false}

--- a/src/main/resources/db/migration/V64__Create_live_activity_start_token.sql
+++ b/src/main/resources/db/migration/V64__Create_live_activity_start_token.sql
@@ -1,0 +1,20 @@
+-- iOS push-to-start 토큰 (iOS 17.2+).
+--
+-- live_activity_token 과 다른 체계라 테이블을 나눈다:
+--   - 그쪽은 카드 하나에 붙는 액티비티 단위 토큰이고 match_id 가 있다.
+--   - 이쪽은 앱 단위 토큰이라 특정 경기에 매이지 않는다. 카드가 없어도 발급된다.
+--     (Activity.pushToStartTokenUpdates)
+--
+-- 이 토큰으로는 서버가 카드를 "만들" 수 있다. 지금까지는 앱이 실행돼야만 카드가 떴다.
+CREATE TABLE live_activity_start_token (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT       NOT NULL,
+    push_token VARCHAR(512) NOT NULL,
+    active     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_live_activity_start_token_push_token UNIQUE (push_token),
+    CONSTRAINT fk_live_activity_start_token_member
+        FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    INDEX idx_live_activity_start_token_member_active (member_id, active)
+);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -51,6 +51,7 @@ class LivePollingSchedulerTest {
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -96,6 +97,7 @@ class LivePollingSchedulerTest {
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -294,6 +296,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -332,6 +335,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -371,6 +375,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -411,6 +416,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -453,6 +459,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -490,6 +497,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, cacheEvictionService, mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -533,6 +541,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, cacheEvictionService, mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -570,6 +579,7 @@ class LivePollingSchedulerTest {
 				leagueConfigService, mock(CacheEvictionService.class), mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -763,6 +773,7 @@ class LivePollingSchedulerTest {
 				mock(NotificationService.class),
 				pushService,
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				frameStallTracker,
 				leagueMatchRepository,
 				Runnable::run);
@@ -792,6 +803,7 @@ class LivePollingSchedulerTest {
 				mock(NotificationService.class),
 				pushService,
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);
@@ -819,6 +831,7 @@ class LivePollingSchedulerTest {
 				mock(NotificationService.class),
 				mock(TeamLiveEventPushService.class),
 				mock(com.toy.nar.app.mobile.push.LiveActivityPushService.class),
+				mock(com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository.class),
 				new LiveFrameStallTracker(180_000L),
 				mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class),
 				Runnable::run);

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -1,5 +1,6 @@
 package com.toy.nar.app.mobile.push;
 
+import com.toy.nar.domain.member.repository.LiveActivityStartTokenRepository;
 import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,14 +22,16 @@ import static org.mockito.Mockito.when;
 class LiveActivityPushServiceTest {
 
 	private LiveActivityTokenRepository tokenRepository;
+	private LiveActivityStartTokenRepository startTokenRepository;
 	private ApnsLiveActivityClient apnsClient;
 	private LiveActivityPushService service;
 
 	@BeforeEach
 	void setUp() {
 		tokenRepository = mock(LiveActivityTokenRepository.class);
+		startTokenRepository = mock(LiveActivityStartTokenRepository.class);
 		apnsClient = mock(ApnsLiveActivityClient.class);
-		service = new LiveActivityPushService(tokenRepository, apnsClient);
+		service = new LiveActivityPushService(tokenRepository, startTokenRepository, apnsClient);
 		when(apnsClient.isAvailable()).thenReturn(true);
 		when(apnsClient.sendUpdateAsync(anyString(), any())).thenReturn(alive(true));
 		when(apnsClient.sendEndAsync(anyString(), any(), any())).thenReturn(alive(true));
@@ -247,6 +250,136 @@ class LiveActivityPushServiceTest {
 		service.notifySetStart("match-1", 1, 0, 0);
 
 		verify(apnsClient, never()).sendUpdateAsync(anyString(), any());
+	}
+
+	// ── push-to-start ──────────────────────────────
+
+	@Test
+	void 구독자에게_카드를_새로_만든다() {
+		enablePushToStart();
+		when(startTokenRepository.findStartTargets("match-1", 10L, 20L))
+				.thenReturn(List.of(startTarget("start-tok", 1L, "T1")));
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		ArgumentCaptor<Map<String, Object>> attrs = mapCaptor();
+		ArgumentCaptor<Map<String, Object>> state = mapCaptor();
+		verify(apnsClient).sendStartAsync(eq("start-tok"), eq("MatchLiveAttributes"),
+				attrs.capture(), state.capture());
+		assertThat(attrs.getValue())
+				.containsEntry("matchId", "match-1")
+				.containsEntry("teamACode", "T1")
+				.containsEntry("teamBCode", "HLE")
+				.containsEntry("leagueName", "LCK")
+				// 앱과 합의한 캐시 파일명 규칙
+				.containsEntry("teamALogoFile", "T1.png")
+				.containsEntry("teamBLogoFile", "HLE.png")
+				.containsEntry("favoriteTeamCode", "T1");
+		assertThat(state.getValue()).containsEntry("phase", "playing").containsEntry("setNumber", 1);
+	}
+
+	@Test
+	void 응원팀이_없으면_하트_필드를_빼고_보낸다() {
+		enablePushToStart();
+		when(startTokenRepository.findStartTargets("match-1", 10L, 20L))
+				.thenReturn(List.of(startTarget("start-tok", 1L, null)));
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		ArgumentCaptor<Map<String, Object>> attrs = mapCaptor();
+		verify(apnsClient).sendStartAsync(anyString(), anyString(), attrs.capture(), any());
+		assertThat(attrs.getValue()).doesNotContainKey("favoriteTeamCode");
+	}
+
+	@Test
+	void 회원마다_응원팀이_달라_payload_를_따로_만든다() {
+		enablePushToStart();
+		when(startTokenRepository.findStartTargets("match-1", 10L, 20L)).thenReturn(List.of(
+				startTarget("tok-a", 1L, "T1"),
+				startTarget("tok-b", 2L, "HLE")));
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		ArgumentCaptor<Map<String, Object>> attrs = mapCaptor();
+		verify(apnsClient, org.mockito.Mockito.times(2))
+				.sendStartAsync(anyString(), anyString(), attrs.capture(), any());
+		assertThat(attrs.getAllValues()).extracting(m -> m.get("favoriteTeamCode"))
+				.containsExactly("T1", "HLE");
+	}
+
+	@Test
+	void push_to_start_스위치가_꺼져_있으면_조회조차_하지_않는다() {
+		// APNs 자체는 켜져 있어도 카드 생성만 따로 끌 수 있어야 한다.
+		when(apnsClient.isAvailable()).thenReturn(true);
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		verify(startTokenRepository, never()).findStartTargets(anyString(), any(), any());
+	}
+
+	@Test
+	void 대상이_없으면_발송하지_않는다() {
+		enablePushToStart();
+		when(startTokenRepository.findStartTargets("match-1", 10L, 20L)).thenReturn(List.of());
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		verify(apnsClient, never()).sendStartAsync(anyString(), anyString(), any(), any());
+	}
+
+	@Test
+	void 죽은_push_to_start_토큰만_비활성화한다() {
+		enablePushToStart();
+		when(startTokenRepository.findStartTargets("match-1", 10L, 20L)).thenReturn(List.of(
+				startTarget("live", 1L, null),
+				startTarget("dead", 2L, null)));
+		when(apnsClient.sendStartAsync(eq("dead"), anyString(), any(), any())).thenReturn(alive(false));
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		verify(startTokenRepository).deactivateByPushTokenIn(List.of("dead"));
+	}
+
+	@Test
+	void 대상_조회가_실패해도_예외가_새지_않는다() {
+		enablePushToStart();
+		when(startTokenRepository.findStartTargets(anyString(), any(), any()))
+				.thenThrow(new RuntimeException("DB down"));
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		verify(apnsClient, never()).sendStartAsync(anyString(), anyString(), any(), any());
+	}
+
+	private void enablePushToStart() {
+		when(apnsClient.isAvailable()).thenReturn(true);
+		org.springframework.test.util.ReflectionTestUtils.setField(service, "pushToStartEnabled", true);
+		when(apnsClient.sendStartAsync(anyString(), anyString(), any(), any())).thenReturn(alive(true));
+	}
+
+	private LiveActivityPushService.MatchCardAttributes attributes() {
+		return new LiveActivityPushService.MatchCardAttributes(
+				"match-1", "T1", "T1", "Hanwha Life Esports", "HLE", "LCK");
+	}
+
+	private LiveActivityStartTokenRepository.StartTargetRow startTarget(
+			String pushToken, Long memberId, String favoriteTeamCode) {
+		return new LiveActivityStartTokenRepository.StartTargetRow() {
+			@Override
+			public String getPushToken() {
+				return pushToken;
+			}
+
+			@Override
+			public Long getMemberId() {
+				return memberId;
+			}
+
+			@Override
+			public String getFavoriteTeamCode() {
+				return favoriteTeamCode;
+			}
+		};
 	}
 
 	private Map<String, Object> captureUpdate() {

--- a/src/test/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepositoryTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepositoryTest.java
@@ -60,6 +60,66 @@ class LiveActivityTokenRepositoryTest {
 		em.clear();
 	}
 
+	@Autowired
+	private LiveActivityStartTokenRepository startTokenRepository;
+
+	@Test
+	void push_to_start_는_구독자에게_보내되_카드가_이미_있으면_제외한다() {
+		subscribeBothMembersToTeam10();
+
+		// match-1 은 seed 에서 두 회원 모두 활성 카드를 갖고 있다 → 전원 제외.
+		assertThat(startTokenRepository.findStartTargets("match-1", 10L, null)).isEmpty();
+
+		// match-3 은 아무도 카드가 없다 → 구독자 전원이 대상.
+		assertThat(startTokenRepository.findStartTargets("match-3", 10L, null))
+				.extracting(LiveActivityStartTokenRepository.StartTargetRow::getPushToken)
+				.containsExactlyInAnyOrder("start-1", "start-2");
+	}
+
+	@Test
+	void 구독하지_않은_팀_경기는_대상이_아니다() {
+		subscribeBothMembersToTeam10();
+
+		assertThat(startTokenRepository.findStartTargets("match-3", 99L, 98L)).isEmpty();
+	}
+
+	@Test
+	void 세트_시작_알림을_끈_구독자에게는_카드를_만들지_않는다() {
+		// 알림을 끈 사람에게 잠금화면 카드를 띄우면 안 된다.
+		exec("INSERT INTO teams (team_id, team_name, team_code) VALUES (10, 'T1', 'T1')");
+		insertStartToken(1L, 1L, "start-1");
+		exec("INSERT INTO member_team_notification_subscription"
+				+ " (id, member_id, team_id, set_start_enabled, set_end_enabled,"
+				+ "  live_event_enabled, created_at, updated_at)"
+				+ " VALUES (1, 1, 10, false, true, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)");
+		em.flush();
+		em.clear();
+
+		assertThat(startTokenRepository.findStartTargets("match-3", 10L, null)).isEmpty();
+	}
+
+	private void subscribeBothMembersToTeam10() {
+		exec("INSERT INTO teams (team_id, team_name, team_code) VALUES (10, 'T1', 'T1')");
+		insertStartToken(1L, 1L, "start-1");
+		insertStartToken(2L, 2L, "start-2");
+		for (long memberId = 1; memberId <= 2; memberId++) {
+			exec("INSERT INTO member_team_notification_subscription"
+					+ " (id, member_id, team_id, set_start_enabled, set_end_enabled,"
+					+ "  live_event_enabled, created_at, updated_at)"
+					+ " VALUES (" + memberId + ", " + memberId + ", 10,"
+					+ " true, true, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)");
+		}
+		em.flush();
+		em.clear();
+	}
+
+	private void insertStartToken(long id, long memberId, String pushToken) {
+		exec("INSERT INTO live_activity_start_token"
+				+ " (id, member_id, push_token, active, created_at, updated_at)"
+				+ " VALUES (" + id + ", " + memberId + ", '" + pushToken + "', true,"
+				+ " CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)");
+	}
+
 	@Test
 	void 매치의_활성_토큰만_돌려준다() {
 		assertThat(tokenRepository.findActivePushTokensByMatchId("match-1"))


### PR DESCRIPTION
지금까지 잠금화면 경기 카드는 앱이 실행돼야만 떴습니다. 카드를 보는 상황이 곧 앱이 안 떠 있는 상황이라, 정작 필요한 때에 카드가 없었습니다. 앱 팀에서도 같은 지점을 요청해 왔습니다.

세트 시작 시점에 서버가 구독자에게 카드를 만들어 줍니다(iOS 17.2+). **기본 OFF입니다.**

## 지금 무엇이 문제인가

iOS는 백그라운드 앱을 suspend해서 Dart가 한 줄도 돌지 않습니다. 그래서 카드가 생기는 순간은 앱 시작·포그라운드 복귀·경기 상세 진입 셋뿐이고, 전부 포그라운드 이벤트입니다.

결과적으로 앱을 닫아둔 채 경기가 시작되면 FCM 알림은 오는데 카드는 없습니다.

push-to-start는 토큰을 넘기는 순간에만 앱 실행이 필요하고, 그 뒤로는 앱이 떠 있지 않아도 서버가 카드를 만듭니다. FCM과 같은 구조입니다 — 등록 1회, 이후 발송은 앱과 무관.

## 갱신 발송과 다른 점

**토큰 체계가 다릅니다.** 기존 `live_activity_token`은 카드 하나를 가리키는 액티비티 단위 토큰이고, push-to-start 토큰은 앱 단위라 카드가 없어도 존재합니다(`Activity.pushToStartTokenUpdates`). 별도 테이블(V64)로 뒀습니다.

**대상 산정이 반대입니다.**

| | 대상 |
|---|---|
| 갱신 | 이미 카드를 띄운 토큰 |
| 생성 | 이 경기를 구독한 회원 |

팀 구독·경기 구독을 그대로 따라가되 세트 시작 토글이 켜진 경우만 보냅니다. 알림을 끈 사람 잠금화면에 카드를 띄우면 안 됩니다.

이미 카드가 있는 회원은 쿼리에서 제외합니다. 앱이 먼저 띄운 카드가 있는데 서버가 또 만들면 같은 경기 카드가 두 장 뜹니다.

## payload

`attributes`는 회원별로 만듭니다. 응원 팀 하트가 회원마다 달라서입니다.

로고는 파일명만 싣습니다(`<팀코드>.png`). 위젯 확장은 렌더 시점에 네트워크를 못 쓰고 payload는 4KB 제한이라 이미지를 실을 수 없어서, 앱이 App Group에 미리 캐싱해 둔 파일을 읽는 구조입니다. **파일이 없으면 로고 없이 그려지므로 앱의 사전 캐싱과 독립적으로 배포·검증할 수 있습니다.**

팀 표기는 세트 기준이 아니라 매치 기준(`LeagueMatch`)을 씁니다. 세트마다 진영이 스왑되는데 앱은 매치 기준으로 A/B를 잡기 때문입니다.

## 스위치

`apns.push-to-start.enabled`(env `APNS_PUSH_TO_START_ENABLED`)를 따로 뒀습니다. 사용자가 띄우지 않은 카드를 잠금화면에 만들어 내는 동작이라, APNs 전체를 켠 뒤에도 이것만 끌 수 있어야 합니다. 꺼져 있으면 대상 조회조차 하지 않습니다.

## 검증

전체 511개 통과. 신규 10건입니다.

- payload 필드·파일명 규칙, 회원별 응원팀 분리, 스위치 동작, 죽은 토큰 정리
- 실제 EntityManager로 돌린 대상 산정 쿼리 — 카드 보유자 제외 / 미구독 팀 제외 / 세트 시작 알림 끈 구독자 제외 3방향
- V64는 로컬 MySQL 8.0에 실제 적용해 스키마 확인

## 앱 작업

```
POST   /api/mobile/me/live-activities/start-token   { "pushToken": "..." }
DELETE /api/mobile/me/live-activities/start-token?pushToken=...
```

`Activity.pushToStartTokenUpdates`로 받은 앱 단위 토큰입니다. 카드 단위 토큰(`POST /`)과 다른 값이라 따로 올려야 합니다.

`attributes-type`은 `MatchLiveAttributes` 고정, 로고 파일명은 `<팀코드>.png` 규칙입니다.

iOS 17.2 미만은 push-to-start가 동작하지 않으니 `scanForLiveMatch()`를 폴백으로 유지해야 합니다.

## 활성화 순서

1. `APNS_KEY_ID` / `APNS_TEAM_ID` 시크릿 등록 (아직 미등록)
2. 앱이 push-to-start 토큰을 올리기 시작
3. `APNS_PUSH_TO_START_ENABLED=true`

## 안 넣은 것

- 킬·오브젝트 이벤트(LIVE_EVENT) 연결 — 카드에 표시할 자리가 없습니다
- 밴픽 시점 "곧 시작" 카드 — 상태를 하나 더 만들어야 해서 별건입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)