### PR TITLE
fix: 경기 종료 반영 지연(최대 16분)과 라이브 카드 "다음 세트 준비 중" 고착

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -89,6 +89,13 @@ public class LivePollingScheduler {
 	 */
 	private final java.util.Set<String> startNotifiedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
+	/**
+	 * 매치 종료(matchEnded) Live Activity 카드를 이미 보낸 matchId.
+	 * 세트 종료 편승 경로와 늦은 스코어 복구 경로가 같은 매치에 두 번 쏘지 않게 한다.
+	 * ponytail: {@link #naverFinalizedMatchIds} 와 같은 이유로 프로세스 생애 동안 누적된다 — 하루 수십 건이라 무해.
+	 */
+	private final java.util.Set<String> matchEndCardPushedMatchIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.max-consecutive-failures:6}")
 	private int maxConsecutiveFailures;
 
@@ -136,6 +143,31 @@ public class LivePollingScheduler {
 					// (2)는 예전에 unstarted 게이트에 걸려 우회로를 못 탔고, 그 사이 세트 하나가
 					// 통째로 추적되지 않았다. 그래서 게이트를 "업스트림이 라이브 게임을 모를 때"로 넓힌다.
 					// completed 는 디스커버리 대상이 아니므로 제외해 불필요한 외부 호출을 막는다.
+					// 네이버 종료 확정으로 이미 completed 를 쓴 매치는 업스트림 flip 이 올 때까지 손대지 않는다.
+					// 프로브도 sync 도 스킵한다 — 업스트림 원본(inProgress/unstarted)으로 sync 하면
+					// DB 의 completed 가 되돌아간다. flip 이 도착하면 state 가 completed 라 이 게이트를 지나
+					// 아래 recentlyCompleted 경로로 최종 스코어가 덮어써진다(self-heal).
+					if (naverFinalizedMatchIds.contains(match.getMatchId())
+							&& !"completed".equalsIgnoreCase(match.getState())) {
+						continue;
+					}
+
+					// 추적 중인 세트가 전부 프레임 finished 로 확정됐는데 업스트림 state 는 아직 inProgress 인 구간.
+					// 업스트림 completed flip 은 실측 4분 50초~16분 늦게 온다(LCK 6경기, 2026-08-05~07 CloudWatch).
+					// 네이버는 종료 후 ~1.5분에 matchStatus=RESULT 를 주므로 그걸로 먼저 확정한다.
+					// 세트 사이면 네이버가 아직 RESULT 가 아니라 false 를 돌려주고 기존 경로가 그대로 돈다.
+					// 프레임 신호를 트리거로 쓰는 이유: probeFeed 는 업스트림이 liveGameIds 를 비웠거나
+					// 프레임이 180초 정지해야 돌아서 그만큼 확정이 늦다.
+					// ponytail: 세트 사이엔 이 호출과 overlayNaverScoreIfAhead 가 같은 day 응답을 각각 받아온다
+					// (10초 주기 2콜). 세트 간격이 짧아 무해 — 콜 수가 문제되면 사이클 단위로 캐시한다.
+					if (!"completed".equalsIgnoreCase(match.getState())
+							&& allTrackedGamesFinished(activeGames, match.getMatchId())
+							&& leagueMatchService.syncCompletedMatchFromNaver(match, league)) {
+						naverFinalizedMatchIds.add(match.getMatchId());
+						scheduleCacheDirty = true;
+						continue;
+					}
+
 					List<String> feedLiveGameIds = List.of();
 					boolean upstreamKnowsLiveGames =
 							match.getLiveGameIds() != null && !match.getLiveGameIds().isEmpty();
@@ -491,6 +523,11 @@ public class LivePollingScheduler {
 		if (!liveActivityPushService.isEnabled()) {
 			return;
 		}
+		// 복구 경로(retryMatchEndCard)가 먼저 매치 종료를 보냈으면 여기서 setEnded 를 뒤에 쏘면 안 된다 —
+		// 매치 종료 발송이 워터마크를 지우므로(notifySetEnd) 뒤늦은 setEnded 가 통과해 카드가 되돌아간다.
+		if (matchEndCardPushedMatchIds.contains(activeGame.matchId())) {
+			return;
+		}
 		try {
 			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
 			Integer blue = match == null ? null : match.getBlueScore();
@@ -503,12 +540,60 @@ public class LivePollingScheduler {
 						? match.getBlueTeamCode()
 						: match.getRedTeamCode();
 			}
+			if (matchEnded) {
+				matchEndCardPushedMatchIds.add(activeGame.matchId());
+			}
 			liveActivityPushService.notifySetEnd(
 					activeGame.matchId(),
 					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
 					blue, red, matchEnded, winner);
 		} catch (Exception e) {
 			log.warn("[live-activity] set-end 실패 matchId={}: {}", activeGame.matchId(), e.getMessage());
+		}
+	}
+
+	/**
+	 * 늦게 도착한 스코어로 매치 종료 카드를 복구한다.
+	 *
+	 * <p>매치 종료 카드는 세트 종료 이벤트에 편승하는데(그 경로가 {@code PHASE_MATCH_ENDED} 유일 진입점),
+	 * 그 시점 DB 스코어가 아직 직전 세트 값이면 setEnded 로 나가 카드가 "다음 세트 준비 중" 으로 고착한다.
+	 * 세트 종료 이벤트는 gameId 단위로 dedup 돼 재발화가 없어서, 스코어가 뒤늦게 맞아도 카드가
+	 * iOS 한도(8시간)까지 잘못된 상태로 잠금화면에 남는다.
+	 * 실측 2026-08-08 DNS vs NS: 카드 21:46:46 발송(스코어 1:0) / 2:0 도착 21:47:03 — 17초 차이로 고착.</p>
+	 *
+	 * <p>그래서 프레임 finished 로 확정된 세트에 대해 폴링 tick 마다 스코어를 다시 보고,
+	 * 다전제 승리 조건에 도달했으면 매치 종료를 한 번 더 보낸다. 카드 진행도 워터마크가
+	 * setEnded(1) → matchEnded(2) 상승만 허용하므로 순서가 뒤집히는 발송은 없다.</p>
+	 */
+	private void retryMatchEndCard(ActiveLiveGame activeGame) {
+		if (!liveActivityPushService.isEnabled()
+				|| activeGame.matchId() == null
+				|| matchEndCardPushedMatchIds.contains(activeGame.matchId())) {
+			return;
+		}
+		try {
+			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
+			if (match == null
+					|| !isMatchEnded(match.getBestOf(), match.getBlueScore(), match.getRedScore())) {
+				return;
+			}
+			// add 로 검사와 등록을 한 번에 한다 — 세트 종료 편승 경로와 동시에 들어올 수 있다.
+			if (!matchEndCardPushedMatchIds.add(activeGame.matchId())) {
+				return;
+			}
+			int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
+			int red = match.getRedScore() == null ? 0 : match.getRedScore();
+			String winner = blue > red ? match.getBlueTeamCode() : match.getRedTeamCode();
+			log.info("[live-activity] 매치 종료 카드 복구 matchId={} set={} score={}:{}",
+					activeGame.matchId(), activeGame.setNumber(), blue, red);
+			// 폴링 스레드에서 APNs 팬아웃을 태우면 다음 프레임 수집이 밀린다.
+			applicationTaskExecutor.execute(() -> liveActivityPushService.notifySetEnd(
+					activeGame.matchId(),
+					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
+					blue, red, true, winner));
+		} catch (Exception e) {
+			log.warn("[live-activity] 매치 종료 카드 복구 실패 matchId={}: {}",
+					activeGame.matchId(), e.getMessage());
 		}
 	}
 
@@ -546,6 +631,27 @@ public class LivePollingScheduler {
 			log.warn("Set-end score check failed matchId={}: {}", activeGame.matchId(), e.getMessage());
 			return false;
 		}
+	}
+
+	/**
+	 * 이 매치의 추적 중 게임이 하나 이상 있고 전부 프레임 finished 로 확정됐는지.
+	 * 하나라도 안 끝났으면(=다음 세트 진행 중) false 라 세트 사이에만 참이 된다.
+	 */
+	private boolean allTrackedGamesFinished(Map<String, ActiveLiveGame> activeGames, String matchId) {
+		if (matchId == null || matchId.isBlank()) {
+			return false;
+		}
+		boolean anyTracked = false;
+		for (ActiveLiveGame activeGame : activeGames.values()) {
+			if (!matchId.equals(activeGame.matchId())) {
+				continue;
+			}
+			anyTracked = true;
+			if (!frameFinishedGameIds.contains(activeGame.gameId())) {
+				return false;
+			}
+		}
+		return anyTracked;
 	}
 
 	/** 이 매치의 추적 중 게임 가운데 프레임이 정지한 것이 있는지. */
