### PR TITLE
feat: Live Activity push-to-start 프로덕션 ON

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,8 @@ jobs:
             # iOS Live Activity 용 APNs 인증 키(.p8).
             # 키가 아직 없으면 시크릿이 비어 있고, 그러면 설치·마운트를 건너뛴 채
             # APNS_ENABLED=false 로 떠서 기존 배포와 동작이 같다(발송 경로 전체 skip).
+            # APNS_PUSH_TO_START_ENABLED 는 서버가 잠금화면 카드를 새로 만드는 별도 스위치다
+            # (#351 에서 기본 OFF 로 머지). 앱이 push-to-start 토큰을 올리기 시작해 켠다.
             APNS_SECRET_FILE="${FIREBASE_SECRET_DIR}/apns-auth-key.p8"
             APNS_MOUNT_ARGS=""
             APNS_ENV_ARGS=""
@@ -119,7 +121,8 @@ jobs:
                 -e APNS_KEY_PATH=/run/secrets/apns-auth-key.p8 \
                 -e APNS_KEY_ID=${APNS_KEY_ID:-} \
                 -e APNS_TEAM_ID=${APNS_TEAM_ID:-} \
-                -e APNS_BUNDLE_ID=com.nar.wardingapp"
+                -e APNS_BUNDLE_ID=com.nar.wardingapp \
+                -e APNS_PUSH_TO_START_ENABLED=true"
             else
               echo "APNS_KEY_BASE64 not set — Live Activity 푸시 비활성 상태로 배포합니다."
               sudo rm -f "${APNS_SECRET_FILE}"


### PR DESCRIPTION
## 문제

`APNS_PUSH_TO_START_ENABLED` 가 `deploy.yml` 에 없어서 프로덕션에서 켤 방법이 없었다.

`APNS_ENV_ARGS` 가 컨테이너에 넘기는 건 5개뿐이다:
```
APNS_ENABLED / APNS_KEY_PATH / APNS_KEY_ID / APNS_TEAM_ID / APNS_BUNDLE_ID
```

`APNS_PUSH_TO_START_ENABLED` 는 전달되지 않으니 `application-prod.yml:201` 의 기본값 `false` 가 적용되고, `LiveActivityPushService:103` 의 `!pushToStartEnabled` 게이트에서 전부 return 된다.

#351 이 "기본 OFF" 로 머지한 건 의도였지만, 켜는 경로 자체가 빠져 있었다.

## 켜는 근거

#351 이 코드 주석에 걸어 둔 전제는 **"앱이 push-to-start 토큰을 올리기 시작한 뒤에 켠다"** 였고, 충족됐다.

프로덕션 실측 2026-08-07 17:56 KST:

| 테이블 | 행 | 최초 | 최근 갱신 |
|---|---|---|---|
| `live_activity_start_token` (push-to-start) | 4행 / 3명, 전부 active | 08-07 00:42 | 08-07 17:13 |
| `live_activity_token` (갱신용) | 33행 | 08-05 01:56 | 08-07 17:37 |

APNs 본체는 이미 ON이다 — 시크릿 3개(`APNS_KEY_BASE64`/`KEY_ID`/`TEAM_ID`)가 08-04 등록돼 `APNS_ENABLED=true` 로 뜬다. **카드 갱신은 동작 중이었고 생성만 막혀 있던 상태.**

## 변경

`APNS_ENV_ARGS` 에 한 줄:
```
-e APNS_PUSH_TO_START_ENABLED=true \
```

`APNS_KEY_BASE64` 가 있을 때만 세팅되는 블록 안에 넣었다. 키가 없으면 APNs 경로 전체가 skip 되므로 "push-to-start 만 따로 켜지는" 조합은 생기지 않는다.

## 배포 후 영향

서버가 구독자 잠금화면에 카드를 **새로 만들기** 시작한다. 현재 대상은 활성 start 토큰 3명. 되돌리려면 이 줄을 지우거나 `=false` 로 바꿔 재배포하면 된다.

확인 지점: 첫 경기 세트 시작 때 `[live-activity] push-to-start matchId=... 발송 N건` 로그, 그리고 `live_activity_start_token.active` 가 죽은 토큰 정리로 줄어드는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)