### PR TITLE
fix: 경기 진행 중 구독 시 라이브위젯 카드 즉시 생성

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationService.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationService.java
@@ -2,6 +2,7 @@ package com.toy.nar.app.mobile.notification;
 
 import com.toy.nar.app.mobile.notification.dto.TeamNotificationSubscriptionResponse;
 import com.toy.nar.app.mobile.notification.dto.TeamNotificationUpdateRequest;
+import com.toy.nar.app.mobile.push.LiveActivityCatchUpService;
 import com.toy.nar.domain.member.entity.Member;
 import com.toy.nar.domain.member.entity.MemberTeamNotificationSubscription;
 import com.toy.nar.domain.member.repository.MemberRepository;
@@ -30,6 +31,7 @@ public class MobileTeamNotificationService {
 	private final MemberRepository memberRepository;
 	private final TeamRepository teamRepository;
 	private final MemberTeamNotificationSubscriptionRepository subscriptionRepository;
+	private final LiveActivityCatchUpService liveActivityCatchUpService;
 
 	public List<TeamNotificationSubscriptionResponse> getSubscriptions(Long memberId) {
 		Member member = requireMember(memberId);
@@ -69,10 +71,18 @@ public class MobileTeamNotificationService {
 	public TeamNotificationSubscriptionResponse subscribe(Long memberId, Long teamId) {
 		Member member = requireMember(memberId);
 		Team team = requireLckTeam(teamId);
+		boolean[] created = { false };
 		MemberTeamNotificationSubscription subscription = subscriptionRepository
 				.findByMember_IdAndTeam_Id(memberId, teamId)
-				.orElseGet(() -> subscriptionRepository.save(
-						new MemberTeamNotificationSubscription(member, team)));
+				.orElseGet(() -> {
+					created[0] = true;
+					return subscriptionRepository.save(
+							new MemberTeamNotificationSubscription(member, team));
+				});
+		// 새로 구독한 경우에만 따라잡는다. 이미 구독 중이면 카드는 이미 받았거나 사용자가 지운 것이다.
+		if (created[0] && subscription.isSetStartEnabled()) {
+			liveActivityCatchUpService.catchUpTeam(memberId, team.getCode());
+		}
 		return toResponse(member, subscription);
 	}
 
@@ -86,10 +96,15 @@ public class MobileTeamNotificationService {
 				.findByMember_IdAndTeam_Id(memberId, teamId)
 				.orElseThrow(() -> new ResponseStatusException(
 						HttpStatus.NOT_FOUND, "팀 알림 구독을 찾을 수 없습니다."));
+		boolean turnedOn = !subscription.isSetStartEnabled() && request.setStartEnabled();
 		subscription.update(
 				request.setStartEnabled(),
 				request.setEndEnabled(),
 				request.liveEventEnabled());
+		// 껐다 켠 것도 "이제부터 보겠다"는 의사표시다. 켜는 전환에서만 따라잡아 재호출로 카드가 쌓이지 않게 한다.
+		if (turnedOn) {
+			liveActivityCatchUpService.catchUpTeam(memberId, subscription.getTeam().getCode());
+		}
 		return toResponse(member, subscription);
 	}
 

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityCatchUpService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityCatchUpService.java
@@ -1,0 +1,124 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.live.ActiveLiveGame;
+import com.toy.nar.app.lolesports.live.LiveStateStore;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+/**
+ * 진행 중인 경기를 구독한 직후, 그 회원의 잠금화면 카드를 따라잡아 띄운다.
+ *
+ * <p>카드 생성(push-to-start)은 세트 첫 프레임을 관측한 순간 1회만 돈다
+ * ({@code LivePollingScheduler.startNotifiedGameIds} 게이트). 그래서 세트 진행 중에 구독하면
+ * 다음 세트 시작까지 카드가 없고, 마지막 세트(또는 bo1)였다면 경기 내내 없다.</p>
+ *
+ * <p>구독은 사용자가 명시적으로 누른 1회 이벤트라 그 시점에만 한 발 쏜다. 폴링마다 채우는 방식은
+ * 두 가지로 새는데, 지금은 앱이 카드 해제({@code DELETE /api/mobile/me/live-activities})를
+ * 호출하지 않아 우연히 가려져 있을 뿐이다: (1) 앱이 해제를 구현하면 사용자가 지운 카드를 매 tick
+ * 되살린다, (2) 카드는 떴지만 갱신 토큰 등록에 실패한 회원에게 카드를 계속 쌓는다.</p>
+ *
+ * <p>세트 사이(진행 중인 세트가 없는 휴식 구간)에는 띄우지 않는다 — 곧 오는 다음 세트 시작
+ * push-to-start 가 정상 경로로 커버한다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LiveActivityCatchUpService {
+
+	private final LiveStateStore liveStateStore;
+	private final LeagueMatchRepository leagueMatchRepository;
+	private final LiveActivityPushService pushService;
+
+	@Qualifier("applicationTaskExecutor")
+	private final Executor applicationTaskExecutor;
+
+	/** 경기 단위 구독 직후. 그 경기의 세트가 지금 진행 중이면 카드를 띄운다. */
+	public void catchUpMatch(Long memberId, String matchId) {
+		if (!ready(memberId) || matchId == null || matchId.isBlank()) {
+			return;
+		}
+		liveGameOf(matchId).ifPresent(game -> leagueMatchRepository.findById(matchId)
+				.ifPresent(match -> submit(memberId, match, game)));
+	}
+
+	/** 팀 구독(또는 세트 시작 알림 켜기) 직후. 그 팀의 진행 중인 경기 카드를 띄운다. */
+	public void catchUpTeam(Long memberId, String teamCode) {
+		if (!ready(memberId) || teamCode == null || teamCode.isBlank()) {
+			return;
+		}
+		liveGames().forEach(game -> leagueMatchRepository.findById(game.matchId())
+				.filter(match -> playsTeam(match, teamCode))
+				.ifPresent(match -> submit(memberId, match, game)));
+	}
+
+	private boolean ready(Long memberId) {
+		return memberId != null && pushService.isEnabled();
+	}
+
+	/** 지금 프레임이 들어오는(=종료 확정 전) 라이브 게임들. */
+	private java.util.stream.Stream<ActiveLiveGame> liveGames() {
+		return liveStateStore.getActiveGames().values().stream()
+				.filter(game -> game.matchId() != null && !game.matchId().isBlank())
+				.filter(game -> !liveStateStore.isFinished(game.gameId()));
+	}
+
+	private Optional<ActiveLiveGame> liveGameOf(String matchId) {
+		return liveGames().filter(game -> matchId.equals(game.matchId())).findFirst();
+	}
+
+	private boolean playsTeam(LeagueMatch match, String teamCode) {
+		return teamCode.equalsIgnoreCase(match.getBlueTeamCode())
+				|| teamCode.equalsIgnoreCase(match.getRedTeamCode());
+	}
+
+	/**
+	 * APNs 왕복을 요청 스레드에서 기다리지 않는다 — 구독 응답이 발송에 묶이면 안 된다.
+	 * 발송 실패가 구독 자체를 깨면 안 되므로 예외도 흡수한다.
+	 */
+	private void submit(Long memberId, LeagueMatch match, ActiveLiveGame game) {
+		int setNumber = setNumberOf(game, match);
+		applicationTaskExecutor.execute(() -> {
+			try {
+				log.info("[live-activity] 구독 직후 카드 생성 matchId={} memberId={} set={}",
+						match.getId(), memberId, setNumber);
+				// 세트마다 진영이 스왑되므로 팀 표기는 매치 기준을 쓴다(set-start 경로와 동일).
+				pushService.startCardForMember(
+						match.getId(),
+						memberId,
+						setNumber,
+						match.getBlueScore(),
+						match.getRedScore(),
+						new LiveActivityPushService.MatchCardAttributes(
+								match.getId(),
+								match.getBlueTeamName(), match.getBlueTeamCode(),
+								match.getRedTeamName(), match.getRedTeamCode(),
+								match.getLeagueName()));
+			} catch (Exception e) {
+				log.warn("[live-activity] 구독 직후 카드 생성 실패 matchId={} memberId={}: {}",
+						match.getId(), memberId, e.getMessage());
+			}
+		});
+	}
+
+	/**
+	 * 카드에 그릴 세트 번호. 라이브 게임이 아는 값이 먼저다.
+	 *
+	 * <p>ponytail: 업스트림 메타데이터가 없으면 확정 스코어 합 + 1 로 추정한다. 리메이크나
+	 * 스코어 반영 지연이면 한 세트 어긋날 수 있지만, 다음 세트 시작 푸시가 바로잡는다.</p>
+	 */
+	private int setNumberOf(ActiveLiveGame game, LeagueMatch match) {
+		if (game.setNumber() != null && game.setNumber() > 0) {
+			return game.setNumber();
+		}
+		int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
+		int red = match.getRedScore() == null ? 0 : match.getRedScore();
+		return blue + red + 1;
+	}
+}

--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -132,6 +132,45 @@ public class LiveActivityPushService {
 			log.warn("push-to-start 대상 조회 실패 matchId={}: {}", matchId, e.getMessage());
 			return;
 		}
+		sendStarts(matchId, setNumber, blueScore, redScore, attributes, targets);
+	}
+
+	/**
+	 * 회원 한 명에게만 카드를 새로 띄운다 — 진행 중인 경기를 구독한 직후의 따라잡기용.
+	 *
+	 * <p>{@link #startCards} 는 세트 첫 프레임 관측 때 1회만 돌기 때문에, 세트 진행 중에 구독한
+	 * 사람은 다음 세트 시작까지(마지막 세트였다면 경기 내내) 카드가 없다. 그 구멍만 메운다.</p>
+	 */
+	public void startCardForMember(
+			String matchId,
+			Long memberId,
+			int setNumber,
+			Integer blueScore,
+			Integer redScore,
+			MatchCardAttributes attributes) {
+		if (!isEnabled() || !pushToStartEnabled || memberId == null
+				|| matchId == null || matchId.isBlank()) {
+			return;
+		}
+		List<LiveActivityStartTokenRepository.StartTargetRow> targets;
+		try {
+			targets = startTokenRepository.findStartTargetsForMember(matchId, memberId);
+		} catch (Exception e) {
+			log.warn("push-to-start 대상 조회 실패 matchId={} memberId={}: {}",
+					matchId, memberId, e.getMessage());
+			return;
+		}
+		sendStarts(matchId, setNumber, blueScore, redScore, attributes, targets);
+	}
+
+	/** 대상 산정만 다르고 발송·죽은 토큰 정리는 같다. */
+	private void sendStarts(
+			String matchId,
+			int setNumber,
+			Integer blueScore,
+			Integer redScore,
+			MatchCardAttributes attributes,
+			List<LiveActivityStartTokenRepository.StartTargetRow> targets) {
 		if (targets.isEmpty()) {
 			return;
 		}

--- a/src/main/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionService.java
+++ b/src/main/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionService.java
@@ -1,6 +1,7 @@
 package com.toy.nar.app.mobile.subscription;
 
 import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.push.LiveActivityCatchUpService;
 import com.toy.nar.common.error.ErrorCode;
 import com.toy.nar.common.error.exception.CustomException;
 import com.toy.nar.domain.member.entity.Member;
@@ -25,6 +26,7 @@ public class MobileMatchSubscriptionService {
 	private final MemberMatchSubscriptionRepository subscriptionRepository;
 	private final MemberRepository memberRepository;
 	private final LeagueMatchRepository leagueMatchRepository;
+	private final LiveActivityCatchUpService liveActivityCatchUpService;
 
 	/** 내가 구독한 경기 matchId 목록. 앱이 리스트에서 벨 상태를 그리는 데 쓴다. */
 	public List<String> getSubscribedMatchIds(Long memberId) {
@@ -48,6 +50,10 @@ public class MobileMatchSubscriptionService {
 				.orElseThrow(() -> new CustomException(ErrorCode.DATA_NOT_FOUND));
 		subscriptionRepository.save(new MemberMatchSubscription(
 				member, matchId, setStartEnabled, setEndEnabled, liveEventEnabled));
+		if (setStartEnabled) {
+			// 진행 중인 경기를 지금 구독했으면 잠금화면 카드는 다음 세트까지 안 뜬다 — 따라잡는다.
+			liveActivityCatchUpService.catchUpMatch(memberId, matchId);
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/toy/nar/domain/member/repository/LiveActivityStartTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/LiveActivityStartTokenRepository.java
@@ -64,6 +64,32 @@ public interface LiveActivityStartTokenRepository extends JpaRepository<LiveActi
 			@Param("blueTeamId") Long blueTeamId,
 			@Param("redTeamId") Long redTeamId);
 
+	/**
+	 * 회원 한 명에게 이 경기 카드를 띄워 줄 대상(없으면 빈 목록).
+	 *
+	 * <p>{@link #findStartTargets} 와 달리 구독 조건을 다시 보지 않는다 — 호출 근거가
+	 * "이 회원이 방금 이 경기를 구독했다"는 액션 자체이고, 그 구독 행은 아직 같은 트랜잭션
+	 * 안에 있어(커밋 전) 이 쿼리로는 보이지 않을 수도 있다.</p>
+	 *
+	 * <p>이미 카드가 떠 있는 회원을 제외하는 조건은 그대로 둔다. 같은 경기 카드가 두 장 뜨는 것을
+	 * 막는 유일한 장치다.</p>
+	 */
+	@Query("""
+			SELECT t.pushToken AS pushToken, m.id AS memberId, ft.code AS favoriteTeamCode
+			FROM LiveActivityStartToken t
+			JOIN t.member m
+			LEFT JOIN m.favoriteTeam ft
+			WHERE t.active = true
+			  AND m.id = :memberId
+			  AND NOT EXISTS (
+				  SELECT a.id FROM LiveActivityToken a
+				  WHERE a.member = m AND a.matchId = :matchId AND a.active = true
+			  )
+			""")
+	List<StartTargetRow> findStartTargetsForMember(
+			@Param("matchId") String matchId,
+			@Param("memberId") Long memberId);
+
 	/** APNs 가 거절한(410 등) 토큰은 더 쓰지 않는다. */
 	@Transactional
 	@Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/test/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/notification/MobileTeamNotificationServiceTest.java
@@ -36,7 +36,9 @@ class MobileTeamNotificationServiceTest {
 		memberRepository = mock(MemberRepository.class);
 		teamRepository = mock(TeamRepository.class);
 		subscriptionRepository = mock(MemberTeamNotificationSubscriptionRepository.class);
-		service = new MobileTeamNotificationService(memberRepository, teamRepository, subscriptionRepository);
+		service = new MobileTeamNotificationService(
+				memberRepository, teamRepository, subscriptionRepository,
+				mock(com.toy.nar.app.mobile.push.LiveActivityCatchUpService.class));
 	}
 
 	@Test

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityCatchUpServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityCatchUpServiceTest.java
@@ -1,0 +1,141 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.live.ActiveLiveGame;
+import com.toy.nar.app.lolesports.live.LiveStateStore;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LiveActivityCatchUpServiceTest {
+
+	private static final String MATCH_ID = "match-1";
+	private static final String GAME_ID = "game-1";
+
+	private LiveStateStore liveStateStore;
+	private LeagueMatchRepository leagueMatchRepository;
+	private LiveActivityPushService pushService;
+	private LiveActivityCatchUpService catchUpService;
+
+	@BeforeEach
+	void setUp() {
+		liveStateStore = mock(LiveStateStore.class);
+		leagueMatchRepository = mock(LeagueMatchRepository.class);
+		pushService = mock(LiveActivityPushService.class);
+		// 테스트에서는 즉시 실행 — 프로덕션은 applicationTaskExecutor 로 비동기.
+		catchUpService = new LiveActivityCatchUpService(
+				liveStateStore, leagueMatchRepository, pushService, Runnable::run);
+		when(pushService.isEnabled()).thenReturn(true);
+	}
+
+	@Test
+	void 진행_중인_경기를_구독하면_그_회원에게_카드를_띄운다() {
+		liveGame(2);
+		match();
+
+		catchUpService.catchUpMatch(7L, MATCH_ID);
+
+		verify(pushService).startCardForMember(eq(MATCH_ID), eq(7L), eq(2), eq(1), eq(0), any());
+	}
+
+	@Test
+	void 세트_번호가_없으면_스코어_합_다음_세트로_추정한다() {
+		liveGame(null);
+		match();
+
+		catchUpService.catchUpMatch(7L, MATCH_ID);
+
+		// 1:0 이면 지금 진행 중인 세트는 2세트다.
+		verify(pushService).startCardForMember(eq(MATCH_ID), eq(7L), eq(2), eq(1), eq(0), any());
+	}
+
+	@Test
+	void 진행_중인_세트가_없으면_띄우지_않는다() {
+		when(liveStateStore.getActiveGames()).thenReturn(Map.of());
+
+		catchUpService.catchUpMatch(7L, MATCH_ID);
+
+		verifyNoStart();
+	}
+
+	@Test
+	void 종료_확정된_세트의_잔상으로는_띄우지_않는다() {
+		liveGame(2);
+		when(liveStateStore.isFinished(GAME_ID)).thenReturn(true);
+
+		catchUpService.catchUpMatch(7L, MATCH_ID);
+
+		verifyNoStart();
+	}
+
+	@Test
+	void 팀_구독은_그_팀이_뛰는_진행_중_경기만_띄운다() {
+		liveGame(2);
+		match();
+
+		catchUpService.catchUpTeam(7L, "blu");
+
+		verify(pushService).startCardForMember(eq(MATCH_ID), eq(7L), eq(2), eq(1), eq(0), any());
+	}
+
+	@Test
+	void 팀_구독에서_그_팀이_없는_경기는_건너뛴다() {
+		liveGame(2);
+		match();
+
+		catchUpService.catchUpTeam(7L, "T1");
+
+		verifyNoStart();
+	}
+
+	@Test
+	void APNs_가_꺼져_있으면_아무것도_하지_않는다() {
+		when(pushService.isEnabled()).thenReturn(false);
+
+		catchUpService.catchUpMatch(7L, MATCH_ID);
+
+		verifyNoStart();
+	}
+
+	private void liveGame(Integer setNumber) {
+		ActiveLiveGame game = new ActiveLiveGame(
+				GAME_ID, MATCH_ID, "LCK", "Blue", "Red", LocalDateTime.now(), 0,
+				setNumber, null, null);
+		when(liveStateStore.getActiveGames()).thenReturn(Map.of(GAME_ID, game));
+	}
+
+	private void match() {
+		LeagueMatch match = LeagueMatch.builder()
+				.id(MATCH_ID)
+				.leagueName("LCK")
+				.state("inProgress")
+				.blueTeamCode("BLU")
+				.blueTeamName("Blue")
+				.redTeamCode("RED")
+				.redTeamName("Red")
+				.blueScore(1)
+				.redScore(0)
+				.bestOf(3)
+				.build();
+		when(leagueMatchRepository.findById(MATCH_ID)).thenReturn(Optional.of(match));
+	}
+
+	private void verifyNoStart() {
+		verify(pushService, never())
+				.startCardForMember(anyString(), anyLong(), anyInt(), any(), any(), any());
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionServiceTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/subscription/MobileMatchSubscriptionServiceTest.java
@@ -30,12 +30,16 @@ class MobileMatchSubscriptionServiceTest {
 	@Mock
 	private LeagueMatchRepository leagueMatchRepository;
 
+	@Mock
+	private com.toy.nar.app.mobile.push.LiveActivityCatchUpService liveActivityCatchUpService;
+
 	private MobileMatchSubscriptionService service;
 
 	@BeforeEach
 	void setUp() {
 		service = new MobileMatchSubscriptionService(
-				subscriptionRepository, memberRepository, leagueMatchRepository);
+				subscriptionRepository, memberRepository, leagueMatchRepository,
+				liveActivityCatchUpService);
 	}
 
 	@Test


### PR DESCRIPTION
## 문제

세트 진행 중에 구독하면 잠금화면 라이브위젯 카드가 안 뜬다. 다음 세트 시작까지 기다려야 하고, 마지막 세트나 bo1 이면 경기 내내 안 뜬다.

카드 생성(push-to-start)이 도는 지점이 딱 하나뿐이다 — `LivePollingScheduler` 가 세트 첫 프레임을 관측한 순간(`startNotifiedGameIds` 게이트로 gameId당 1회) → `LiveActivityPushService.startCards`. 그 외엔 만드는 경로가 없다:

| 경로 | 카드 생성 |
|---|---|
| 경기 구독 API | ❌ DB 행만 |
| 팀 알림 구독/토글 | ❌ LiveActivity 참조 없음 |
| 앱 | ❌ 2026-08 에 표시 경로 접음(`live_match_activity_controller` 는 정리만) |
| orphan 스윕 | ❌ 닫기 전용 |

## 수정

구독 액션 시점에 그 회원 한 명에게 push-to-start 한 발.

- **`LiveActivityCatchUpService`** — `LiveStateStore` 에 라이브 게임이 있는 매치에만 발송(세트 사이 휴식 구간은 곧 오는 세트 시작 푸시가 커버하므로 건너뜀). 세트 번호는 라이브 게임 값 우선, 없으면 확정 스코어 합 + 1. APNs 왕복은 `applicationTaskExecutor` 로 넘겨 구독 응답을 붙잡지 않는다.
- **`findStartTargetsForMember`** — 회원 1명 대상 쿼리. 구독 조건은 다시 보지 않는다(호출 근거가 구독 액션 자체이고, 그 행은 아직 같은 트랜잭션 안이라 커밋 전이면 안 보인다). 같은 경기 카드 2장을 막는 `NOT EXISTS(active LiveActivityToken)` 는 유지.
- **훅 3곳** — 경기 구독 신규 생성(`setStartEnabled` 일 때), 팀 구독 신규 생성, 세트시작 알림 `off→on` 전환. 전환 시점만 잡아 재호출로 카드가 쌓이지 않게 한다.

## 폴링마다 채우지 않은 이유

폴링 백필이 더 짧지만 두 군데서 샌다. 지금은 앱이 카드 해제(`DELETE /api/mobile/me/live-activities`)를 **호출하지 않아서** 우연히 가려져 있을 뿐이다:

1. 앱이 해제를 구현하면(포그라운드 reconcile) 사용자가 지운 카드를 매 tick 되살린다.
2. 카드는 떴지만 갱신 토큰 등록에 실패한 회원(백그라운드 wake 실패, JWT 만료)에게 매 tick 새 카드를 쌓는다.

구독은 사용자가 명시적으로 누른 1회 이벤트라 의미상으로도 여기가 맞다.

## 테스트

`LiveActivityCatchUpServiceTest` 7건 — 진행 중 구독 발송 / 세트번호 추정 / 라이브 없음 / 종료 확정 잔상 제외 / 팀 구독 매칭·비매칭 / APNs off.

```
./gradlew test --tests "com.toy.nar.app.mobile.push.*" --tests "com.toy.nar.app.mobile.notification.*" --tests "com.toy.nar.app.mobile.subscription.*"
BUILD SUCCESSFUL
```

## 남은 것 (이 PR 범위 아님)

- 유령 갱신 토큰: 사용자가 카드를 지워도 서버 B토큰이 active 로 남는다. 앱 reconcile 이 필요하고, 그게 들어오면 위 1번 위험이 실재화되므로 폴링 백필은 계속 쓰지 않는 게 맞다.
- `APNS_PUSH_TO_START_ENABLED` 가 off 면 이 경로도 전부 no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)