@@ -614,6 +720,12 @@ public class LivePollingScheduler {
 								activeGame.gameId(), activeGame.matchId(), activeGame.setNumber());
 						fireSetEndNotification(activeGame);
 					}
+				}
+
+				// 종료된 세트는 stale 제거(기본 3분) 전까지 매 tick 여기를 지난다. 그동안 스코어가
+				// 늦게 도착하면 매치 종료 카드를 복구한다.
+				if (frameFinishedGameIds.contains(activeGame.gameId())) {
+					retryMatchEndCard(activeGame);
 				}
 
 				liveFrameProcessor.process(activeGame, window, details);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -709,6 +709,112 @@ class LivePollingSchedulerTest {
 				anyString(), anyInt(), anyString(), anyString(), anyString(), anyString());
 	}
 
+	@Test
+	void lateScoreRecoversMatchEndCard() {
+		// 세트 종료 시점 DB 스코어가 직전 세트 값이면 카드가 setEnded 로 나가 "다음 세트 준비 중" 으로
+		// 고착한다(2026-08-08 DNS vs NS: 카드 21:46:46 / 스코어 2:0 도착 21:47:03).
+		// 스코어가 뒤늦게 도착하면 매치 종료 카드를 한 번 더 보내 복구해야 한다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		java.util.concurrent.atomic.AtomicInteger blueScore = new java.util.concurrent.atomic.AtomicInteger(1);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(180_000L), matchRepositoryWithMutableScore(blueScore));
+		var activityPush = liveActivityPushService(scheduler);
+		when(activityPush.isEnabled()).thenReturn(true);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();          // 스코어 1:0 — 아직 매치 종료 조건 미달
+		blueScore.set(2);                     // 네이버 sync 로 2:0 도착
+		scheduler.pollActiveGames();
+
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 1, 0, false, null);
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 2, 0, true, "KT");
+	}
+
+	@Test
+	void matchEndCardIsNotSentTwiceWhenScoreWasAlreadyFresh() {
+		// 세트 종료 시점에 이미 스코어가 맞으면 편승 경로가 매치 종료를 보내고,
+		// 복구 경로는 같은 매치에 두 번 쏘지 않아야 한다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		java.util.concurrent.atomic.AtomicInteger blueScore = new java.util.concurrent.atomic.AtomicInteger(2);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(180_000L), matchRepositoryWithMutableScore(blueScore));
+		var activityPush = liveActivityPushService(scheduler);
+		when(activityPush.isEnabled()).thenReturn(true);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();
+		scheduler.pollActiveGames();
+
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 2, 0, true, "KT");
+		verify(activityPush, never()).notifySetEnd(
+				anyString(), anyInt(), anyInt(), anyInt(), eq(false), org.mockito.ArgumentMatchers.any());
+	}
+
+	@Test
+	void allTrackedSetsFinishedFlipsMatchToCompletedFromNaver() {
+		// 업스트림 state 가 inProgress 인 채로 flip 이 실측 4분 50초~16분 늦게 온다.
+		// 추적 세트가 전부 프레임 finished 면 네이버 RESULT 로 먼저 확정해야 한다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		WorldsService worldsService = mock(WorldsService.class);
+		LeagueMatchService leagueMatchService = mock(LeagueMatchService.class);
+		when(leagueMatchService.findLeaguesWithMatchesBetween(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any()))
+				.thenReturn(List.of("LCK"));
+		when(leagueMatchService.syncCompletedMatchFromNaver(
+				org.mockito.ArgumentMatchers.any(), anyString())).thenReturn(true);
+		LivePollingScheduler scheduler = schedulerWith(
+				liveStateStore, mock(TeamLiveEventPushService.class), worldsService, leagueMatchService);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+		// 폴링이 프레임 finished 를 확정해야 디스커버리가 종료 후보로 본다.
+		scheduler.pollActiveGames();
+
+		MatchResultDto inProgress = MatchResultDto.builder()
+				.matchId("match-1").leagueName("LCK").state("inProgress")
+				.matchDate(Instant.now().minusSeconds(3600).toString())
+				.gameIds(List.of("game-1")).liveGameIds(List.of("game-1")).build();
+		when(worldsService.getWorldsMatches(null, "LCK")).thenReturn(MatchResponseWrapper.builder()
+				.matches(List.of(inProgress)).build());
+
+		scheduler.discoverLiveGames();
+		scheduler.discoverLiveGames();
+
+		// 확정은 1회. 이후 사이클은 업스트림 flip 전까지 네이버를 다시 찌르지 않는다.
+		verify(leagueMatchService, times(1)).syncCompletedMatchFromNaver(inProgress, "LCK");
+		// 업스트림 원본 inProgress 로 sync 하면 방금 쓴 completed 가 되돌아간다.
+		verify(leagueMatchService, never()).syncRealtimeMatchStatus(
+				org.mockito.ArgumentMatchers.any(), anyString());
+	}
+
+	/** 스코어가 폴링 사이에 바뀌는 상황(네이버 sync 지연)을 흉내낸다. bestOf 3, 승리 조건 2승. */
+	private com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepositoryWithMutableScore(
+			java.util.concurrent.atomic.AtomicInteger blueScore) {
+		var match = mock(com.toy.nar.app.lolesports.repository.LeagueMatch.class);
+		when(match.getBlueScore()).thenAnswer(invocation -> blueScore.get());
+		when(match.getRedScore()).thenReturn(0);
+		when(match.getBestOf()).thenReturn(3);
+		when(match.getBlueTeamCode()).thenReturn("KT");
+		when(match.getRedTeamCode()).thenReturn("HLE");
+		var repository = mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class);
+		when(repository.findById("match-1")).thenReturn(java.util.Optional.of(match));
+		return repository;
+	}
+
+	private com.toy.nar.app.mobile.push.LiveActivityPushService liveActivityPushService(
+			LivePollingScheduler scheduler) {
+		return (com.toy.nar.app.mobile.push.LiveActivityPushService)
+				ReflectionTestUtils.getField(scheduler, "liveActivityPushService");
+	}
+
 	private com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepositoryWithScore(
 			int blueScore, int redScore) {
 		var match = mock(com.toy.nar.app.lolesports.repository.LeagueMatch.class);


### PR DESCRIPTION
뿌리가 같은 두 증상을 함께 고칩니다. 둘 다 "경기가 끝났는데 그 사실이 DB/카드에 늦게 반영된다"는 하나의 문제입니다.

## 1. 매치 `completed` 반영이 4분 50초 ~ 16분 늦다

CloudWatch `/nar/app` 실측 (LCK 6경기, 2026-08-05~07). `set-end(frame)` 감지 → `state=completed` 기록:

| matchId | 종료 감지 | completed | 지연 |
|---|---|---|---|
| 115548147900684633 | 08-07 20:49:34 | 20:54:24 | 4분 50초 |
| 115548147900553445 | 08-05 22:52:32 | 22:59:19 | 6분 47초 |
| 115548147900553465 | 08-06 20:44:17 | 20:54:31 | 10분 14초 |
| 115548147900684641 | 08-05 19:31:46 | 19:45:48 | 14분 01초 |
| 115548147900684665 | 08-06 18:29:08 | 18:45:10 | 16분 02초 |

전부 업스트림 flip 대기입니다. 이 구간을 메우려고 만든 `syncCompletedMatchFromNaver` 가 `unstarted` 게이트에 막혀 **실전에서 한 번도 실행되지 않았습니다** (로그 `"종료 확정"` 8/5~8/8 전수 0건). 업스트림이 state 를 정상 전이시키는 리그(LCK 등)는 게이트를 통과할 수 없었습니다.

네이버는 종료 후 ~1.5분에 최종 결과를 갖고 있고, 우리는 그걸 **스코어에만** 쓰고 `state` 에는 쓰지 않았습니다.

**수정** — 트리거를 프레임 신호로 바꿉니다. 추적 중인 세트가 전부 `frameFinishedGameIds` 에 있으면 네이버 `matchStatus=RESULT` 로 확정합니다.

- `probeFeed` 를 안 쓰는 이유: 그쪽은 업스트림 `liveGameIds` 가 비거나 프레임이 180초 정지해야 돌아 그만큼 늦습니다
- 확정 후에는 flip 이 올 때까지 그 매치의 프로브·sync 를 건너뜁니다 (업스트림 원본 `inProgress` 로 sync 하면 방금 쓴 `completed` 가 되돌아감)
- flip 이 도착하면 `state=completed` 라 게이트를 지나 `recentlyCompleted` 경로로 최종 스코어가 덮어써집니다 (self-heal)
- 기존 `unstarted` + `sawFinished` 경로는 EWC/KESPA 용으로 유지

## 2. 매치 종료 카드가 "다음 세트 준비 중"으로 고착한다

2026-08-08 DNS vs NS 실측:

```
21:45:32  set-end(frame) set=2
21:46:46  [live-activity] end=false 발송      <- 이때 DB 스코어 1:0
21:47:03  score=2:0 도착
```

카드 발송이 **17초 일렀습니다.** `isMatchEnded(3, 1, 0)` 이 false 라 `setEnded` 로 나가고 위젯이 "SET 3 준비 중입니다"를 그립니다.

`PHASE_MATCH_ENDED` 로 가는 유일한 경로가 세트 종료 이벤트 편승인데 그건 gameId 단위로 dedup 되어 재발화가 없습니다. 그래서 스코어가 뒤늦게 맞아도 카드는 **iOS 한도 8시간까지** 잘못된 상태로 잠금화면에 남습니다.

**수정** — 프레임 finished 로 확정된 세트에 대해 폴링 tick 마다 스코어를 다시 보고, 다전제 승리 조건에 도달했으면 매치 종료를 한 번 더 보냅니다.

- 카드 진행도 워터마크가 `setEnded(1)` → `matchEnded(2)` 상승만 허용하므로 순서가 뒤집히는 발송 없음
- 편승 경로와 복구 경로는 matchId 집합 하나로 상호 배제 — 두 번 쏘거나 매치 종료 뒤에 `setEnded` 가 따라붙지 않음
- 1번이 스코어 도착을 앞당겨 레이스 자체가 줄지만, 네이버 반영이 느린 날을 위한 안전망으로 둡니다

## 테스트

전체 518개 통과 (신규 5개).

- `lateScoreRecoversMatchEndCard` — 1:0 발송 후 2:0 도착 시 매치 종료 복구
- `matchEndCardIsNotSentTwiceWhenScoreWasAlreadyFresh` — 스코어가 이미 맞으면 1회만
- `allTrackedSetsFinishedFlipsMatchToCompletedFromNaver` — `inProgress` 에서 네이버 확정 1회, `syncRealtimeMatchStatus` 미호출
- `완료된_경기를_직전_세트_스코어의_진행중_으로_되돌려도_막는다` — 2:0 completed ← 1:0 inProgress 차단
- `완료된_경기를_같은_스코어의_진행중_으로_되돌려도_막는다` — state 만 되돌아가는 경우도 차단

## 3. 완료 매치가 "종료 → 진행중 → 종료" 로 튀던 구멍

1번을 넣으면서 드러난 것. `isResultRegression` 은 스코어 합 0 만 막는데, 그 조건이 마지막 세트 구간을 못 잡습니다 — 업스트림 `gameWins` 는 마지막 세트에서 25분+ stale 이라 2:0 으로 끝난 경기가 `0:0` 이 아니라 **`inProgress 1:0`** 으로 들어옵니다.

1번 전에는 DB 가 어차피 `inProgress` 라 무해했지만, 네이버 확정을 앞당기면 30분 주기 전체 동기화가 확정 직후~업스트림 flip 사이(최대 16분)에 끼어 화면이 튑니다. 되돌아간 뒤에는 디스커버리가 `naverFinalizedMatchIds` 게이트에 막혀 스스로 복구하지도 못합니다.

**수정** — 결과가 있는 `completed` 를 `completed` 가 아닌 상태로 되돌리는 것은 전부 막습니다. 업스트림도 종료로 보는 갱신(`incoming` 이 completed)은 그대로 통과 — 리메이크·오기 정정이 그 경로로 들어오고, flip 도착 시 최종 스코어로 덮어쓰는 self-heal 도 거기에 의존합니다.

## 검증 관점

- 네이버 오탐 시 진행 중 매치가 `completed` 로 찍힐 여지가 있습니다. 게이트는 "추적 세트 전부 finished + 네이버 RESULT" 이고, 스코어 오버레이는 이미 전 리그가 네이버를 신뢰 중이라 신뢰 수준이 새로 낮아지지는 않습니다. 배포 후 첫날 `"Naver 종료 확정으로 매치 completed 반영"` 로그를 확인할 계획입니다.
- 세트 사이에는 이 확정 시도와 `overlayNaverScoreIfAhead` 가 같은 day 응답을 각각 받아옵니다(10초 주기 2콜). 세트 간격이 짧아 무해하다고 보고 캐시는 넣지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
