### PR TITLE
feat: 끝난 경기의 살아있는 Live Activity 카드를 닫는 스윕

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeper.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeper.java
@@ -1,0 +1,75 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * 끝난 경기의 살아있는 Live Activity 카드를 주기적으로 닫는다.
+ *
+ * <p>카드 종료는 라이브 폴링 이벤트에 편승한다 — 세트 종료를 관측한 순간의 DB 스코어로
+ * 매치 종료를 판정해 end 를 쏜다. 그래서 이벤트 기반의 빈틈이 그대로 카드 고착이 된다:
+ * 스코어가 stale 제거(3분) 후에 도착하거나, discovery stale 폴백 경로라 복구 루프가 없거나,
+ * bestOf 미상이라 종료 판정이 영영 false 거나, 재기동으로 in-memory 상태가 날아가거나.
+ * 어느 경우든 카드는 iOS 한도(8시간)까지 "다음 세트 준비 중"으로 잠금화면에 남는다.</p>
+ *
+ * <p>이 스윕은 발송 경로가 아니라 DB 상태를 본다 — 살아있는 카드의 매치가 completed 면
+ * 매치 종료를 보낸다. 위 빈틈 전부와, 앞으로 생길 발송 경로의 빈틈까지 한 번에 덮는다.
+ * 서버가 아는 카드(update 토큰이 등록된 카드)만 닫을 수 있다는 한계는 그대로다 —
+ * 토큰 없는 카드는 앱의 endAll 정리 경로만 남는다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LiveActivityOrphanCardSweeper {
+
+	private final LiveActivityTokenRepository tokenRepository;
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final LiveActivityPushService liveActivityPushService;
+
+	@Qualifier("applicationTaskExecutor")
+	private final Executor applicationTaskExecutor;
+
+	@Scheduled(fixedDelayString = "${apns.orphan-sweep-interval-ms:300000}")
+	public void sweep() {
+		if (!liveActivityPushService.isEnabled()) {
+			return;
+		}
+		List<String> matchIds;
+		try {
+			matchIds = tokenRepository.findDistinctActiveMatchIds();
+		} catch (Exception e) {
+			log.warn("[live-activity] 스윕 대상 조회 실패: {}", e.getMessage());
+			return;
+		}
+		if (matchIds.isEmpty()) {
+			return;
+		}
+		for (LeagueMatch match : leagueMatchRepository.findAllById(matchIds)) {
+			if (!"completed".equalsIgnoreCase(match.getState())) {
+				continue;
+			}
+			int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
+			int red = match.getRedScore() == null ? 0 : match.getRedScore();
+			// 세트 번호는 진행도 워터마크(progressKey) 비교에만 쓰인다. 스코어 합이 곧 치른 세트
+			// 수이고, 완료 매치의 스코어는 이미 확정이라 폴링이 봤을 어떤 세트보다 뒤거나 같다.
+			int setNumber = Math.max(1, blue + red);
+			String winner = blue == red ? null
+					: blue > red ? match.getBlueTeamCode() : match.getRedTeamCode();
+			log.info("[live-activity] 스윕 — 끝난 매치의 카드 정리 matchId={} score={}:{}",
+					match.getId(), blue, red);
+			// APNs 팬아웃을 스케줄러 스레드에서 돌리면 다른 잡의 슬롯을 막는다
+			// (5슬롯 공유 — 2026-07-29 폴링 스레드가 발송 락 대기 50초에 걸린 실사고 참고).
+			applicationTaskExecutor.execute(() -> liveActivityPushService.notifySetEnd(
+					match.getId(), setNumber, blue, red, true, winner));
+		}
+	}
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
@@ -17,6 +17,10 @@ public interface LiveActivityTokenRepository extends JpaRepository<LiveActivityT
 	@Query("select t.pushToken from LiveActivityToken t where t.matchId = :matchId and t.active = true")
 	List<String> findActivePushTokensByMatchId(@Param("matchId") String matchId);
 
+	/** 살아있는 카드가 있는 매치 목록. 스윕이 "끝난 매치의 카드"를 찾는 출발점이다. */
+	@Query("select distinct t.matchId from LiveActivityToken t where t.active = true")
+	List<String> findDistinctActiveMatchIds();
+
 	/**
 	 * APNs 가 410(Unregistered) 등으로 거절한 토큰은 더 쓰지 않는다.
 	 *

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeperTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeperTest.java
@@ -1,0 +1,95 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class LiveActivityOrphanCardSweeperTest {
+
+	private LiveActivityTokenRepository tokenRepository;
+	private LeagueMatchRepository leagueMatchRepository;
+	private LiveActivityPushService pushService;
+	private LiveActivityOrphanCardSweeper sweeper;
+
+	@BeforeEach
+	void setUp() {
+		tokenRepository = mock(LiveActivityTokenRepository.class);
+		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		pushService = mock(LiveActivityPushService.class);
+		// 테스트에서는 즉시 실행 — 프로덕션은 applicationTaskExecutor 로 비동기.
+		sweeper = new LiveActivityOrphanCardSweeper(
+				tokenRepository, leagueMatchRepository, pushService, Runnable::run);
+		when(pushService.isEnabled()).thenReturn(true);
+	}
+
+	@Test
+	void 끝난_매치의_살아있는_카드에_매치_종료를_보낸다() {
+		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
+		when(leagueMatchRepository.findAllById(List.of("match-1")))
+				.thenReturn(List.of(match("match-1", "completed", 2, 0)));
+
+		sweeper.sweep();
+
+		// 세트 번호 = 스코어 합, 승자 = 스코어 우세 팀 코드.
+		verify(pushService).notifySetEnd("match-1", 2, 2, 0, true, "BLU");
+	}
+
+	@Test
+	void 진행_중인_매치는_건드리지_않는다() {
+		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
+		when(leagueMatchRepository.findAllById(List.of("match-1")))
+				.thenReturn(List.of(match("match-1", "inProgress", 1, 0)));
+
+		sweeper.sweep();
+
+		verify(pushService, never()).notifySetEnd(
+				org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.anyInt(),
+				org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.anyBoolean(),
+				org.mockito.ArgumentMatchers.any());
+	}
+
+	@Test
+	void 스코어_미상이면_승자_없이_세트1로_닫는다() {
+		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
+		when(leagueMatchRepository.findAllById(List.of("match-1")))
+				.thenReturn(List.of(match("match-1", "completed", null, null)));
+
+		sweeper.sweep();
+
+		verify(pushService).notifySetEnd("match-1", 1, 0, 0, true, null);
+	}
+
+	@Test
+	void APNs_비활성이면_조회조차_하지_않는다() {
+		when(pushService.isEnabled()).thenReturn(false);
+
+		sweeper.sweep();
+
+		verifyNoInteractions(tokenRepository, leagueMatchRepository);
+	}
+
+	private static LeagueMatch match(String id, String state, Integer blue, Integer red) {
+		return LeagueMatch.builder()
+				.id(id)
+				.leagueName("LCK")
+				.state(state)
+				.blueTeamCode("BLU")
+				.blueScore(blue)
+				.redTeamCode("RED")
+				.redScore(red)
+				.build();
+	}
+}


### PR DESCRIPTION
## 문제

카드 종료가 라이브 폴링 이벤트에 편승해, 이벤트를 놓치면 복구가 없다. 실제 빈틈 4개:

1. discovery stale 폴백으로 setEnd 를 쏘는 경로는 `retryMatchEndCard` 진입 조건(`frameFinishedGameIds`)에 안 걸리고 발송 직후 게임이 제거됨
2. 복구 창이 stale 제거까지 3분 — 네이버 RESULT 없는 리그(EWC·KESPA)는 업스트림 flip 이 최대 16분
3. `bestOf == null` 이면 `isMatchEnded` 영구 false
4. 재기동 시 `frameFinishedGameIds`·`matchEndCardPushedMatchIds`·워터마크 전부 in-memory 소실

어느 경우든 카드가 iOS 한도(8시간)까지 "다음 세트 준비 중"으로 잠금화면 고착. (bo3 2:0 종료 후 대기 고착 증상)

## 해결

5분 주기 스윕: 살아있는 카드(`live_activity_token.active=true`)의 매치가 `state=completed` 면 매치 종료 발송 + 토큰 정리(기존 `fanOut` end 경로 재사용). 발송 경로가 아니라 DB 상태 기반이라 위 4개와 미래의 빈틈까지 덮는다.

- 세트 번호 = 스코어 합. 완료 스코어는 확정이라 진행도 워터마크(`progressKey`)를 항상 통과
- 팬아웃은 `applicationTaskExecutor` 로 — 스케줄러 5슬롯 점유 방지 (2026-07-29 락 대기 50초 실사고 패턴 회피)
- 조회는 `(match_id, active)` 커버링 인덱스 스캔, 평상시 0행. 추가 인덱스 불필요

## 한계

update 토큰이 등록된 카드만 닫을 수 있다. 서버가 push-to-start 로 만들고 앱이 한 번도 안 열린 카드는 토큰이 없어 서버가 존재를 모른다 — 그 등록 경로는 모바일 NAR-GG/warding-mobile-repo#169 가 메웠고, 최후 정리는 앱 `endAll` 경로.

## 테스트

`LiveActivityOrphanCardSweeperTest` 4건: completed 발송·inProgress 무시·스코어 미상 처리·비활성 게이트. `app.mobile.push` 패키지 전체 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)