### PR TITLE
fix: 마이구독 알림함을 푸시 발송 전에 적재

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
+++ b/src/main/java/com/toy/nar/app/mobile/notification/MemberNotificationService.java
@@ -17,9 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -51,9 +49,12 @@ public class MemberNotificationService {
 	/**
 	 * 여러 구독자에게 같은 알림을 한 번에 기록한다.
 	 *
-	 * <p>fan-out 에서 구독자마다 {@link #record} 를 부르면 INSERT 왕복이 구독자 수만큼 난다.
-	 * saveAll 로 넘기면 {@code hibernate.jdbc.batch_size}(50) 단위로 묶이고,
-	 * prod 는 {@code rewriteBatchedStatements=true} 라 다중 VALUES 로 다시 쓰인다.</p>
+	 * <p>다중 VALUES INSERT 로 직접 넣는다({@code insertAll}). {@code saveAll} 은 이 엔티티에서
+	 * 배치가 안 된다 — id 가 {@code GenerationType.IDENTITY} 라 Hibernate 가 INSERT 배치를
+	 * 비활성화하고, 그러면 왕복이 구독자 수만큼 난다({@code hibernate.jdbc.batch_size} 무관).
+	 * 프로덕션은 앱(EC2 서울)과 DB(OCI 춘천)가 떨어져 있어 왕복당 10ms 대이고, 실측
+	 * 2026-08-11 Zeus 구독 1,440명 적재가 약 20초였다. 팬아웃이 발송 전에 피드를 남기므로
+	 * 이 시간이 그대로 푸시 지연이 된다.</p>
 	 */
 	@Transactional
 	public void recordAll(
@@ -62,16 +63,7 @@ public class MemberNotificationService {
 			String title,
 			String body,
 			Map<String, String> data) {
-		if (memberIds == null || memberIds.isEmpty() || type == null || title == null) {
-			return;
-		}
-		List<MemberNotification> notifications = memberIds.stream()
-				.filter(Objects::nonNull)
-				.distinct()
-				.map(memberId -> new MemberNotification(
-						memberRepository.getReferenceById(memberId), type, title, body, data))
-				.toList();
-		notificationRepository.saveAll(notifications);
+		notificationRepository.insertAll(memberIds, type, title, body, data);
 	}
 
 	public MemberNotificationListResponse getNotifications(

--- a/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushService.java
@@ -135,6 +135,17 @@ public class PlayerSoloRankPushService {
 			return;
 		}
 
+		// 알림함(마이구독 피드)은 발송 '전에' 남긴다. 예전엔 멀티캐스트와 마감 뒤에 기록해서,
+		// 푸시를 받고 바로 마이구독을 열면 아직 행이 없었다 — 2026-08-11 프로덕션 실측
+		// (Zeus 구독 1,440명): 예약 00:12:23 → 발송 완료 00:12:33 → 피드 INSERT 00:12:53 로
+		// 기기 수신부터 약 29초. 그 화면은 진입·복귀 때만 다시 읽기 때문에 한 번 비면
+		// 나갔다 들어오기 전까지 계속 비어 있었다. 구독자가 많은 선수일수록 확실히 터진다.
+		//
+		// ponytail: 발송이 실패한 회원도 피드에 남는다(실측 6,181건 중 FAILED 1건). 재예약된
+		// 재시도라면 같은 알림이 두 줄 남을 수 있는데, 그 빈도가 위 지연보다 훨씬 낮아
+		// dedup 장치는 두지 않는다. 필요해지면 (member, playerId, gameId) 유니크로 막는다.
+		recordFeedAll(tokensByMember.keySet(), message);
+
 		List<String> allTokens = tokensByMember.values().stream().flatMap(List::stream).toList();
 		QuietAwarePushSender.Outcome outcome;
 		try {
@@ -166,10 +177,9 @@ public class PlayerSoloRankPushService {
 		});
 
 		markSentAll(delivered, player.getId(), gameId);
+		// 잠자기로 건너뛴 회원은 발송 없이 마감만 한다 — 알림함에는 위에서 이미 남겼다.
 		markSkippedQuietAll(outcome.skippedMemberIds(), player.getId(), gameId);
 		markFailedAll(undelivered, player.getId(), gameId, "FCM 전송 성공 기기가 없습니다.");
-		// 건너뛴 회원도 알림함에는 남는다 — 앱을 열면 밤에 무슨 알림이 있었는지 보인다.
-		recordFeedAll(concat(delivered, outcome.skippedMemberIds()), message);
 
 		if (!result.invalidTokens().isEmpty()) {
 			deactivateInvalidTokens(result.invalidTokens(), player.getId(), gameId);
@@ -221,16 +231,6 @@ public class PlayerSoloRankPushService {
 					memberIds.size(),
 					e);
 		}
-	}
-
-	/** 발송 성공 회원 + 잠자기로 건너뛴 회원을 합친다. 둘 다 알림함에는 남는다. */
-	private static List<Long> concat(List<Long> delivered, List<Long> skipped) {
-		if (skipped.isEmpty()) {
-			return delivered;
-		}
-		List<Long> all = new ArrayList<>(delivered);
-		all.addAll(skipped);
-		return all;
 	}
 
 	private void markFailedAll(

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -382,6 +382,10 @@ public class TeamLiveEventPushService {
 			return;
 		}
 
+		// 알림함(마이구독 피드)은 발송 '전에' 남긴다 — 근거는 PlayerSoloRankPushService 의
+		// 같은 지점 주석 참고(발송 뒤에 기록하면 푸시 받고 바로 마이구독을 열었을 때 비어 있다).
+		recordFeedAll(List.copyOf(tokensByMember.keySet()), eventType, message);
+
 		List<String> allTokens = tokensByMember.values().stream().flatMap(List::stream).toList();
 		QuietAwarePushSender.Outcome outcome;
 		try {
@@ -409,10 +413,9 @@ public class TeamLiveEventPushService {
 		});
 
 		markSentAll(delivered, matchId, setNumber, eventType, eventOrder);
+		// 잠자기로 건너뛴 구독자는 발송 없이 마감만 한다 — 알림함에는 위에서 이미 남겼다.
 		markSkippedQuietAll(outcome.skippedMemberIds(), matchId, setNumber, eventType, eventOrder);
 		markFailedAll(undelivered, matchId, setNumber, eventType, eventOrder, "FCM 전송 성공 기기가 없습니다.");
-		// 건너뛴 구독자도 알림함에는 남는다 — 앱을 열면 밤에 무슨 알림이 있었는지 보인다.
-		recordFeedAll(concat(delivered, outcome.skippedMemberIds()), eventType, message);
 
 		if (!result.invalidTokens().isEmpty()) {
 			deactivateInvalidTokens(result.invalidTokens(), matchId, eventType);
@@ -444,16 +447,6 @@ public class TeamLiveEventPushService {
 			log.warn("Failed to mark team live event pushes quiet-skipped eventType={} matchId={} setNumber={} members={}",
 					eventType, matchId, setNumber, memberIds.size(), e);
 		}
-	}
-
-	/** 발송 성공 구독자 + 잠자기로 건너뛴 구독자를 합친다. 둘 다 알림함에는 남는다. */
-	private static List<Long> concat(List<Long> delivered, List<Long> skipped) {
-		if (skipped.isEmpty()) {
-			return delivered;
-		}
-		List<Long> all = new ArrayList<>(delivered);
-		all.addAll(skipped);
-		return all;
 	}
 
 	private void markFailedAll(

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepository.java
@@ -12,7 +12,8 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
+public interface MemberNotificationRepository
+		extends JpaRepository<MemberNotification, Long>, MemberNotificationRepositoryCustom {
 
 	Page<MemberNotification> findByMember_IdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepositoryCustom.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepositoryCustom.java
@@ -1,0 +1,30 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface MemberNotificationRepositoryCustom {
+
+	/**
+	 * 같은 알림 1건을 여러 회원에게 한 번에 적재한다.
+	 *
+	 * <p>{@code saveAll} 로는 왕복이 회원 수만큼 난다 — {@code MemberNotification} 의 id 가
+	 * {@code GenerationType.IDENTITY} 라서 Hibernate 가 INSERT 배치를 아예 비활성화한다
+	 * ({@code hibernate.jdbc.batch_size} 와 무관하다). 프로덕션은 앱(EC2 서울)과 DB(OCI 춘천)가
+	 * 분리돼 있어 왕복당 10ms 대이고, 실측 2026-08-11 Zeus 구독 1,440명 적재가 약 20초였다.</p>
+	 *
+	 * <p>그래서 다중 VALUES 로 직접 넣는다({@code PlayerSoloRankPushDeliveryRepositoryImpl}
+	 * 과 같은 방식). 팬아웃이 푸시 발송 전에 피드를 남기므로, 이 적재 시간이 곧 알림 지연이 된다.</p>
+	 *
+	 * @param data JSON 컬럼에 그대로 보존할 푸시 payload. null 이면 컬럼도 null.
+	 * @return 적재한 행 수
+	 */
+	int insertAll(
+			Collection<Long> memberIds,
+			MemberNotificationType type,
+			String title,
+			String body,
+			Map<String, String> data);
+}

--- a/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepositoryImpl.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/MemberNotificationRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.toy.nar.domain.member.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MemberNotificationRepositoryImpl implements MemberNotificationRepositoryCustom {
+
+	/** 한 INSERT 에 담을 최대 행 수. SQL 이 과하게 길어지지 않게 나눈다. */
+	private static final int CHUNK_SIZE = 500;
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Override
+	public int insertAll(
+			Collection<Long> memberIds,
+			MemberNotificationType type,
+			String title,
+			String body,
+			Map<String, String> data) {
+		if (memberIds == null || memberIds.isEmpty() || type == null || title == null) {
+			return 0;
+		}
+		List<Long> targets = memberIds.stream()
+				.filter(Objects::nonNull)
+				.collect(Collectors.toCollection(LinkedHashSet::new))
+				.stream()
+				.toList();
+		if (targets.isEmpty()) {
+			return 0;
+		}
+		String dataJson = toJson(data);
+
+		int inserted = 0;
+		for (int start = 0; start < targets.size(); start += CHUNK_SIZE) {
+			List<Long> chunk = targets.subList(start, Math.min(start + CHUNK_SIZE, targets.size()));
+			// created_at 은 DB NOW() 가 아니라 애플리케이션 시각을 쓴다 — 기존 엔티티 경로
+			// (LocalDateTime.now())와 같은 시간대여야 피드 정렬이 섞이지 않는다. DB 서버는 UTC 다.
+			String values = chunk.stream()
+					.map(id -> "(?, ?, ?, ?, ?, NULL, ?)")
+					.collect(Collectors.joining(", "));
+			List<Object> params = new ArrayList<>();
+			java.time.LocalDateTime now = java.time.LocalDateTime.now();
+			for (Long memberId : chunk) {
+				params.add(memberId);
+				params.add(type.name());
+				params.add(title);
+				params.add(body);
+				params.add(dataJson);
+				params.add(now);
+			}
+			inserted += jdbcTemplate.update(
+					"INSERT INTO member_notification"
+							+ " (member_id, type, title, body, data, read_at, created_at) VALUES "
+							+ values,
+					params.toArray());
+		}
+		return inserted;
+	}
+
+	private String toJson(Map<String, String> data) {
+		if (data == null || data.isEmpty()) {
+			return null;
+		}
+		try {
+			return OBJECT_MAPPER.writeValueAsString(data);
+		} catch (JsonProcessingException e) {
+			// data 는 딥링크용 부가 정보다. 직렬화가 깨져도 알림 자체는 남기는 게 낫다.
+			log.warn("알림 data 직렬화 실패 — data 없이 적재한다: {}", e.getMessage());
+			return null;
+		}
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushFanOutBatchTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/PlayerSoloRankPushFanOutBatchTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collection;
@@ -23,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -76,7 +78,7 @@ class PlayerSoloRankPushFanOutBatchTest {
 		verify(deliveryRepository).markSkippedQuietAll(List.of(8L), PLAYER_ID, GAME_ID);
 		// FAILED 로 남으면 재예약돼서 잠자기가 끝난 뒤 뒤늦은 푸시가 나간다.
 		verify(deliveryRepository, never()).markFailedAll(any(), any(), any(), any());
-		// 알림함에는 발송 성공 회원과 건너뛴 회원이 모두 남아야 한다.
+		// 알림함에는 발송 성공 회원과 건너뛴 회원이 모두 남아야 한다(발송 전에 예약자 전원으로 기록).
 		ArgumentCaptor<Collection<Long>> feed = ArgumentCaptor.forClass(Collection.class);
 		verify(notificationService).recordAll(feed.capture(), any(), anyString(), any(), any());
 		assertThat(feed.getValue()).containsExactlyInAnyOrder(7L, 8L);
@@ -119,10 +121,11 @@ class PlayerSoloRankPushFanOutBatchTest {
 
 		assertThat(capturedIds(sentCaptor())).containsExactly(8L);
 		assertThat(capturedIds(failedCaptor())).containsExactly(7L);
-		// 발송 기록도 성공한 구독자만
+		// 알림함은 발송 전에 예약자 전원으로 남긴다 — FCM 실패자(7번)도 포함된다.
+		// 발송 결과를 기다리면 푸시를 받고 바로 마이구독을 열었을 때 비어 있다.
 		ArgumentCaptor<Collection<Long>> recorded = ArgumentCaptor.forClass(Collection.class);
 		verify(notificationService).recordAll(recorded.capture(), any(), anyString(), any(), any());
-		assertThat(recorded.getValue()).containsExactly(8L);
+		assertThat(recorded.getValue()).containsExactlyInAnyOrder(7L, 8L);
 	}
 
 	@Test
@@ -166,6 +169,25 @@ class PlayerSoloRankPushFanOutBatchTest {
 				.markFailedAll(failed.capture(), eq(PLAYER_ID), eq(GAME_ID), eq("firebase down"));
 		assertThat(failed.getValue()).containsExactly(7L, 8L);
 		verify(deliveryRepository, never()).markSentAll(any(), anyLong(), anyString());
+		// FCM 이 죽어도 알림함에는 남는다 — 앱을 열면 무슨 알림이 있었는지는 보여야 한다.
+		verify(notificationService).recordAll(any(), any(), anyString(), any(), any());
+	}
+
+	@Test
+	@DisplayName("알림함 기록이 FCM 발송보다 먼저 일어난다")
+	void 피드를_발송_전에_남긴다() {
+		givenSubscribers(device(1L, member(7L), "token-1"));
+		when(deliveryRepository.reserveAll(any(), eq(PLAYER_ID), eq(GAME_ID))).thenReturn(List.of(7L));
+		when(quietAwarePushSender.send(any(), any())).thenReturn(new QuietAwarePushSender.Outcome(
+				new MobilePushResult(1, 0, List.of(), List.of("token-1")), List.of()));
+
+		notifyGame();
+
+		// 발송 뒤에 기록하면 푸시를 받고 바로 마이구독을 열었을 때 그 알림이 없다.
+		// 실측 2026-08-11(Zeus 구독 1,440명): 기기 수신 → 피드 INSERT 까지 약 29초.
+		InOrder order = inOrder(notificationService, quietAwarePushSender);
+		order.verify(notificationService).recordAll(any(), any(), anyString(), any(), any());
+		order.verify(quietAwarePushSender).send(any(), any());
 	}
 
 	private void notifyGame() {

--- a/src/test/java/com/toy/nar/domain/member/repository/MemberNotificationRepositoryImplTest.java
+++ b/src/test/java/com/toy/nar/domain/member/repository/MemberNotificationRepositoryImplTest.java
@@ -1,0 +1,103 @@
+package com.toy.nar.domain.member.repository;
+
+import com.toy.nar.domain.member.entity.MemberNotificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * 알림 피드 적재가 구독자 수와 무관하게 상수 왕복인지 지키는 테스트.
+ *
+ * <p>{@code saveAll} 은 이 엔티티에서 배치가 안 된다 — id 가 {@code GenerationType.IDENTITY} 라
+ * Hibernate 가 INSERT 배치를 비활성화한다. 프로덕션(앱 EC2 서울 / DB OCI 춘천, 왕복 10ms 대)에서
+ * 구독 1,440명 적재가 약 20초였고, 팬아웃이 발송 전에 피드를 남기므로 그게 곧 푸시 지연이 된다.</p>
+ */
+class MemberNotificationRepositoryImplTest {
+
+	private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+	private final MemberNotificationRepositoryImpl repository =
+			new MemberNotificationRepositoryImpl(jdbcTemplate);
+
+	@Test
+	@DisplayName("구독자 1,440명을 500행씩 3번의 INSERT 로 적재한다")
+	void 구독자_수와_무관하게_왕복이_상수다() {
+		when(jdbcTemplate.update(anyString(), any(Object[].class))).thenReturn(500);
+
+		repository.insertAll(
+				LongStream.rangeClosed(1, 1_440).boxed().toList(),
+				MemberNotificationType.PLAYER_SOLO_RANK_STARTED,
+				"Zeus 선수가 솔랭을 시작했어요",
+				"아리로 솔로 랭크 플레이 중",
+				Map.of("type", "PLAYER_SOLO_RANK_STARTED", "playerId", "383"));
+
+		// 1,440 = 500 + 500 + 440 → 3회. 행마다 왕복하면 1,440회다.
+		verify(jdbcTemplate, times(3)).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	@DisplayName("한 INSERT 에 행 수만큼 VALUES 를 싣고 컬럼 7개를 바인딩한다")
+	void 다중_VALUES_로_넣는다() {
+		when(jdbcTemplate.update(anyString(), any(Object[].class))).thenReturn(3);
+		ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<Object[]> params = ArgumentCaptor.forClass(Object[].class);
+
+		repository.insertAll(
+				List.of(7L, 8L, 9L),
+				MemberNotificationType.SET_START,
+				"T1 vs GEN 1세트 시작",
+				"1세트 시작",
+				Map.of("matchId", "115548147900750245"));
+
+		verify(jdbcTemplate).update(sql.capture(), params.capture());
+		assertThat(sql.getValue()).startsWith("INSERT INTO member_notification");
+		assertThat(sql.getValue()).contains("(?, ?, ?, ?, ?, NULL, ?), (?, ?, ?, ?, ?, NULL, ?), (?, ?, ?, ?, ?, NULL, ?)");
+		// member_id, type, title, body, data, created_at → 행당 6개 바인딩(read_at 은 상수 NULL)
+		assertThat(params.getValue()).hasSize(18);
+		assertThat(params.getValue()[0]).isEqualTo(7L);
+		assertThat(params.getValue()[1]).isEqualTo("SET_START");
+		// data 는 JSON 문자열로 직렬화돼 들어간다.
+		assertThat(params.getValue()[4]).isEqualTo("{\"matchId\":\"115548147900750245\"}");
+	}
+
+	@Test
+	@DisplayName("같은 회원이 두 번 들어와도 한 행만 적재한다")
+	void 중복_회원은_한_번만_넣는다() {
+		when(jdbcTemplate.update(anyString(), any(Object[].class))).thenReturn(1);
+		ArgumentCaptor<Object[]> params = ArgumentCaptor.forClass(Object[].class);
+
+		repository.insertAll(
+				List.of(7L, 7L, 7L),
+				MemberNotificationType.LIVE_EVENT,
+				"제목",
+				"본문",
+				null);
+
+		verify(jdbcTemplate).update(anyString(), params.capture());
+		assertThat(params.getValue()).hasSize(6);
+		// data 가 없으면 컬럼도 null 이다.
+		assertThat(params.getValue()[4]).isNull();
+	}
+
+	@Test
+	@DisplayName("대상이 없거나 필수 값이 비면 DB 를 건드리지 않는다")
+	void 빈_입력은_왕복하지_않는다() {
+		assertThat(repository.insertAll(List.of(), MemberNotificationType.SET_END, "제목", null, null)).isZero();
+		assertThat(repository.insertAll(List.of(7L), null, "제목", null, null)).isZero();
+		assertThat(repository.insertAll(List.of(7L), MemberNotificationType.SET_END, null, null, null)).isZero();
+		verifyNoInteractions(jdbcTemplate);
+	}
+}


### PR DESCRIPTION
## 문제

솔랭 푸시를 받고 바로 마이구독을 열면 **방금 온 알림이 목록에 없다.**

팬아웃 순서가 이랬다 (`PlayerSoloRankPushService.fanOutBatched`):

```
reserveAll → FCM 멀티캐스트 → markSent/markSkipped/markFailed → recordFeedAll(피드 INSERT)
```

2026-08-11 프로덕션 실측 (Zeus, 구독 1,440명):

| 시점 | KST |
|---|---|
| 예약(발송 직전) | 00:12:23 |
| 발송 완료 `sent_at` | 00:12:33 |
| 피드 행 `created_at` | 00:12:53 |

기기 수신부터 피드 INSERT까지 **약 29초**. 구독자 수에 비례한다 — 287명 1초, 1,152명 5초, 1,440명 12초(발송)+20초(피드).

그리고 피드 화면은 진입·앱 복귀 때만 서버를 다시 읽는다. 푸시 탭으로 들어간 그 한 번이 비면 **나갔다 들어오기 전까지 계속 비어 있다.**

## 수정

예약 직후, 발송 전에 적재한다.

```
reserveAll → recordFeedAll ← 여기 → FCM 멀티캐스트 → markSent/markSkipped/markFailed
```

발송 성공 여부는 `player_solo_rank_push_delivery` / `member_team_event_push_delivery` 가 따로 기록한다. 알림함은 "무슨 알림이 왔는지" 보여주는 곳이라 FCM 결과를 기다릴 이유가 없다 — FCM 이 죽어도 알림함에는 남는 편이 낫다.

솔랭·팀 라이브 이벤트 두 경로가 같은 순서였고 함께 고쳤다. 발송 뒤 `concat(delivered, skipped)` 헬퍼는 쓰는 곳이 없어져 양쪽에서 삭제.

## 대가

- 발송이 실패한 회원도 피드에 남는다 (실측 6,181건 중 FAILED 1건).
- 재예약된 재시도(FAILED → PENDING)면 같은 알림이 두 줄 남을 수 있다. 빈도가 위 지연보다 훨씬 낮아 dedup 은 두지 않았다 — 필요해지면 `(member, playerId, gameId)` 유니크로 막는다.

## 테스트

```
PlayerSoloRankPushFanOutBatchTest   tests=7 failures=0   (+ 순서 검증 1건 신규)
TeamLiveEventPushFanOutBatchTest    tests=5 failures=0
PlayerSoloRankPushServiceTest       tests=4 failures=0
TeamLiveEventPushServiceBestOfTest  tests=5 failures=0
```

신규: `피드를_발송_전에_남긴다` — `InOrder` 로 `recordAll` 이 `send` 보다 먼저 호출되는지 고정. 기존 테스트 중 "발송 성공자만 피드에 남는다" 기대는 새 계약(예약자 전원)으로 갱신했고, 발송 예외 케이스에는 "FCM 이 죽어도 알림함에는 남는다" 검증을 추가했다.

## 앱 쪽 짝

앱이 떠 있는 채로 푸시를 받으면 복귀 이벤트가 없어 피드가 그대로였다 — warding-mobile-repo PR 로 포그라운드 수신 시 재조회 훅을 넣었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)