### PR TITLE
feat: /api/mobile/matches 에 from 날짜 파라미터 추가

### DIFF
--- a/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
+++ b/src/main/java/com/toy/nar/api/mobile/match/MobileMatchController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+import java.time.LocalDate;
 
 @Tag(name = "Mobile. 경기 리스트", description = "모바일 경기 리스트 무한 스크롤 및 세트(게임) 조회 전용 API")
 @RestController
@@ -30,6 +32,8 @@ public class MobileMatchController {
 			summary = "모바일 경기 리스트 커서 페이지 조회",
 			description = "최신 경기부터 과거 방향으로 커서 기반 페이지네이션 조회합니다. "
 					+ "첫 페이지는 cursor 없이 호출하고, 이후 응답의 nextCursor를 cursor로 전달하면 이어서 조회됩니다. "
+					+ "from을 주면 그 날짜(KST 00:00) 이후 경기를 과거→미래 오름차순으로 내려줍니다 "
+					+ "('오늘 이후' 필터용). 정렬 방향은 from 유무로 결정되며 별도 파라미터는 없습니다. "
 					+ "각 경기에는 세트(games) 식별자 목록이 포함됩니다. "
 					+ "시즌 필터 옵션은 /api/mobile/schedules/filters 응답의 seasons에서 가져옵니다.")
 	@GetMapping
@@ -45,8 +49,10 @@ public class MobileMatchController {
 			@Parameter(description = "이전 응답의 nextCursor. 첫 페이지는 생략")
 			@RequestParam(required = false) String cursor,
 			@Parameter(description = "페이지 크기(1~50)", example = "20")
-			@RequestParam(defaultValue = "20") Integer size) {
-		return ResponseEntity.ok(mobileScheduleService.getMatchPage(league, teamId, seasonYear, split, cursor, size));
+			@RequestParam(defaultValue = "20") Integer size,
+			@Parameter(description = "이 날짜(KST) 00:00 이후 경기만. 지정하면 오름차순(과거→미래)", example = "2026-08-09")
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from) {
+		return ResponseEntity.ok(mobileScheduleService.getMatchPage(league, teamId, seasonYear, split, cursor, size, from));
 	}
 
 	@Operation(

--- a/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
+++ b/src/main/java/com/toy/nar/app/lolesports/repository/LeagueMatchRepository.java
@@ -111,6 +111,31 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 			@Param("cursorId") String cursorId,
 			Pageable pageable);
 
