### PR TITLE
fix: 완료 매치를 직전 세트 스코어의 inProgress 로 되돌리던 구멍 (#354 후속)

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -246,14 +246,21 @@ public class LeagueMatchService {
 	 * T1 vs HLE 가 18:02 에 네이버로 2:1 completed 확정된 뒤 이 경로로 0:0 unstarted 가 됐다.
 	 * 디스커버리의 재확정은 matchId 당 1회라 되돌려진 뒤에는 스스로 복구되지 않는다.</p>
 	 *
-	 * <p>스코어 합이 0인 경우만 막는다. 리메이크나 오기 정정처럼 실제로 값이 바뀌는 갱신은
-	 * 0 이 아닌 스코어로 들어오므로 그대로 통과한다.</p>
+	 * <p>결과가 있는 completed 를 completed 가 아닌 상태로 되돌리는 것은 전부 막는다.
+	 * 처음에는 스코어 합 0 만 막았는데, 그것으로는 마지막 세트 구간을 못 잡는다 — 업스트림
+	 * gameWins 는 마지막 세트에서 25분+ stale 이라 2:0 으로 끝난 경기가 0:0 이 아니라
+	 * {@code inProgress 1:0} 으로 들어온다. 네이버로 먼저 확정한 completed 가 그 값에 덮여
+	 * "종료 → 진행중 → 종료" 로 튄다.</p>
+	 *
+	 * <p>업스트림도 종료로 보는 갱신({@code incoming} 이 completed)은 그대로 통과시킨다 —
+	 * 리메이크·오기 정정이 이 경로로 들어오고, 업스트림 flip 이 도착했을 때 최종 스코어로
+	 * 덮어쓰는 self-heal 도 여기에 의존한다.</p>
 	 */
 	static boolean isResultRegression(LeagueMatch existing, LeagueMatch incoming) {
 		if (!isCompleted(existing) || scoreSum(existing) <= 0) {
 			return false;
 		}
-		return scoreSum(incoming) == 0;
+		return !isCompleted(incoming);
 	}
 
 	private static int scoreSum(LeagueMatch match) {

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceResultRegressionTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceResultRegressionTest.java
@@ -73,6 +73,22 @@ class LeagueMatchServiceResultRegressionTest {
 		assertThat(incoming.getRedScore()).isEqualTo(1);
 	}
 
+	@Test
+	void 완료된_경기를_직전_세트_스코어의_진행중_으로_되돌려도_막는다() {
+		// 스코어 합 0 만 막던 시절의 구멍. 업스트림 gameWins 는 마지막 세트에서 25분+ stale 이라
+		// 2:0 으로 끝난 경기가 0:0 이 아니라 inProgress 1:0 으로 들어온다. 네이버로 먼저 확정한
+		// completed 가 여기 덮이면 화면이 "종료 -> 진행중 -> 종료" 로 튄다.
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 2, 0), match("inProgress", 1, 0))).isTrue();
+	}
+
+	@Test
+	void 완료된_경기를_같은_스코어의_진행중_으로_되돌려도_막는다() {
+		// 스코어는 따라왔는데 state 만 늦게 오는 구간. state 만 되돌아가도 화면은 진행중이 된다.
+		assertThat(LeagueMatchService.isResultRegression(
+				match("completed", 2, 0), match("inProgress", 2, 0))).isTrue();
+	}
+
 	private LeagueMatch match(String state, Integer blueScore, Integer redScore) {
 		return LeagueMatch.builder()
 				.id("116929376557102172")


### PR DESCRIPTION
#354 를 머지하면서 드러난 구멍. **#354 가 이미 프로덕션에 나가 있어 지금 열려 있는 상태**입니다.

## 문제

`isResultRegression` 은 스코어 합 0 만 막습니다. 그 조건이 마지막 세트 구간을 못 잡습니다.

| | 기존 가드가 잡는 케이스 | 마지막 세트 |
|---|---|---|
| 업스트림이 보내는 값 | `unstarted 0:0` (KESPA/EWC 방치) | `inProgress 1:0` |
| 왜 | state·스코어 둘 다 방치 | `gameWins` 가 마지막 세트에서 25분+ stale — 직전 세트까지만 반영 |
| 가드 | 발동 | **통과** |

2:0 으로 끝난 경기가 `0:0` 이 아니라 `inProgress 1:0` 으로 들어오므로 그냥 통과합니다.

## #354 전에는 무해했는데 지금은 아닌 이유

전에는 DB 가 어차피 `inProgress` 라 30분 주기 전체 동기화가 `inProgress` 를 써도 변화가 없었습니다.

#354 로 네이버 확정이 앞당겨지면서 DB 가 먼저 `completed` 가 됩니다. 그 뒤 30분 동기화가 확정 직후 ~ 업스트림 flip 사이(최대 16분)에 끼면 `completed 2:0` → `inProgress 1:0` 으로 되돌아가 화면이 **"종료 → 진행중 → 종료"** 로 튑니다.

되돌아간 뒤에는 디스커버리가 `naverFinalizedMatchIds` 게이트에 막혀 스스로 복구하지도 못합니다 — 업스트림 flip 이 올 때까지 잘못된 상태로 남습니다.

## 수정

결과가 있는 `completed` 를 `completed` 가 아닌 상태로 되돌리는 것은 전부 막습니다.

```java
return !isCompleted(incoming);   // was: scoreSum(incoming) == 0
```

업스트림도 종료로 보는 갱신(`incoming` 이 completed)은 그대로 통과 — 리메이크·오기 정정이 그 경로로 들어오고, flip 도착 시 최종 스코어로 덮어쓰는 self-heal 도 거기에 의존합니다.

조건이 넓어지기만 해서 기존 회귀 테스트 7개는 그대로 통과합니다.

## 테스트

- `완료된_경기를_직전_세트_스코어의_진행중_으로_되돌려도_막는다` — 2:0 completed ← 1:0 inProgress 차단
- `완료된_경기를_같은_스코어의_진행중_으로_되돌려도_막는다` — 스코어는 따라왔는데 state 만 늦게 오는 경우도 차단

## 트레이드오프

업스트림이 실수로 completed 를 보냈다가 정정하는 경우, 그 매치는 `completed` 에서 못 나옵니다. 되돌림 차단 시 WARN 로그가 남으므로 관측 가능하고, 필요하면 백오피스 재동기화로 고칩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)