### PR TITLE
fix: prod HikariCP 풀 30으로 확대 — 푸시 직후 동시 유입 커넥션 대기 해소

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,6 +8,11 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
+      # 기본값 10이 매치 종료 푸시 직후 동시 유입을 못 받는다. 실측 2026-08-11 20:17
+      # (DNS vs HLE 종료): 분당 2,259 요청, 1,034건이 커넥션 대기 3~14초 — SQL 자체는
+      # 5~65ms. refresh 까지 5초씩 대기해 동시 리프레시 레이스로 강제 로그아웃 유발.
+      # DB(MySQL) max_connections=151, 역대 최대 사용 48 — 30으로 올려도 여유.
+      maximum-pool-size: ${DB_POOL_MAX_SIZE:30}
       data-source-properties:
         rewriteBatchedStatements: true
 


### PR DESCRIPTION
## 문제

매치 종료 푸시 팬아웃 직후 앱 동시 유입을 커넥션 풀이 못 받는다.

실측 2026-08-11 20:17 (DNS vs HLE 종료, WhaTap 트레이스 3,110건 분석):

| 분 | 요청 수 | 커넥션 3초+ 대기 | 최대 대기 |
|---|---|---|---|
| 20:15 | 19 | 0 | 4ms |
| 20:16 | 52 | 0 | 5ms |
| **20:17** | **2,259** | **1,034** | **14초** |
| 20:18 | 413 | 0 | 34ms |

SQL 자체는 5~65ms — 지연의 95%가 커넥션 대기. `/api/auth/refresh`까지 3~5.7초 대기해 동시 리프레시 rotation 레이스가 열렸고 실제 강제 로그아웃 2건(`401 유효하지 않은 리프레시 토큰`) 발생.

## 변경

prod 프로파일에 `maximum-pool-size: 30` (기본값 10 → 30, env `DB_POOL_MAX_SIZE` 오버라이드 가능).

근거: MySQL `max_connections=151`, 역대 최대 사용 48 — 30으로 올려도 여유 큼.

## 남은 후속 (별도 PR)

- `/api/mobile/live/games/{id}/events` 요청당 SQL 75건 (N+1, 폴링 증폭)
- refresh rotation grace 60s + 모바일 refresh 실패 구분 (간헐 로그아웃 근본 수정)
- `/api/categories/tree` 응답 캐시 (금일 최악 지연 14초)

🤖 Generated with [Claude Code](https://claude.com/claude-code)