### PR TITLE
fix: 네이버 RESULT 조기확정에 다전제 승리 조건 가드

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -138,6 +138,16 @@ public class LeagueMatchService {
 				|| naver.score()[0] + naver.score()[1] == 0) {
 			return false;
 		}
+		// 네이버 RESULT 만으로는 매치 종료를 단정할 수 없다 — KESPA 는 네이버가 세트를 개별
+		// 경기로 올려서 세트 사이에도 RESULT 가 온다(실측 2026-08-10 GEN vs HLE: 세트1 종료
+		// 직후 RESULT 1:0 → bo3 가 1:0 completed 로 고착, 이후 추적까지 게이트에 막혀 세트2·3
+		// 무음). 다전제 승리 조건에 실제로 도달한 스코어만 종료로 받아들인다.
+		// bestOf 미상이면 확정하지 않는다 — 늦더라도(업스트림 flip 대기) 틀리는 것보단 낫다.
+		if (!reachesMatchWin(match.getBestOf(), naver.score()[0], naver.score()[1])) {
+			log.info("Naver RESULT 를 다전제 미완으로 무시. matchId={} bestOf={} score={}:{}",
+					match.getMatchId(), match.getBestOf(), naver.score()[0], naver.score()[1]);
+			return false;
+		}
 		match.getBlueTeam().setWins(naver.score()[0]);
 		match.getRedTeam().setWins(naver.score()[1]);
 		match.setState("completed");
@@ -151,6 +161,14 @@ public class LeagueMatchService {
 					match.getMatchId(), naver.score()[0], naver.score()[1]);
 		}
 		return changed;
+	}
+
+	/** 다전제 승리 조건 도달 여부. LivePollingScheduler.isMatchEnded 와 같은 판정 — bestOf 미상은 false. */
+	static boolean reachesMatchWin(Integer bestOf, int blueScore, int redScore) {
+		if (bestOf == null || bestOf < 1) {
+			return false;
+		}
+		return Math.max(blueScore, redScore) >= bestOf / 2 + 1;
 	}
 
 	/**

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceReachesMatchWinTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceReachesMatchWinTest.java
@@ -1,0 +1,40 @@
+package com.toy.nar.app.lolesports;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 네이버 RESULT 조기확정 가드. KESPA 는 네이버가 세트를 개별 경기로 올려 세트 사이에도
+ * RESULT 가 오므로(2026-08-10 GEN vs HLE 실사고: bo3 이 세트1 직후 1:0 completed 고착),
+ * 다전제 승리 조건에 도달한 스코어만 매치 종료로 인정한다.
+ */
+class LeagueMatchServiceReachesMatchWinTest {
+
+	@Test
+	void bo3_는_2승부터_종료다() {
+		assertThat(LeagueMatchService.reachesMatchWin(3, 1, 0)).isFalse(); // 실사고 케이스
+		assertThat(LeagueMatchService.reachesMatchWin(3, 1, 1)).isFalse();
+		assertThat(LeagueMatchService.reachesMatchWin(3, 2, 0)).isTrue();
+		assertThat(LeagueMatchService.reachesMatchWin(3, 1, 2)).isTrue();
+	}
+
+	@Test
+	void bo1_은_1승이면_종료다() {
+		assertThat(LeagueMatchService.reachesMatchWin(1, 1, 0)).isTrue();
+		assertThat(LeagueMatchService.reachesMatchWin(1, 0, 1)).isTrue();
+	}
+
+	@Test
+	void bo5_는_3승부터_종료다() {
+		assertThat(LeagueMatchService.reachesMatchWin(5, 2, 2)).isFalse();
+		assertThat(LeagueMatchService.reachesMatchWin(5, 3, 1)).isTrue();
+	}
+
+	@Test
+	void bestOf_미상이면_종료로_단정하지_않는다() {
+		// 틀린 조기확정은 추적 중단까지 번지므로, 미상이면 업스트림 flip 을 기다린다.
+		assertThat(LeagueMatchService.reachesMatchWin(null, 2, 0)).isFalse();
+		assertThat(LeagueMatchService.reachesMatchWin(0, 2, 0)).isFalse();
+	}
+}


### PR DESCRIPTION
## 사고 (2026-08-10 KESPA GEN vs HLE)

bo3 이 세트1 직후 **1:0 completed 로 고착**, 이후 세트2·3 은 추적·알림·라이브카드 전부 무음.

```
15:47:36  set-end(frame) set=1
15:48:50  Naver 종료 확정으로 매치 completed 반영. score=1:0   ← 오발
15:49:34  스윕이 completed 를 보고 카드 종료 발송 (스윕은 정상 동작)
16:00:28  isResultRegression 이 업스트림 되돌림까지 차단 → 1:0 고착
```

## 원인

#354 의 네이버 조기확정은 "세트 사이엔 네이버가 RESULT 를 안 준다"를 전제로 했다. LCK 는 네이버가 bo3 전체를 한 경기로 모델링해 성립하지만, **KESPA 는 세트를 개별 경기로 올려 세트 사이에도 RESULT 가 온다.**

2차 피해: `naverFinalizedMatchIds` 게이트가 확정 후 그 매치의 프로브·sync 를 업스트림 flip 까지 차단하므로, 오확정 = 남은 세트 전체 추적 중단.

## 수정

RESULT 를 받아도 스코어가 **다전제 승리 조건(bestOf/2+1) 도달**일 때만 종료 인정. bestOf 미상이면 확정 안 함(업스트림 flip 대기 — 늦는 게 틀리는 것보다 낫다). LCK 는 RESULT 시점에 이미 조건 충족이라 동작 불변.

## 테스트

`LeagueMatchServiceReachesMatchWinTest` — 실사고 케이스(bo3 1:0) 포함 4건. 기존 ResultRegression 테스트 통과.

## 배포 후 수동 조치 (별도)

- DB: 해당 매치 state 를 inProgress 로 복구
- 재배포 재시작이 `naverFinalizedMatchIds`(in-memory) 를 비워 추적 자동 재개

🤖 Generated with [Claude Code](https://claude.com/claude-code)