### PR TITLE
fix: push-to-start 페이로드에 alert 추가 — 없으면 iOS 가 start 를 버린다

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/ApnsLiveActivityClient.java
@@ -126,18 +126,28 @@ public class ApnsLiveActivityClient {
 	 *
 	 * <p>토큰도 다르다 — 여기 넘기는 것은 액티비티 토큰이 아니라 앱 단위
 	 * push-to-start 토큰이다.</p>
+	 *
+	 * <p>{@code alert} 는 장식이 아니라 필수다. 없으면 iOS 가 start 이벤트를 그대로 버린다 —
+	 * 실측 2026-08-09 KT vs DK: APNs 200, 기기 도착, 예산 통과까지 다 되고 liveactivitiesd 가
+	 * "Received start without an alert configuration" ERROR 로 카드 생성을 중단했다.</p>
 	 */
 	public CompletableFuture<Boolean> sendStartAsync(
 			String pushToStartToken,
 			String attributesType,
 			Map<String, Object> attributes,
-			Map<String, Object> contentState) {
+			Map<String, Object> contentState,
+			String alertTitle,
+			String alertBody) {
+		Map<String, Object> alert = new LinkedHashMap<>();
+		alert.put("title", alertTitle);
+		alert.put("body", alertBody);
 		Map<String, Object> aps = new LinkedHashMap<>();
 		aps.put("timestamp", Instant.now().getEpochSecond());
 		aps.put("event", "start");
 		aps.put("attributes-type", attributesType);
 		aps.put("attributes", attributes);
 		aps.put("content-state", contentState);
+		aps.put("alert", alert);
 		return sendAsync(pushToStartToken, Map.of("aps", aps));
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -115,6 +115,10 @@ public class LiveActivityPushService {
 		}
 
 		Map<String, Object> state = contentState(PHASE_PLAYING, setNumber, blueScore, redScore, "", null);
+		// alert 는 iOS 가 start 를 받아들이는 필수 조건이다(ApnsLiveActivityClient.sendStartAsync 참고).
+		// 문구는 SET_START FCM 배너와 겹치므로 최소한으로 — 시스템이 상황 따라 워치 등에만 쓴다.
+		String alertTitle = attributes.teamAName() + " vs " + attributes.teamBName();
+		String alertBody = setNumber + "세트 시작";
 		Map<String, CompletableFuture<Boolean>> inFlight = new LinkedHashMap<>();
 		for (LiveActivityStartTokenRepository.StartTargetRow target : targets) {
 			// 응원 팀 하트는 회원마다 달라 payload 를 회원별로 만든다.
@@ -122,7 +126,9 @@ public class LiveActivityPushService {
 					target.getPushToken(),
 					ATTRIBUTES_TYPE,
 					attributes.toPayload(target.getFavoriteTeamCode()),
-					state));
+					state,
+					alertTitle,
+					alertBody));
 		}
 
 		List<String> deadTokens = new ArrayList<>();

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -265,7 +265,9 @@ class LiveActivityPushServiceTest {
 		ArgumentCaptor<Map<String, Object>> attrs = mapCaptor();
 		ArgumentCaptor<Map<String, Object>> state = mapCaptor();
 		verify(apnsClient).sendStartAsync(eq("start-tok"), eq("MatchLiveAttributes"),
-				attrs.capture(), state.capture());
+				attrs.capture(), state.capture(),
+				// alert 없이 보내면 iOS 가 start 를 버린다 — 문구까지 계약이다.
+				eq("T1 vs Hanwha Life Esports"), eq("1세트 시작"));
 		assertThat(attrs.getValue())
 				.containsEntry("matchId", "match-1")
 				.containsEntry("teamACode", "T1")
@@ -287,7 +289,8 @@ class LiveActivityPushServiceTest {
 		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
 
 		ArgumentCaptor<Map<String, Object>> attrs = mapCaptor();
-		verify(apnsClient).sendStartAsync(anyString(), anyString(), attrs.capture(), any());
+		verify(apnsClient).sendStartAsync(anyString(), anyString(), attrs.capture(), any(),
+				anyString(), anyString());
 		assertThat(attrs.getValue()).doesNotContainKey("favoriteTeamCode");
 	}
 