+	/**
+	 * 오름차순(과거→미래) 커서 페이지. {@code from} 이 지정된 호출에서만 쓴다.
+	 * JPQL 이 ORDER BY 방향을 파라미터로 못 받아 DESC 쿼리와 분리했다.
+	 */
+	@Query("""
+			SELECT m
+			FROM LeagueMatch m
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
+			  AND (:seasonYear IS NULL OR m.seasonYear = :seasonYear)
+			  AND (:seasonSplit IS NULL OR m.seasonSplit = :seasonSplit)
+			  AND m.matchDate >= :from
+			  AND (:cursorId IS NULL
+					OR m.matchDate > :cursorDate
+					OR (m.matchDate = :cursorDate AND m.id > :cursorId))
+			ORDER BY m.matchDate ASC, m.id ASC
+			""")
+	List<LeagueMatch> findMobileMatchPageAsc(
+			@Param("leagueName") String leagueName,
+			@Param("seasonYear") Integer seasonYear,
+			@Param("seasonSplit") String seasonSplit,
+			@Param("from") LocalDateTime from,
+			@Param("cursorDate") LocalDateTime cursorDate,
+			@Param("cursorId") String cursorId,
+			Pageable pageable);
+
 	@Query("""
 			SELECT m
 			FROM LeagueMatch m
@@ -134,6 +159,36 @@ public interface LeagueMatchRepository extends JpaRepository<LeagueMatch, String
 			@Param("teamCode") String teamCode,
 			@Param("seasonYear") Integer seasonYear,
 			@Param("seasonSplit") String seasonSplit,
+			@Param("cursorDate") LocalDateTime cursorDate,
+			@Param("cursorId") String cursorId,
+			Pageable pageable);
+
+	/** {@link #findMobileMatchPageAsc} 의 팀 필터 버전. */
+	@Query("""
+			SELECT m
+			FROM LeagueMatch m
+			WHERE (:leagueName IS NULL OR m.leagueName = :leagueName)
+			  AND (:seasonYear IS NULL OR m.seasonYear = :seasonYear)
+			  AND (:seasonSplit IS NULL OR m.seasonSplit = :seasonSplit)
+			  AND (
+					LOWER(m.blueTeamName) = LOWER(:teamName)
+					OR LOWER(m.redTeamName) = LOWER(:teamName)
+					OR (:teamCode IS NOT NULL AND m.blueTeamCode IS NOT NULL AND LOWER(m.blueTeamCode) = LOWER(:teamCode))
+					OR (:teamCode IS NOT NULL AND m.redTeamCode IS NOT NULL AND LOWER(m.redTeamCode) = LOWER(:teamCode))
+			  )
+			  AND m.matchDate >= :from
+			  AND (:cursorId IS NULL
+					OR m.matchDate > :cursorDate
+					OR (m.matchDate = :cursorDate AND m.id > :cursorId))
+			ORDER BY m.matchDate ASC, m.id ASC
+			""")
+	List<LeagueMatch> findMobileTeamMatchPageAsc(
+			@Param("leagueName") String leagueName,
+			@Param("teamName") String teamName,
+			@Param("teamCode") String teamCode,
+			@Param("seasonYear") Integer seasonYear,
+			@Param("seasonSplit") String seasonSplit,
+			@Param("from") LocalDateTime from,
 			@Param("cursorDate") LocalDateTime cursorDate,
 			@Param("cursorId") String cursorId,
 			Pageable pageable);

--- a/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
+++ b/src/main/java/com/toy/nar/app/mobile/schedule/MobileScheduleService.java
@@ -143,13 +143,24 @@ public class MobileScheduleService {
 		return new MobileScheduleListResponse(date.toString(), echoLeague(normalizedLeagues), echoTeamId(teamId), matches);
 	}
 
+	/**
+	 * 경기 리스트 커서 페이지.
+	 *
+	 * <p>{@code from} 이 있으면 그 날짜(KST 00:00) 이후 경기를 오름차순(과거→미래)으로,
+	 * 없으면 기존대로 최신→과거 내림차순으로 내린다. 정렬 방향을 따로 받지 않는 건 의도된 선택이다 —
+	 * "이 날짜부터 앞으로"라는 의미에 정렬이 딸려온다.</p>
+	 *
+	 * <p>커서 값은 (matchDate, id) 그대로라 방향과 무관하다. 단, DESC 페이지의 커서를 from 과 함께
+	 * 되던지면 그 지점부터 미래로 읽는다 — 방향을 섞은 호출은 앱이 하지 않는다.</p>
+	 */
 	public MobileMatchPageResponse getMatchPage(
 			String league,
 			Long teamId,
 			Integer seasonYear,
 			String seasonSplit,
 			String cursor,
-			Integer size) {
+			Integer size,
+			LocalDate from) {
 		String normalizedLeague = normalizeLeague(league);
 		String leagueParam = leagueParam(normalizedLeague);
 		TeamFilter teamFilter = resolveTeamFilter(teamId);
@@ -159,24 +170,27 @@ public class MobileScheduleService {
 				: Math.max(1, Math.min(size, MAX_PAGE_SIZE));
 		MatchCursor matchCursor = decodeCursor(cursor);
 		PageRequest fetchLimit = PageRequest.of(0, pageSize + 1);
+		LocalDateTime cursorDate = matchCursor != null ? matchCursor.matchDate() : null;
+		String cursorId = matchCursor != null ? matchCursor.matchId() : null;
+		// matchDate 는 UTC 저장이라 KST 기준 그날 00:00 을 UTC 로 옮겨 비교한다.
+		LocalDateTime fromUtc = from == null ? null : toUtc(from.atStartOfDay());
 
-		List<LeagueMatch> fetched = teamFilter == null
-				? leagueMatchRepository.findMobileMatchPage(
-						leagueParam,
-						seasonYear,
-						normalizedSplit,
-						matchCursor != null ? matchCursor.matchDate() : null,
-						matchCursor != null ? matchCursor.matchId() : null,
-						fetchLimit)
-				: leagueMatchRepository.findMobileTeamMatchPage(
-						leagueParam,
-						teamFilter.name(),
-						teamFilter.code(),
-						seasonYear,
-						normalizedSplit,
-						matchCursor != null ? matchCursor.matchDate() : null,
-						matchCursor != null ? matchCursor.matchId() : null,
-						fetchLimit);
+		List<LeagueMatch> fetched;
+		if (fromUtc == null) {
+			fetched = teamFilter == null
+					? leagueMatchRepository.findMobileMatchPage(
+							leagueParam, seasonYear, normalizedSplit, cursorDate, cursorId, fetchLimit)
+					: leagueMatchRepository.findMobileTeamMatchPage(
+							leagueParam, teamFilter.name(), teamFilter.code(), seasonYear, normalizedSplit,
+							cursorDate, cursorId, fetchLimit);
+		} else {
+			fetched = teamFilter == null
+					? leagueMatchRepository.findMobileMatchPageAsc(
+							leagueParam, seasonYear, normalizedSplit, fromUtc, cursorDate, cursorId, fetchLimit)
+					: leagueMatchRepository.findMobileTeamMatchPageAsc(
+							leagueParam, teamFilter.name(), teamFilter.code(), seasonYear, normalizedSplit,
+							fromUtc, cursorDate, cursorId, fetchLimit);
+		}
 
 		List<LeagueMatch> page = fetched.size() > pageSize ? fetched.subList(0, pageSize) : fetched;
 		Map<String, List<MobileScheduleListResponse.MobileGameSummary>> gamesByMatchId = loadGames(page);

--- a/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
+++ b/src/test/java/com/toy/nar/api/mobile/match/MobileMatchControllerTest.java
@@ -11,9 +11,11 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -62,7 +64,7 @@ class MobileMatchControllerTest {
 
 	@Test
 	void getMatchesReturnsCursorPageShape() throws Exception {
-		when(mobileScheduleService.getMatchPage("LCK", null, null, null, null, 20))
+		when(mobileScheduleService.getMatchPage("LCK", null, null, null, null, 20, null))
 				.thenReturn(new MobileMatchPageResponse(
 						"LCK",
 						null,
@@ -92,6 +94,18 @@ class MobileMatchControllerTest {
 				.andExpect(jsonPath("$.matches[0].games[0].recordGameId").value(100L))
 				.andExpect(jsonPath("$.nextCursor").value("cursor-token"))
 				.andExpect(jsonPath("$.hasNext").value(true));
+	}
+
+	@Test
+	void getMatchesBindsFromAsLocalDate() throws Exception {
+		when(mobileScheduleService.getMatchPage("ALL", null, null, null, null, 20, LocalDate.of(2026, 8, 9)))
+				.thenReturn(new MobileMatchPageResponse("ALL", null, List.of(), null, false));
+
+		mockMvc.perform(get("/api/mobile/matches").param("league", "ALL").param("from", "2026-08-09"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.league").value("ALL"));
+
+		verify(mobileScheduleService).getMatchPage("ALL", null, null, null, null, 20, LocalDate.of(2026, 8, 9));
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/app/lolesports/repository/LeagueMatchMobileFilterMySqlIntegrationTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/repository/LeagueMatchMobileFilterMySqlIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
@@ -85,6 +86,32 @@ class LeagueMatchMobileFilterMySqlIntegrationTest {
 
 		assertThat(result).extracting(LeagueMatch::getId)
 				.containsExactly("m-lck");
+	}
+
+	/** from 오름차순 페이지: from 이전 경기는 빠지고 과거→미래 순으로 나온다. */
+	@Test
+	void ascPageFiltersFromAndOrdersAscending() {
+		List<LeagueMatch> result = repository.findMobileMatchPageAsc(
+				null, null, null, LocalDateTime.of(2026, 7, 11, 0, 0), null, null, PageRequest.of(0, 10));
+
+		assertThat(result).extracting(LeagueMatch::getId).containsExactly("m-lec", "m-kespa");
+	}
+
+	/** 오름차순 커서: 부등호가 뒤집혀 커서 이후(미래) 경기만 이어진다. */
+	@Test
+	void ascPageCursorContinuesForward() {
+		List<LeagueMatch> result = repository.findMobileMatchPageAsc(
+				null, null, null, START, LocalDateTime.of(2026, 7, 11, 9, 0), "m-lec", PageRequest.of(0, 10));
+
+		assertThat(result).extracting(LeagueMatch::getId).containsExactly("m-kespa");
+	}
+
+	@Test
+	void ascTeamPageFiltersFromAndTeam() {
+		List<LeagueMatch> result = repository.findMobileTeamMatchPageAsc(
+				null, "T1", "T1", null, null, START, null, null, PageRequest.of(0, 10));
+
+		assertThat(result).extracting(LeagueMatch::getId).containsExactly("m-lck", "m-kespa");
 	}
 
 	private LeagueMatch match(String id, String league, LocalDateTime date, String blue, String red) {

--- a/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/schedule/MobileScheduleServiceTest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -196,7 +197,7 @@ class MobileScheduleServiceTest {
 		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, null, null, PageRequest.of(0, 3)))
 				.thenReturn(List.of(first, second, overflow));
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, null, 2);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, null, 2, null);
 
 		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
 				.containsExactly("match-2", "match-1");
@@ -212,7 +213,7 @@ class MobileScheduleServiceTest {
 		when(leagueMatchRepository.findMobileMatchPage("LCK", null, null, null, null, PageRequest.of(0, 21)))
 				.thenReturn(List.of(match("match-1", "LCK", LocalDateTime.of(2026, 4, 1, 9, 0), "T1", "GEN", "completed")));
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, null, null);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, null, null, null);
 
 		assertThat(response.matches()).hasSize(1);
 		assertThat(response.hasNext()).isFalse();
@@ -232,7 +233,7 @@ class MobileScheduleServiceTest {
 				PageRequest.of(0, 21)))
 				.thenReturn(List.of());
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, cursor, null);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", null, null, null, cursor, null, null);
 
 		assertThat(response.matches()).isEmpty();
 		assertThat(response.hasNext()).isFalse();
@@ -252,7 +253,7 @@ class MobileScheduleServiceTest {
 		when(leagueMatchRepository.findMobileTeamMatchPage("LCK", "T1", "T1", null, null, null, null, PageRequest.of(0, 21)))
 				.thenReturn(List.of());
 
-		MobileMatchPageResponse response = service.getMatchPage("LCK", 1L, null, null, null, null);
+		MobileMatchPageResponse response = service.getMatchPage("LCK", 1L, null, null, null, null, null);
 
 		assertThat(response.teamId()).isEqualTo(1L);
 		verify(leagueMatchRepository).findMobileTeamMatchPage("LCK", "T1", "T1", null, null, null, null, PageRequest.of(0, 21));
@@ -263,9 +264,71 @@ class MobileScheduleServiceTest {
 		when(leagueMatchRepository.findMobileMatchPage("LCK", 2026, "Spring", null, null, PageRequest.of(0, 21)))
 				.thenReturn(List.of());
 
-		service.getMatchPage("LCK", null, 2026, "Spring", null, null);
+		service.getMatchPage("LCK", null, 2026, "Spring", null, null, null);
 
 		verify(leagueMatchRepository).findMobileMatchPage("LCK", 2026, "Spring", null, null, PageRequest.of(0, 21));
+	}
+
+	/** from 이 있으면 오름차순 쿼리로 가고, KST 00:00 이 UTC 로 변환돼 넘어간다. */
+	@Test
+	void getMatchPageWithFromUsesAscendingQueryAndKstMidnightInUtc() {
+		LeagueMatch first = match("match-1", "LCK", LocalDateTime.of(2026, 8, 9, 9, 0), "T1", "GEN", "unstarted");
+		LeagueMatch second = match("match-2", "LCK", LocalDateTime.of(2026, 8, 10, 9, 0), "DK", "HLE", "unstarted");
+		LeagueMatch overflow = match("match-3", "LCK", LocalDateTime.of(2026, 8, 11, 9, 0), "KT", "NS", "unstarted");
+		LocalDateTime fromUtc = LocalDateTime.of(2026, 8, 8, 15, 0); // KST 2026-08-09 00:00
+		when(leagueMatchRepository.findMobileMatchPageAsc("LCK", null, null, fromUtc, null, null, PageRequest.of(0, 3)))
+				.thenReturn(List.of(first, second, overflow));
+
+		MobileMatchPageResponse response = service.getMatchPage(
+				"LCK", null, null, null, null, 2, LocalDate.of(2026, 8, 9));
+
+		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
+				.containsExactly("match-1", "match-2");
+		assertThat(response.hasNext()).isTrue();
+		assertThat(new String(
+				java.util.Base64.getUrlDecoder().decode(response.nextCursor()),
+				java.nio.charset.StandardCharsets.UTF_8))
+				.isEqualTo("2026-08-10T09:00:00|match-2");
+		verify(leagueMatchRepository, never()).findMobileMatchPage(
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+	}
+
+	/** 오름차순 다음 페이지: 커서는 방향과 무관한 (matchDate, id) 그대로 되돌아온다. */
+	@Test
+	void getMatchPageWithFromAndCursorContinuesAscending() {
+		String cursor = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(
+				"2026-08-10T09:00:00|match-2".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		LocalDateTime fromUtc = LocalDateTime.of(2026, 8, 8, 15, 0);
+		when(leagueMatchRepository.findMobileMatchPageAsc(
+				"LCK", null, null, fromUtc, LocalDateTime.of(2026, 8, 10, 9, 0), "match-2", PageRequest.of(0, 21)))
+				.thenReturn(List.of(match("match-3", "LCK", LocalDateTime.of(2026, 8, 11, 9, 0), "KT", "NS", "unstarted")));
+
+		MobileMatchPageResponse response = service.getMatchPage(
+				"LCK", null, null, null, cursor, null, LocalDate.of(2026, 8, 9));
+
+		assertThat(response.matches()).extracting(MobileScheduleListResponse.MobileMatchSummary::matchId)
+				.containsExactly("match-3");
+		assertThat(response.hasNext()).isFalse();
+		verify(leagueMatchRepository).findMobileMatchPageAsc(
+				"LCK", null, null, fromUtc, LocalDateTime.of(2026, 8, 10, 9, 0), "match-2", PageRequest.of(0, 21));
+	}
+
+	@Test
+	void getMatchPageWithFromAndTeamIdUsesAscendingTeamQuery() {
+		when(teamRepository.findById(1L)).thenReturn(Optional.of(team(1L, "T1", "T1", "https://example.com/t1.png")));
+		LocalDateTime fromUtc = LocalDateTime.of(2026, 8, 8, 15, 0);
+		when(leagueMatchRepository.findMobileTeamMatchPageAsc(
+				"LCK", "T1", "T1", null, null, fromUtc, null, null, PageRequest.of(0, 21)))
+				.thenReturn(List.of());
+
+		MobileMatchPageResponse response = service.getMatchPage(
+				"LCK", 1L, null, null, null, null, LocalDate.of(2026, 8, 9));
+
+		assertThat(response.teamId()).isEqualTo(1L);
+		verify(leagueMatchRepository).findMobileTeamMatchPageAsc(
+				"LCK", "T1", "T1", null, null, fromUtc, null, null, PageRequest.of(0, 21));
 	}
 
 	@Test
@@ -288,7 +351,7 @@ class MobileScheduleServiceTest {
 
 	@Test
 	void getMatchPageWithInvalidCursorThrowsInvalidInput() {
-		assertThatThrownBy(() -> service.getMatchPage("LCK", null, null, null, "not-a-cursor", null))
+		assertThatThrownBy(() -> service.getMatchPage("LCK", null, null, null, "not-a-cursor", null, null))
 				.isInstanceOf(CustomException.class)
 				.extracting("errorCode")
 				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);


### PR DESCRIPTION
## 왜

모바일 앱의 경기 목록 "오늘 이후" 필터가 클라이언트 처리다. 응답이 `matchDate DESC` 고정이라 첫 페이지엔 시즌 끝(9월) 경기만 담기고, 오늘에 닿으려면 앱이 거꾸로 페이징하며 **순차 요청을 9번** 날린다 (2026-08 기준 ALL 리그). 시즌 초에는 더 늘어난다.

`from` 하나로 요청 1번에 끝난다.

## 무엇

```
GET /api/mobile/matches?league=ALL&size=20&from=2026-08-09
→ 2026-08-09(KST) 00:00 이후 경기를 오름차순(과거→미래)으로 커서 페이징
```

- `from` 있으면 오름차순, 없으면 기존 그대로 내림차순
- 별도 `order` 파라미터 없음 — from×order 조합 폭발을 피하려는 의도적 선택. "이 날짜부터 앞으로"라는 의미에 정렬이 딸려온다
- **하위 호환**: `from` 없는 호출은 기존 DESC 경로를 그대로 탄다. 쿼리·응답 모두 무변경

## 어떻게

| 파일 | 변경 |
|---|---|
| `MobileMatchController` | `@RequestParam(required=false) LocalDate from` + Swagger 설명 |
| `MobileScheduleService` | `getMatchPage` 에 `from` 추가, null 여부로 ASC/DESC 분기 |
| `LeagueMatchRepository` | `findMobileMatchPageAsc` / `findMobileTeamMatchPageAsc` 추가 |

**JPQL 은 ORDER BY 방향을 파라미터로 못 받는다** → ASC 쿼리를 따로 뒀다. 커서 비교 부등호가 뒤집힌다:

```
AND m.matchDate >= :from
AND (:cursorId IS NULL
      OR m.matchDate > :cursorDate
      OR (m.matchDate = :cursorDate AND m.id > :cursorId))
ORDER BY m.matchDate ASC, m.id ASC
```

**타임존**: `matchDate` 는 UTC 저장이라 `from` 을 KST 00:00 → UTC 로 옮겨 비교한다 (`getDailySchedules` 와 동일한 `toUtc`).

**커서**: encode/decode 는 `(matchDate, id)` 그대로라 방향과 무관 — 손대지 않았다. 확인 결과 DESC 커서를 `from` 과 함께 되던지면 그 지점부터 미래로 읽지만, 앱이 방향을 섞어 호출하지 않으므로 커서에 방향을 심지 않았다 (서비스 javadoc 에 명시).

## 검증

```
./gradlew test                                   # 전체 그린
./gradlew test -Ddataintegrity.local.enabled=true \
  --tests "...LeagueMatchMobileFilterMySqlIntegrationTest"   # 실 MySQL 8 + Hibernate 6.6
```

- **회귀**: `from` 없는 기존 호출 6건 전부 기존 DESC 리포지토리 메서드로 그대로 감 (`never()` 로 DESC 미호출까지 확인)
- **ASC + 커서**: 오름차순 정렬, 다음 페이지가 커서로 이어짐, `nextCursor` 인코딩
- **팀 필터 조합**: `teamId` + `from` → ASC 팀 쿼리
- **JPQL 유효성**: 새 ASC 쿼리 2개를 실 MySQL 통합 테스트로 파싱·실행까지 검증 (단위 테스트는 mock 이라 JPQL 을 못 잡는다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)