### PR TITLE
fix: 스윕 안전장치 — 오염 completed 증폭 방지·워터마크 우회·역행 가드 공유

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -138,14 +138,19 @@ public class LeagueMatchService {
 				|| naver.score()[0] + naver.score()[1] == 0) {
 			return false;
 		}
-		// 네이버 RESULT 만으로는 매치 종료를 단정할 수 없다 — KESPA 는 네이버가 세트를 개별
-		// 경기로 올려서 세트 사이에도 RESULT 가 온다(실측 2026-08-10 GEN vs HLE: 세트1 종료
-		// 직후 RESULT 1:0 → bo3 가 1:0 completed 로 고착, 이후 추적까지 게이트에 막혀 세트2·3
-		// 무음). 다전제 승리 조건에 실제로 도달한 스코어만 종료로 받아들인다.
-		// bestOf 미상이면 확정하지 않는다 — 늦더라도(업스트림 flip 대기) 틀리는 것보단 낫다.
-		if (!reachesMatchWin(match.getBestOf(), naver.score()[0], naver.score()[1])) {
+		// 네이버 RESULT 만으로는 매치 종료를 단정할 수 없다 — KESPA 는 네이버가 RESULT 플래그를
+		// 매치 중간에 미리 세운다(실측 2026-08-10 GEN vs HLE: 세트1 종료 직후 RESULT+진행 스코어
+		// 1:0 → bo3 가 1:0 completed 로 고착, 이후 추적까지 게이트에 막혀 세트2·3 무음).
+		// 다전제 승리 조건에 실제로 도달한 스코어만 종료로 받아들인다.
+		// bestOf 는 업스트림 DTO 가 간헐적으로 비워 보내므로 DB 값으로 폴백한다 — 폴백까지
+		// 미상이면 확정하지 않는다. 늦더라도(업스트림 flip 대기) 틀리는 것보단 낫다.
+		Integer bestOf = match.getBestOf() != null
+				? match.getBestOf()
+				: leagueMatchRepository.findById(match.getMatchId())
+						.map(LeagueMatch::getBestOf).orElse(null);
+		if (!reachesMatchWin(bestOf, naver.score()[0], naver.score()[1])) {
 			log.info("Naver RESULT 를 다전제 미완으로 무시. matchId={} bestOf={} score={}:{}",
-					match.getMatchId(), match.getBestOf(), naver.score()[0], naver.score()[1]);
+					match.getMatchId(), bestOf, naver.score()[0], naver.score()[1]);
 			return false;
 		}
 		match.getBlueTeam().setWins(naver.score()[0]);
@@ -164,7 +169,7 @@ public class LeagueMatchService {
 	}
 
 	/** 다전제 승리 조건 도달 여부. LivePollingScheduler.isMatchEnded 와 같은 판정 — bestOf 미상은 false. */