@@ -302,7 +305,8 @@ class LiveActivityPushServiceTest {
 
 		ArgumentCaptor<Map<String, Object>> attrs = mapCaptor();
 		verify(apnsClient, org.mockito.Mockito.times(2))
-				.sendStartAsync(anyString(), anyString(), attrs.capture(), any());
+				.sendStartAsync(anyString(), anyString(), attrs.capture(), any(),
+						anyString(), anyString());
 		assertThat(attrs.getAllValues()).extracting(m -> m.get("favoriteTeamCode"))
 				.containsExactly("T1", "HLE");
 	}
@@ -324,7 +328,8 @@ class LiveActivityPushServiceTest {
 
 		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
 
-		verify(apnsClient, never()).sendStartAsync(anyString(), anyString(), any(), any());
+		verify(apnsClient, never()).sendStartAsync(anyString(), anyString(), any(), any(),
+				anyString(), anyString());
 	}
 
 	@Test
@@ -333,7 +338,8 @@ class LiveActivityPushServiceTest {
 		when(startTokenRepository.findStartTargets("match-1", 10L, 20L)).thenReturn(List.of(
 				startTarget("live", 1L, null),
 				startTarget("dead", 2L, null)));
-		when(apnsClient.sendStartAsync(eq("dead"), anyString(), any(), any())).thenReturn(alive(false));
+		when(apnsClient.sendStartAsync(eq("dead"), anyString(), any(), any(), anyString(), anyString()))
+				.thenReturn(alive(false));
 
 		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
 
@@ -348,13 +354,15 @@ class LiveActivityPushServiceTest {
 
 		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
 
-		verify(apnsClient, never()).sendStartAsync(anyString(), anyString(), any(), any());
+		verify(apnsClient, never()).sendStartAsync(anyString(), anyString(), any(), any(),
+				anyString(), anyString());
 	}
 
 	private void enablePushToStart() {
 		when(apnsClient.isAvailable()).thenReturn(true);
 		org.springframework.test.util.ReflectionTestUtils.setField(service, "pushToStartEnabled", true);
-		when(apnsClient.sendStartAsync(anyString(), anyString(), any(), any())).thenReturn(alive(true));
+		when(apnsClient.sendStartAsync(anyString(), anyString(), any(), any(), anyString(), anyString()))
+				.thenReturn(alive(true));
 	}
 
 	private LiveActivityPushService.MatchCardAttributes attributes() {


### PR DESCRIPTION
## 증상

서버 push-to-start 카드가 실기기 잠금화면에 뜨지 않음 (2026-08-09 KT vs DK 내부 테스트).

## 진단 — 발송 체인 전 구간 추적

| 단계 | 결과 |
|---|---|
| 대상 산정 (`findStartTargets`) | ✓ DK 구독 + 토큰 매칭 |
| APNs 발송 | ✓ 200, 죽은 토큰 0 |
| 기기 도착 (`log collect --device`) | ✓ topic·production env·attributes 208B 수신 |
| 예산 | ✓ 잔여 8 (스로틀 아님) |
| 카드 생성 | ✗ **여기서 중단** |

```
17:58:18.245 ERROR liveactivitiesd (SessionCore) [activityManager]
Received start without an alert configuration
```

## 원인·수정

push-to-start 는 `aps.alert`(title/body) 가 **필수**다. 우리 `sendStartAsync` 는 timestamp/event/attributes-type/attributes/content-state 만 실었다. alert 추가 (start 전용 — update/end 는 alert 없이 정상 동작 실증됨).

문구: `"KT vs DK" / "2세트 시작"` 수준 최소한. SET_START FCM 배너가 이미 상세 문구를 담당.

## 테스트

`LiveActivityPushServiceTest` 시그니처 갱신 + alert 문구 계약 검증 추가. `app.mobile.push` 패키지 통과.

머지 → 자동 배포 후 다음 세트 시작에서 실기기 재검 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)