### PR TITLE
fix: 리프레시 회전 grace + 로그인 시 세션 전량 삭제 제거 — 간헐 강제 로그아웃 서버측 수정

### DIFF
--- a/src/main/java/com/toy/nar/api/auth/AuthController.java
+++ b/src/main/java/com/toy/nar/api/auth/AuthController.java
@@ -50,7 +50,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -68,6 +70,9 @@ import static org.springframework.http.HttpStatus.*;
 public class AuthController {
 
     private static final int DEFAULT_ONBOARDING_YEAR = 2026;
+
+    /** 리프레시 회전 grace — 구 토큰이 이 시간만큼 더 살아 동시 리프레시의 늦은 쪽도 성공한다. */
+    private static final Duration ROTATION_GRACE = Duration.ofSeconds(60);
 
     /** 온보딩 선수 목록은 페이징 없이 전체를 쓴다. LCK 로스터는 한 시즌 100명 미만이라 상한 200이면 충분하다. */
     private static final org.springframework.data.domain.PageRequest ONBOARDING_PLAYER_PAGE =
@@ -262,7 +267,8 @@ public class AuthController {
                 .orElseThrow(() -> new ResponseStatusException(UNAUTHORIZED, "유효하지 않은 리프레시 토큰"));
 
         if (stored.isExpired()) {
-            refreshTokenRepository.delete(stored);
+            // 벌크 삭제 — 엔티티 삭제는 같은 만료 토큰의 동시 요청에서 row count 0 500 을 낸다.
+            refreshTokenRepository.deleteByToken(refreshToken);
             throw new ResponseStatusException(UNAUTHORIZED, "만료된 리프레시 토큰");
         }
 
@@ -270,9 +276,14 @@ public class AuthController {
         String newAccessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded(), member.getRole().name());
         String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
 
-        // 벌크 삭제 — 동시 리프레시의 늦은 쪽이 이미 지워진 행을 만나도(0건 삭제) 예외 없이
-        // 자기 토큰을 커밋한다. 두 클라이언트 모두 유효한 토큰을 받는다.
-        refreshTokenRepository.deleteByToken(refreshToken);
+        // 회전 grace — 구 토큰을 즉시 지우면 동시 리프레시의 늦은 쪽이 findByToken 에서 401 을
+        // 받아 클라이언트가 강제 로그아웃된다(실측 2026-08-11 20:17: 매치 종료 푸시 유입으로
+        // 커넥션 풀 대기가 3~5.7초로 벌어지자 레이스가 실제 발생, 로그아웃 2건). 즉시 삭제 대신
+        // 만료를 짧게 단축해 그 사이 늦은 쪽도 자기 토큰을 발급받게 한다. 재사용 창이 grace 만큼
+        // 생기지만 도난 토큰은 어차피 14일 유효했으므로 순손실이 아니다.
+        refreshTokenRepository.shortenExpiryByToken(refreshToken, LocalDateTime.now().plus(ROTATION_GRACE));
+        // grace 가 남기는 짧은 수명 행이 쌓이지 않게 이 회원의 만료분을 함께 청소한다.
+        refreshTokenRepository.deleteExpiredByMemberId(member.getId(), LocalDateTime.now());
         refreshTokenRepository.save(RefreshToken.builder()
                 .member(member)
                 .token(newRefreshToken)

--- a/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
+++ b/src/main/java/com/toy/nar/app/auth/SocialLoginService.java
@@ -22,6 +22,9 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @RequiredArgsConstructor
 public class SocialLoginService {
 
+	/** 계정당 동시 세션(리프레시 토큰) 상한. 초과 시 가장 오래된 세션부터 밀려난다. */
+	static final int MAX_SESSIONS = 5;
+
 	private final JwtTokenProvider jwtTokenProvider;
 	private final NicknameGenerator nicknameGenerator;
 	private final MemberRepository memberRepository;
@@ -71,7 +74,15 @@ public class SocialLoginService {
 		String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.isOnboarded(), member.getRole().name());
 		String refreshTokenValue = jwtTokenProvider.createRefreshToken(member.getId());
 
-		refreshTokenRepository.deleteByMemberId(member.getId());
+		// 로그인마다 전량 삭제(deleteByMemberId)하면 같은 계정의 다른 기기·세션이 다음
+		// 리프레시에서 401 로 강제 로그아웃된다. 세션을 공존시키되 상한으로 증식만 막는다 —
+		// 만료분을 청소한 뒤 상한을 넘는 만큼 가장 오래된 것(만료 임박 순)부터 지운다.
+		refreshTokenRepository.deleteExpiredByMemberId(member.getId(), java.time.LocalDateTime.now());
+		java.util.List<RefreshToken> active =
+				refreshTokenRepository.findByMemberIdOrderByExpiresAtDesc(member.getId());
+		if (active.size() >= MAX_SESSIONS) {
+			refreshTokenRepository.deleteAllInBatch(active.subList(MAX_SESSIONS - 1, active.size()));
+		}
 		refreshTokenRepository.save(RefreshToken.builder()
 				.member(member)
 				.token(refreshTokenValue)

--- a/src/main/java/com/toy/nar/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/RefreshTokenRepository.java
@@ -9,6 +9,9 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByToken(String token);
     void deleteByMemberId(Long memberId);
 
+    /** 세션 상한 판정용. expiresAt = 발급+14일 고정이라 만료 내림차순 = 발급 최신순. */
+    java.util.List<RefreshToken> findByMemberIdOrderByExpiresAtDesc(Long memberId);
+
     /**
      * 토큰 회전용 벌크 삭제. 엔티티 삭제(delete(stored))는 동시 리프레시 두 건이 같은 행을
      * 지우면 늦은 쪽이 row count 0 flush 예외로 500 이 난다(#321 탈퇴와 같은 계급).
@@ -17,4 +20,25 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @org.springframework.data.jpa.repository.Modifying
     @org.springframework.data.jpa.repository.Query("delete from RefreshToken rt where rt.token = :token")
     int deleteByToken(@org.springframework.data.repository.query.Param("token") String token);
+
+    /**
+     * 회전 grace: 구 토큰을 즉시 지우는 대신 만료를 단축한다. 즉시 삭제하면 동시 리프레시의
+     * 늦은 쪽이 findByToken 에서 401 을 받아 클라이언트가 강제 로그아웃된다(실측 2026-08-11
+     * 커넥션 풀 대기로 레이스 창 5초). 조건의 {@code > :graceEnd} 는 단축만 허용 — 이미 grace 에
+     * 들어간 토큰을 뒤이은 재사용이 다시 연장하지 못한다.
+     */
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Query(
+            "update RefreshToken rt set rt.expiresAt = :graceEnd where rt.token = :token and rt.expiresAt > :graceEnd")
+    int shortenExpiryByToken(
+            @org.springframework.data.repository.query.Param("token") String token,
+            @org.springframework.data.repository.query.Param("graceEnd") java.time.LocalDateTime graceEnd);
+
+    /** grace 방식이 남기는 짧은 수명 행이 쌓이지 않게 회전·로그인 시 만료분을 함께 지운다. */
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Query(
+            "delete from RefreshToken rt where rt.member.id = :memberId and rt.expiresAt < :now")
+    int deleteExpiredByMemberId(
+            @org.springframework.data.repository.query.Param("memberId") Long memberId,
+            @org.springframework.data.repository.query.Param("now") java.time.LocalDateTime now);
 }

--- a/src/test/java/com/toy/nar/api/auth/AuthControllerRefreshRotationTest.java
+++ b/src/test/java/com/toy/nar/api/auth/AuthControllerRefreshRotationTest.java
@@ -1,0 +1,124 @@
+package com.toy.nar.api.auth;
+
+import com.toy.nar.app.auth.AppleUserClient;
+import com.toy.nar.app.auth.GoogleUserClient;
+import com.toy.nar.app.auth.JwtTokenProvider;
+import com.toy.nar.app.auth.KakaoUserClient;
+import com.toy.nar.app.auth.NaverUserClient;
+import com.toy.nar.app.auth.SocialLoginService;
+import com.toy.nar.app.auth.profile.CloudinarySignatureService;
+import com.toy.nar.app.auth.profile.ProfileService;
+import com.toy.nar.app.mobile.device.MobileDeviceService;
+import com.toy.nar.app.mobile.notification.MobileTeamNotificationService;
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberRole;
+import com.toy.nar.domain.member.entity.RefreshToken;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.member.repository.MemberSocialRepository;
+import com.toy.nar.domain.member.repository.RefreshTokenRepository;
+import com.toy.nar.domain.participant.repository.PlayerRepository;
+import com.toy.nar.domain.participant.repository.TeamRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 리프레시 회전은 구 토큰을 즉시 지우지 않는다(grace).
+ *
+ * <p>즉시 삭제하면 동시 리프레시의 늦은 쪽이 findByToken 에서 401 "유효하지 않은 리프레시
+ * 토큰"을 받아 클라이언트가 강제 로그아웃된다. 실측 2026-08-11 20:17: 매치 종료 푸시 유입으로
+ * 커넥션 풀 대기가 3~5.7초로 벌어지자 레이스 창이 열려 로그아웃 2건 발생. #329 벌크 삭제는
+ * 두 요청이 모두 조회에 성공한 경우만 구제하고, 삭제 커밋 뒤에 조회가 도착하는 경우는
+ * 그대로 401 이었다.</p>
+ */
+class AuthControllerRefreshRotationTest {
+
+	private final JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+	private final RefreshTokenRepository refreshTokenRepository = mock(RefreshTokenRepository.class);
+
+	private final AuthController controller = new AuthController(
+			jwtTokenProvider,
+			mock(KakaoUserClient.class),
+			mock(GoogleUserClient.class),
+			mock(NaverUserClient.class),
+			mock(AppleUserClient.class),
+			mock(SocialLoginService.class),
+			mock(MemberRepository.class),
+			mock(MemberSocialRepository.class),
+			refreshTokenRepository,
+			mock(TeamRepository.class),
+			mock(PlayerRepository.class),
+			mock(MobileDeviceService.class),
+			mock(MobileTeamNotificationService.class),
+			mock(ProfileService.class),
+			mock(CloudinarySignatureService.class),
+			null);
+
+	@Test
+	@DisplayName("회전은 구 토큰을 삭제하지 않고 만료를 단축한다 — 늦은 동시 리프레시도 성공해야 한다")
+	void rotationShortensExpiryInsteadOfDelete() {
+		RefreshToken stored = storedToken("rt-old", false);
+		when(refreshTokenRepository.findByToken("rt-old")).thenReturn(Optional.of(stored));
+		when(jwtTokenProvider.createAccessToken(anyLong(), any(Boolean.class), any())).thenReturn("at-new");
+		when(jwtTokenProvider.createRefreshToken(anyLong())).thenReturn("rt-new");
+		when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(14));
+
+		var response = controller.refresh("rt-old");
+
+		assertThat(response.getStatusCode().value()).isEqualTo(200);
+		verify(refreshTokenRepository).shortenExpiryByToken(eq("rt-old"), any(LocalDateTime.class));
+		verify(refreshTokenRepository, never()).deleteByToken("rt-old");
+		verify(refreshTokenRepository).save(any(RefreshToken.class));
+	}
+
+	@Test
+	@DisplayName("만료된 토큰은 벌크 삭제 후 401 — 엔티티 삭제는 동시 요청에서 row count 0 500을 낸다")
+	void expiredTokenIsBulkDeletedThen401() {
+		RefreshToken stored = storedToken("rt-expired", true);
+		when(refreshTokenRepository.findByToken("rt-expired")).thenReturn(Optional.of(stored));
+
+		assertThatThrownBy(() -> controller.refresh("rt-expired"))
+				.isInstanceOf(ResponseStatusException.class)
+				.hasFieldOrPropertyWithValue("statusCode", HttpStatus.UNAUTHORIZED);
+		verify(refreshTokenRepository).deleteByToken("rt-expired");
+		verify(refreshTokenRepository, never()).delete(any(RefreshToken.class));
+	}
+
+	@Test
+	@DisplayName("모르는 토큰은 401")
+	void unknownTokenIs401() {
+		when(refreshTokenRepository.findByToken("rt-unknown")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> controller.refresh("rt-unknown"))
+				.isInstanceOf(ResponseStatusException.class)
+				.hasFieldOrPropertyWithValue("statusCode", HttpStatus.UNAUTHORIZED);
+	}
+
+	private RefreshToken storedToken(String token, boolean expired) {
+		Member member = Member.builder()
+				.email("user@example.com")
+				.name("유저")
+				.tag("0001")
+				.build();
+		org.springframework.test.util.ReflectionTestUtils.setField(member, "id", 7L);
+		return RefreshToken.builder()
+				.member(member)
+				.token(token)
+				.expiresAt(expired ? LocalDateTime.now().minusMinutes(1) : LocalDateTime.now().plusDays(7))
+				.build();
+	}
+}

--- a/src/test/java/com/toy/nar/app/auth/SocialLoginServiceSessionCapTest.java
+++ b/src/test/java/com/toy/nar/app/auth/SocialLoginServiceSessionCapTest.java
@@ -1,0 +1,135 @@
+package com.toy.nar.app.auth;
+
+import com.toy.nar.domain.member.entity.Member;
+import com.toy.nar.domain.member.entity.MemberRole;
+import com.toy.nar.domain.member.entity.RefreshToken;
+import com.toy.nar.domain.member.repository.MemberRepository;
+import com.toy.nar.domain.member.repository.MemberSocialRepository;
+import com.toy.nar.domain.member.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 로그인이 같은 계정의 다른 세션을 죽이면 안 된다.
+ *
+ * <p>기존엔 로그인마다 deleteByMemberId 로 그 계정의 리프레시 토큰을 전량 삭제해,
+ * 다른 기기(또는 같은 기기의 이전 세션)가 다음 리프레시에서 401 → 강제 로그아웃됐다.
+ * 세션을 공존시키되 상한으로 무한 증식만 막는다 — 초과분은 가장 오래된 것부터 지운다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class SocialLoginServiceSessionCapTest {
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+	@Mock
+	private NicknameGenerator nicknameGenerator;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private MemberSocialRepository memberSocialRepository;
+	@Mock
+	private RefreshTokenRepository refreshTokenRepository;
+
+	private SocialLoginService socialLoginService;
+
+	@BeforeEach
+	void setUp() {
+		socialLoginService = new SocialLoginService(
+				jwtTokenProvider,
+				nicknameGenerator,
+				memberRepository,
+				memberSocialRepository,
+				refreshTokenRepository
+		);
+		lenient().when(jwtTokenProvider.createAccessToken(anyLong(), any(Boolean.class), any())).thenReturn("at");
+		lenient().when(jwtTokenProvider.createRefreshToken(anyLong())).thenReturn("rt-new");
+		lenient().when(jwtTokenProvider.getRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(14));
+		lenient().when(memberRepository.findById(7L)).thenReturn(Optional.of(member()));
+	}
+
+	@Test
+	@DisplayName("로그인은 기존 세션을 전량 삭제하지 않는다")
+	void loginKeepsExistingSessions() {
+		when(refreshTokenRepository.findByMemberIdOrderByExpiresAtDesc(7L)).thenReturn(List.of(token(1)));
+
+		socialLoginService.issueTokens(7L);
+
+		verify(refreshTokenRepository, never()).deleteByMemberId(7L);
+		verify(refreshTokenRepository).save(any(RefreshToken.class));
+	}
+
+	@Test
+	@DisplayName("만료 토큰은 로그인 시 청소한다")
+	void loginPurgesExpiredTokens() {
+		when(refreshTokenRepository.findByMemberIdOrderByExpiresAtDesc(7L)).thenReturn(List.of());
+
+		socialLoginService.issueTokens(7L);
+
+		verify(refreshTokenRepository).deleteExpiredByMemberId(any(Long.class), any(LocalDateTime.class));
+	}
+
+	@Test
+	@DisplayName("세션 상한(5) 도달 시 가장 오래된 것부터 지워 새 토큰 포함 5개를 유지한다")
+	void loginEvictsOldestBeyondCap() {
+		// expiresAt = 발급+14일 고정이라 만료 내림차순 = 최신순. index 0 이 최신.
+		List<RefreshToken> five = IntStream.range(0, 5).mapToObj(this::token).toList();
+		when(refreshTokenRepository.findByMemberIdOrderByExpiresAtDesc(7L)).thenReturn(five);
+
+		socialLoginService.issueTokens(7L);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Collection<RefreshToken>> evicted = ArgumentCaptor.forClass(Collection.class);
+		verify(refreshTokenRepository).deleteAllInBatch(evicted.capture());
+		// 5개 중 가장 오래된 1개만 지워 신규 발급 후 총 5개.
+		assertThat(evicted.getValue()).containsExactly(five.get(4));
+		verify(refreshTokenRepository).save(any(RefreshToken.class));
+	}
+
+	@Test
+	@DisplayName("상한 미만이면 아무것도 지우지 않는다")
+	void loginBelowCapEvictsNothing() {
+		List<RefreshToken> two = IntStream.range(0, 2).mapToObj(this::token).toList();
+		when(refreshTokenRepository.findByMemberIdOrderByExpiresAtDesc(7L)).thenReturn(two);
+
+		socialLoginService.issueTokens(7L);
+
+		verify(refreshTokenRepository, never()).deleteAllInBatch(any());
+	}
+
+	private Member member() {
+		Member member = Member.builder()
+				.email("user@example.com")
+				.name("유저")
+				.tag("0001")
+				.build();
+		org.springframework.test.util.ReflectionTestUtils.setField(member, "id", 7L);
+		return member;
+	}
+
+	private RefreshToken token(int ageDays) {
+		return RefreshToken.builder()
+				.member(member())
+				.token("rt-" + ageDays)
+				.expiresAt(LocalDateTime.now().plusDays(14).minusDays(ageDays))
+				.build();
+	}
+}

--- a/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
+++ b/src/test/java/com/toy/nar/app/auth/SocialLoginServiceTest.java
@@ -80,7 +80,7 @@ class SocialLoginServiceTest {
 		assertThat(tokens.isOnboarded()).isFalse();
 
 		verify(memberRepository, never()).save(any());
-		verify(refreshTokenRepository).deleteByMemberId(7L);
+		verify(refreshTokenRepository, never()).deleteByMemberId(7L);
 		verify(refreshTokenRepository).save(any(RefreshToken.class));
 	}
 
@@ -116,7 +116,7 @@ class SocialLoginServiceTest {
 		assertThat(socialCaptor.getValue().getProvider()).isEqualTo(OAuthProvider.KAKAO);
 		assertThat(socialCaptor.getValue().getProviderId()).isEqualTo("67890");
 		assertThat(socialCaptor.getValue().getMember().getEmail()).isEqualTo("new-user@example.com");
-		verify(refreshTokenRepository).deleteByMemberId(11L);
+		verify(refreshTokenRepository, never()).deleteByMemberId(11L);
 	}
 
 	@Test


### PR DESCRIPTION
## 문제

간헐적 강제 로그아웃(로그인 페이지로 튕김)의 서버측 원인 2개.

**1) 회전 즉시 삭제 레이스** — 동시 리프레시의 늦은 쪽이 `findByToken`에서 401 "유효하지 않은 리프레시 토큰" → 앱이 강제 로그아웃. #329 벌크 삭제는 두 요청이 **모두 조회에 성공한** 경우만 구제했고, 삭제 커밋 뒤 조회가 도착하는 순서는 그대로 401이었다. 실측 2026-08-11 20:17: 매치 종료 푸시 유입으로 커넥션 대기가 3~5.7초로 벌어지자 레이스 창이 열려 실제 로그아웃 2건 발생 (WhaTap 트레이스).

**2) 로그인 시 `deleteByMemberId`** — 같은 계정의 다른 기기·이전 세션 리프레시 토큰 전량 삭제 → 그 기기들은 다음 리프레시에서 401 → 강제 로그아웃. 계정 전환이 잦은 유저는 매번 발동.

## 변경

- **회전 grace 60초**: 구 토큰 즉시 삭제 대신 `expires_at = now+60s`로 단축 (`shortenExpiryByToken`, 단축만 허용 — 재사용이 grace를 연장 못 함). 늦은 동시 리프레시도 자기 토큰을 발급받는다. 재사용 창 60초는 도난 토큰이 어차피 14일 유효했던 것 대비 순손실 아님.
- **로그인 세션 공존**: `deleteByMemberId` 제거. 상한 5개 — 초과분은 가장 오래된 것(만료 임박순 = 발급순)부터 제거.
- **행 증식 방지**: grace가 남기는 짧은 수명 행은 회전·로그인 시 `deleteExpiredByMemberId`로 청소.
- **부수**: 만료 토큰 삭제를 엔티티 delete → 벌크 `deleteByToken`으로 (동시 요청 row count 0 500 방지, #329와 같은 계급).

명시적 로그아웃(`POST /api/auth/logout`)의 전 세션 폐기는 유지 — 사용자 의도적 행동.

## 테스트

- `AuthControllerRefreshRotationTest` 3건 — 회전이 삭제 대신 단축하는지, 만료 토큰 벌크 삭제, 미존재 401
- `SocialLoginServiceSessionCapTest` 4건 — 전량 삭제 안 함, 만료 청소, 상한 초과 시 최고령만 제거, 미만 시 무삭제
- 기존 `SocialLoginServiceTest` 2건 어서션을 새 동작으로 갱신
- 전체 `./gradlew test` green

## 남은 후속 (모바일, 별도 PR)

- refresh 실패를 전부 로그아웃 처리하는 클라 로직 — 401일 때만 로그아웃하도록
- 홈위젯 아이솔레이트의 독립 refresh 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)