-	static boolean reachesMatchWin(Integer bestOf, int blueScore, int redScore) {
+	public static boolean reachesMatchWin(Integer bestOf, int blueScore, int redScore) {
 		if (bestOf == null || bestOf < 1) {
 			return false;
 		}

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -89,12 +89,8 @@ public class LivePollingScheduler {
 	 */
 	private final java.util.Set<String> startNotifiedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
-	/**
-	 * 매치 종료(matchEnded) Live Activity 카드를 이미 보낸 matchId.
-	 * 세트 종료 편승 경로와 늦은 스코어 복구 경로가 같은 매치에 두 번 쏘지 않게 한다.
-	 * ponytail: {@link #naverFinalizedMatchIds} 와 같은 이유로 프로세스 생애 동안 누적된다 — 하루 수십 건이라 무해.
-	 */
-	private final java.util.Set<String> matchEndCardPushedMatchIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+	// 매치 종료 카드 발송 여부는 LiveActivityPushService 가 공유 상태로 관리한다
+	// (matchEndPushed/claimMatchEndPush) — 스윕까지 발송자가 셋이라 여기 두면 스윕 발송이 안 보인다.
 
 	@org.springframework.beans.factory.annotation.Value("${lolesports.live.max-consecutive-failures:6}")
 	private int maxConsecutiveFailures;
@@ -523,9 +519,9 @@ public class LivePollingScheduler {
 		if (!liveActivityPushService.isEnabled()) {
 			return;
 		}
-		// 복구 경로(retryMatchEndCard)가 먼저 매치 종료를 보냈으면 여기서 setEnded 를 뒤에 쏘면 안 된다 —
-		// 매치 종료 발송이 워터마크를 지우므로(notifySetEnd) 뒤늦은 setEnded 가 통과해 카드가 되돌아간다.
-		if (matchEndCardPushedMatchIds.contains(activeGame.matchId())) {
+		// 복구 경로(retryMatchEndCard)나 스윕이 먼저 매치 종료를 보냈으면 setEnded 를 뒤에 쏘면 안 된다 —
+		// 매치 종료 발송이 워터마크를 지우므로 뒤늦은 setEnded 가 통과해 카드가 되돌아간다.
+		if (liveActivityPushService.matchEndPushed(activeGame.matchId())) {
 			return;
 		}
 		try {
@@ -541,7 +537,7 @@ public class LivePollingScheduler {
 						: match.getRedTeamCode();
 			}
 			if (matchEnded) {
-				matchEndCardPushedMatchIds.add(activeGame.matchId());
+				liveActivityPushService.claimMatchEndPush(activeGame.matchId());
 			}
 			liveActivityPushService.notifySetEnd(
 					activeGame.matchId(),
@@ -568,7 +564,7 @@ public class LivePollingScheduler {
 	private void retryMatchEndCard(ActiveLiveGame activeGame) {
 		if (!liveActivityPushService.isEnabled()
 				|| activeGame.matchId() == null
-				|| matchEndCardPushedMatchIds.contains(activeGame.matchId())) {
+				|| liveActivityPushService.matchEndPushed(activeGame.matchId())) {
 			return;
 		}
 		try {
@@ -577,8 +573,8 @@ public class LivePollingScheduler {
 					|| !isMatchEnded(match.getBestOf(), match.getBlueScore(), match.getRedScore())) {
 				return;
 			}
-			// add 로 검사와 등록을 한 번에 한다 — 세트 종료 편승 경로와 동시에 들어올 수 있다.
-			if (!matchEndCardPushedMatchIds.add(activeGame.matchId())) {
+			// claim 으로 검사와 등록을 한 번에 한다 — 세트 종료 편승 경로·스윕과 동시에 들어올 수 있다.
+			if (!liveActivityPushService.claimMatchEndPush(activeGame.matchId())) {
 				return;
 			}
 			int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeper.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeper.java
@@ -21,9 +21,11 @@ import java.util.concurrent.Executor;
  * bestOf 미상이라 종료 판정이 영영 false 거나, 재기동으로 in-memory 상태가 날아가거나.
  * 어느 경우든 카드는 iOS 한도(8시간)까지 "다음 세트 준비 중"으로 잠금화면에 남는다.</p>
  *
- * <p>이 스윕은 발송 경로가 아니라 DB 상태를 본다 — 살아있는 카드의 매치가 completed 면
- * 매치 종료를 보낸다. 위 빈틈 전부와, 앞으로 생길 발송 경로의 빈틈까지 한 번에 덮는다.
- * 서버가 아는 카드(update 토큰이 등록된 카드)만 닫을 수 있다는 한계는 그대로다 —
+ * <p>이 스윕은 발송 경로가 아니라 DB 상태를 본다 — 살아있는 카드의 매치가 completed 이고
+ * 스코어가 다전제 승리 조건에 도달했으면 매치 종료를 보낸다. 승리 조건 교차검증은 오염된
+ * completed(다른 버그가 만든 조기 확정)를 능동적 카드 파괴로 증폭하지 않기 위한 가드라,
+ * bestOf 미상 매치는 스윕도 보류한다(그 카드는 앱의 endAll 정리·iOS 8시간 한도가 마지막
+ * 안전망). 서버가 아는 카드(update 토큰이 등록된 카드)만 닫을 수 있다는 한계도 그대로다 —
  * 토큰 없는 카드는 앱의 endAll 정리 경로만 남는다.</p>
  */
 @Slf4j
@@ -59,17 +61,27 @@ public class LiveActivityOrphanCardSweeper {
 			}
 			int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
 			int red = match.getRedScore() == null ? 0 : match.getRedScore();
-			// 세트 번호는 진행도 워터마크(progressKey) 비교에만 쓰인다. 스코어 합이 곧 치른 세트
-			// 수이고, 완료 매치의 스코어는 이미 확정이라 폴링이 봤을 어떤 세트보다 뒤거나 같다.
-			int setNumber = Math.max(1, blue + red);
-			String winner = blue == red ? null
-					: blue > red ? match.getBlueTeamCode() : match.getRedTeamCode();
+			// completed 라도 스코어가 다전제 승리 조건 미달이면 오염 의심 — 건드리지 않는다.
+			// 잘못된 completed 는 다른 버그가 만들 수 있고(실측 2026-08-10 GEN vs HLE: 네이버
+			// 조기 RESULT 로 bo3 이 1:0 completed), 그걸 믿고 쓸면 진행 중 경기의 카드를 전부
+			// 닫고 토큰까지 죽여 state 복구 후에도 카드를 살릴 수 없다. 늦게 닫는 건 다음
+			// tick 이 만회하지만 잘못 닫는 건 복구 불가라, 의심스러우면 두는 쪽이 싸다.
+			if (!com.toy.nar.app.lolesports.LeagueMatchService.reachesMatchWin(
+					match.getBestOf(), blue, red)) {
+				log.warn("[live-activity] 스윕 보류 — completed 인데 승리 조건 미달 matchId={} bestOf={} score={}:{}",
+						match.getId(), match.getBestOf(), blue, red);
+				continue;
+			}
+			int setNumber = blue + red;
+			String winner = blue > red ? match.getBlueTeamCode() : match.getRedTeamCode();
 			log.info("[live-activity] 스윕 — 끝난 매치의 카드 정리 matchId={} score={}:{}",
 					match.getId(), blue, red);
 			// APNs 팬아웃을 스케줄러 스레드에서 돌리면 다른 잡의 슬롯을 막는다
 			// (5슬롯 공유 — 2026-07-29 폴링 스레드가 발송 락 대기 50초에 걸린 실사고 참고).
-			applicationTaskExecutor.execute(() -> liveActivityPushService.notifySetEnd(
-					match.getId(), setNumber, blue, red, true, winner));
+			// forceMatchEnd: 스윕의 근거는 DB 확정 상태라 진행도 워터마크 검사를 건너뛴다 —
+			// 리메이크로 워터마크 세트가 스코어 합보다 높으면 notifySetEnd 는 영구 기각된다.
+			applicationTaskExecutor.execute(() -> liveActivityPushService.forceMatchEnd(
+					match.getId(), setNumber, blue, red, winner));
 		}
 	}
 }

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -69,8 +69,26 @@ public class LiveActivityPushService {
 	 */
 	private final Map<String, Long> lastProgressByMatch = new ConcurrentHashMap<>();
 
+	/**
+	 * 매치 종료 카드를 이미 내보낸 매치. 발송자가 셋(프레임 편승·복구 재시도·스윕)이라
+	 * "종료가 나간 뒤 늦은 setEnded 가 카드를 되돌리는" 역행을 막는 상태는 발송 지점인
+	 * 여기서 공유해야 한다 — 스케줄러 안에 있으면 스윕 발송이 보이지 않는다.
+	 */
+	private final java.util.Set<String> matchEndPushedMatchIds =
+			java.util.concurrent.ConcurrentHashMap.newKeySet();
+
 	public boolean isEnabled() {
 		return apnsClient.isAvailable();
+	}
+
+	/** 이 매치의 종료 카드가 이미 나갔는지. 늦은 setEnded 를 쏘기 전에 확인한다. */
+	public boolean matchEndPushed(String matchId) {
+		return matchEndPushedMatchIds.contains(matchId);
+	}
+
+	/** 종료 발송 선점. 처음 선점했으면 true — 동시 진입하는 발송 경로의 dedup 에 쓴다. */
+	public boolean claimMatchEndPush(String matchId) {
+		return matchEndPushedMatchIds.add(matchId);
 	}
 
 	/** 세트 시작 — 카드를 진행 중으로 바꾼다. */
@@ -262,10 +280,32 @@ public class LiveActivityPushService {
 				phase, setNumber, blueScore, redScore, label, matchEnded ? winnerTeamCode : null);
 		fanOut(matchId, state, matchEnded);
 		if (matchEnded) {
+			claimMatchEndPush(matchId);
 			// 카드가 닫혔으니 워터마크도 함께 정리한다. 이후 늦게 도착하는 이벤트는
 			// 토큰이 이미 비활성이라 fanOut 에서 자연히 걸러진다.
 			lastProgressByMatch.remove(matchId);
 		}
+	}
+
+	/**
+	 * 매치 종료 강제 발송 — 스윕 전용. 진행도 워터마크({@link #accept}) 검사를 건너뛴다.
+	 *
+	 * <p>워터마크는 발송 이벤트끼리의 순서를 지키는 장치인데, 스윕의 근거는 이벤트가 아니라
+	 * DB 확정 상태(completed)다. completed 보다 미래의 이벤트는 없으므로 순서 검사가 지킬 게
+	 * 없고, 오히려 방해가 된다 — 리메이크로 폴링 워터마크(gameIds 인덱스 기준 세트)가 스코어 합
+	 * 기반 세트 추정보다 높으면 스윕 발송이 영구 기각돼, 스윕이 잡으려던 카드 고착을 스윕
+	 * 자신이 재생산한다(5분마다 기각 반복).</p>
+	 */
+	public void forceMatchEnd(String matchId, int setNumber, Integer blueScore, Integer redScore,
+			String winnerTeamCode) {
+		if (matchId == null || matchId.isBlank()) {
+			return;
+		}
+		Map<String, Object> state = contentState(
+				PHASE_MATCH_ENDED, Math.max(1, setNumber), blueScore, redScore, "경기 종료", winnerTeamCode);
+		fanOut(matchId, state, true);
+		claimMatchEndPush(matchId);
+		lastProgressByMatch.remove(matchId);
 	}
 
 	/**

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -811,8 +811,16 @@ class LivePollingSchedulerTest {
 
 	private com.toy.nar.app.mobile.push.LiveActivityPushService liveActivityPushService(
 			LivePollingScheduler scheduler) {
-		return (com.toy.nar.app.mobile.push.LiveActivityPushService)
+		var mock = (com.toy.nar.app.mobile.push.LiveActivityPushService)
 				ReflectionTestUtils.getField(scheduler, "liveActivityPushService");
+		// 스케줄러가 종료 발송 선점(claim)/조회를 실제 집합 의미로 쓰므로 모의도 그 계약을 따른다 —
+		// 기본 스텁(false)이면 복구 경로가 선점 실패로 오인해 발송 자체를 건너뛴다.
+		java.util.Set<String> claimed = java.util.concurrent.ConcurrentHashMap.newKeySet();
+		when(mock.claimMatchEndPush(anyString()))
+				.thenAnswer(inv -> claimed.add(inv.getArgument(0)));
+		when(mock.matchEndPushed(anyString()))
+				.thenAnswer(inv -> claimed.contains(inv.getArgument(0)));
+		return mock;
 	}
 
 	private com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepositoryWithScore(

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeperTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityOrphanCardSweeperTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,43 +36,50 @@ class LiveActivityOrphanCardSweeperTest {
 	}
 
 	@Test
-	void 끝난_매치의_살아있는_카드에_매치_종료를_보낸다() {
+	void 끝난_매치의_살아있는_카드에_매치_종료를_강제_발송한다() {
 		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
 		when(leagueMatchRepository.findAllById(List.of("match-1")))
-				.thenReturn(List.of(match("match-1", "completed", 2, 0)));
+				.thenReturn(List.of(match("match-1", "completed", 3, 2, 0)));
 
 		sweeper.sweep();
 
-		// 세트 번호 = 스코어 합, 승자 = 스코어 우세 팀 코드.
-		verify(pushService).notifySetEnd("match-1", 2, 2, 0, true, "BLU");
+		// forceMatchEnd: DB 확정 상태 기반이라 워터마크 검사를 우회한다. 세트 = 스코어 합.
+		verify(pushService).forceMatchEnd("match-1", 2, 2, 0, "BLU");
 	}
 
 	@Test
 	void 진행_중인_매치는_건드리지_않는다() {
 		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
 		when(leagueMatchRepository.findAllById(List.of("match-1")))
-				.thenReturn(List.of(match("match-1", "inProgress", 1, 0)));
+				.thenReturn(List.of(match("match-1", "inProgress", 3, 1, 0)));
 
 		sweeper.sweep();
 
-		verify(pushService, never()).notifySetEnd(
-				org.mockito.ArgumentMatchers.anyString(),
-				org.mockito.ArgumentMatchers.anyInt(),
-				org.mockito.ArgumentMatchers.any(),
-				org.mockito.ArgumentMatchers.any(),
-				org.mockito.ArgumentMatchers.anyBoolean(),
-				org.mockito.ArgumentMatchers.any());
+		verifyNoForceMatchEnd();
 	}
 
 	@Test
-	void 스코어_미상이면_승자_없이_세트1로_닫는다() {
+	void completed_라도_승리_조건_미달이면_오염_의심으로_보류한다() {
+		// 2026-08-10 GEN vs HLE 실사고: 네이버 조기 RESULT 로 bo3 이 1:0 completed.
+		// 이걸 믿고 쓸면 진행 중 경기 카드를 닫고 토큰을 죽여 복구 불가가 된다.
 		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
 		when(leagueMatchRepository.findAllById(List.of("match-1")))
-				.thenReturn(List.of(match("match-1", "completed", null, null)));
+				.thenReturn(List.of(match("match-1", "completed", 3, 1, 0)));
 
 		sweeper.sweep();
 
-		verify(pushService).notifySetEnd("match-1", 1, 0, 0, true, null);
+		verifyNoForceMatchEnd();
+	}
+
+	@Test
+	void bestOf_미상_completed_는_검증_불가라_보류한다() {
+		when(tokenRepository.findDistinctActiveMatchIds()).thenReturn(List.of("match-1"));
+		when(leagueMatchRepository.findAllById(List.of("match-1")))
+				.thenReturn(List.of(match("match-1", "completed", null, 2, 0)));
+
+		sweeper.sweep();
+
+		verifyNoForceMatchEnd();
 	}
 
 	@Test
@@ -81,11 +91,16 @@ class LiveActivityOrphanCardSweeperTest {
 		verifyNoInteractions(tokenRepository, leagueMatchRepository);
 	}
 
-	private static LeagueMatch match(String id, String state, Integer blue, Integer red) {
+	private void verifyNoForceMatchEnd() {
+		verify(pushService, never()).forceMatchEnd(anyString(), anyInt(), any(), any(), any());
+	}
+
+	private static LeagueMatch match(String id, String state, Integer bestOf, Integer blue, Integer red) {
 		return LeagueMatch.builder()
 				.id(id)
 				.leagueName("LCK")
 				.state(state)
+				.bestOf(bestOf)
 				.blueTeamCode("BLU")
 				.blueScore(blue)
 				.redTeamCode("RED")

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceTest.java
@@ -210,6 +210,39 @@ class LiveActivityPushServiceTest {
 	}
 
 	@Test
+	void forceMatchEnd_는_워터마크가_더_높아도_발송한다() {
+		// 리메이크로 폴링 워터마크(3세트 playing=30)가 스코어 합 기반 세트(2)보다 높은 상황.
+		// notifySetEnd 라면 키 22 < 30 으로 기각되지만, 스윕의 근거는 DB 확정 상태라 우회한다.
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+		service.notifySetStart("match-1", 3, 1, 0);
+
+		service.forceMatchEnd("match-1", 2, 2, 0, "T1");
+
+		verify(apnsClient).sendEndAsync(anyString(), any(), any());
+		assertThat(service.matchEndPushed("match-1")).isTrue();
+	}
+
+	@Test
+	void 매치_종료가_나가면_늦은_setEnded_역행을_가드가_본다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		assertThat(service.matchEndPushed("match-1")).isFalse();
+		assertThat(service.claimMatchEndPush("match-1")).isTrue();
+		// 두 번째 선점은 실패 — 발송 경로 셋(편승·복구·스윕)의 dedup.
+		assertThat(service.claimMatchEndPush("match-1")).isFalse();
+		assertThat(service.matchEndPushed("match-1")).isTrue();
+	}
+
+	@Test
+	void notifySetEnd_매치종료도_발송_기록을_남긴다() {
+		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));
+
+		service.notifySetEnd("match-1", 2, 2, 0, true, "T1");
+
+		assertThat(service.matchEndPushed("match-1")).isTrue();
+	}
+
+	@Test
 	void 같은_상태_재발화는_통과시킨다() {
 		// 같은 세트를 다시 그리는 것뿐이라 무해하고, 그 사이 스코어가 갱신됐을 수 있다.
 		when(tokenRepository.findActivePushTokensByMatchId("match-1")).thenReturn(List.of("tok-1"));


### PR DESCRIPTION
코드리뷰(#357~#359 상호작용, 워크플로 검증 21건)에서 확정된 스윕 결함 3개 + bestOf 폴백.

## 1. 오염된 completed 증폭 방지 (CONFIRMED)

스윕이 `state=completed` 만 믿어서, 잘못된 completed(2026-08-10 GEN vs HLE — 네이버 조기 RESULT 로 bo3 이 1:0 completed)가 생기면 **5분 내 진행 중 경기 전 카드에 틀린 '경기 종료' 발송 + 토큰 전멸**로 증폭. 토큰이 죽으면 state 복구 후에도 카드 복구 불가.

→ `reachesMatchWin(bestOf/2+1)` 교차검증 통과한 completed 만 스윕. bestOf 미상은 보류(검증 불가 — 그 카드는 앱 endAll·iOS 8h 한도가 안전망).

## 2. 워터마크 기각 루프 (PLAUSIBLE)

스윕 세트 추정(스코어 합)이 폴링 워터마크(gameIds 인덱스)보다 낮으면 — 리메이크 케이스 — `accept()` 가 영구 기각. 5분마다 헛돌고 카드 8시간 고착.

→ `forceMatchEnd` 신설: 워터마크 검사 우회. 스윕 근거는 이벤트 순서가 아니라 DB 확정 상태고, completed 보다 미래 이벤트는 없어 순서 검사가 지킬 게 없음.

## 3. 역행 가드가 스윕 발송을 못 봄 (PLAUSIBLE)

`matchEndCardPushedMatchIds` 가 스케줄러 소유라 스윕의 종료 발송이 등록 안 됨 → 종료 직후 stale 폴백의 늦은 setEnded 가 카드를 '다음 세트 준비 중'으로 되돌릴 수 있는 레이스.

→ 집합을 `LiveActivityPushService` 로 이동(`matchEndPushed`/`claimMatchEndPush`) — 발송자 3곳(편승·복구·스윕)이 공유.

## + bestOf DB 폴백 (PLAUSIBLE)

#359 가드가 DTO bestOf 만 봐서 업스트림이 간헐적으로 비워 보내면 정당한 종료 확정까지 차단 → DB 값 폴백.

## 리뷰에서 기각·잔여

- "KESPA 네이버 확정 영구 무력화"(CONFIRMED 판정)는 **실데이터로 반증** — 네이버는 KESPA bo3 을 단일 엔트리로 집계(2:1 확인). 가드는 설계대로 동작.
- 중복 카드(NOT EXISTS 재개방)는 앱 reconcile 설계와 묶어 별도 진행.

## 테스트

- 스위퍼: 오염 completed 보류(실사고 케이스)·bestOf 미상 보류·forceMatchEnd 전환 5건
- 서비스: forceMatchEnd 워터마크 우회·claim dedup·notifySetEnd 기록 3건
- 스케줄러: 기존 복구/중복 방지 테스트가 공유 집합 계약으로 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)