### PR TITLE
fix: 카드를 지운 뒤 재구독하면 라이브위젯이 다시 뜨게

### DIFF
--- a/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/LiveActivityPushService.java
@@ -140,6 +140,11 @@ public class LiveActivityPushService {
 	 *
 	 * <p>{@link #startCards} 는 세트 첫 프레임 관측 때 1회만 돌기 때문에, 세트 진행 중에 구독한
 	 * 사람은 다음 세트 시작까지(마지막 세트였다면 경기 내내) 카드가 없다. 그 구멍만 메운다.</p>
+	 *
+	 * <p>발행 전에 그 회원의 이전 카드를 닫는다. 사용자가 잠금화면에서 카드를 지워도 서버는
+	 * 모르므로(앱에 해제 호출 경로가 없다) 갱신 토큰이 유령으로 남아 중복 방지 조건에 걸려
+	 * 재신청해도 카드가 다시 뜨지 않았다 — 실측 2026-08-12 DK vs KT: 카드 삭제 뒤 구독
+	 * 해제·재신청에도 발송 0건. 이전 카드가 실제로 살아있었다면 닫히므로 두 장이 되지 않는다.</p>
 	 */
 	public void startCardForMember(
 			String matchId,
@@ -152,6 +157,7 @@ public class LiveActivityPushService {
 				|| matchId == null || matchId.isBlank()) {
 			return;
 		}
+		closePreviousCard(matchId, memberId, setNumber, blueScore, redScore);
 		List<LiveActivityStartTokenRepository.StartTargetRow> targets;
 		try {
 			targets = startTokenRepository.findStartTargetsForMember(matchId, memberId);
@@ -161,6 +167,45 @@ public class LiveActivityPushService {
 			return;
 		}
 		sendStarts(matchId, setNumber, blueScore, redScore, attributes, targets);
+	}
+
+	/**
+	 * 이 회원의 이 경기 카드를 즉시 닫고 갱신 토큰을 비활성화한다. 카드가 이미 없으면
+	 * APNs 가 200 을 주고 아무 일도 일어나지 않으므로(유령 토큰) 무해하다.
+	 *
+	 * <p>발송 성공 여부와 무관하게 토큰을 정리한다 — 유령 토큰이 남아 재발행을 계속 막는 쪽이
+	 * 카드가 잠깐 두 장 보이는 것보다 나쁘다. 정리는 새 카드 대상 조회보다 먼저 끝나야 한다
+	 * (조회의 중복 방지 조건이 이 토큰을 보고 대상에서 제외한다).</p>
+	 */
+	private void closePreviousCard(
+			String matchId, Long memberId, int setNumber, Integer blueScore, Integer redScore) {
+		List<String> previousTokens;
+		try {
+			previousTokens = tokenRepository.findActivePushTokensByMemberIdAndMatchId(memberId, matchId);
+		} catch (Exception e) {
+			log.warn("이전 카드 토큰 조회 실패 matchId={} memberId={}: {}", matchId, memberId, e.getMessage());
+			return;
+		}
+		if (previousTokens.isEmpty()) {
+			return;
+		}
+		Map<String, Object> state = contentState(PHASE_PLAYING, setNumber, blueScore, redScore, "", null);
+		for (String pushToken : previousTokens) {
+			try {
+				// dismissal-date 를 지금으로 둬 카드가 바로 사라지게 한다. 새 카드가 곧 뜨므로
+				// 매치 종료(30분 유지)와 달리 남겨둘 이유가 없다.
+				apnsClient.sendEndAsync(pushToken, state, Duration.ZERO).join();
+			} catch (Exception e) {
+				log.warn("이전 카드 닫기 실패 matchId={} memberId={}: {}", matchId, memberId, e.getMessage());
+			}
+		}
+		try {
+			tokenRepository.deactivateByPushTokenIn(previousTokens);
+		} catch (Exception e) {
+			log.warn("이전 카드 토큰 비활성화 실패 matchId={} memberId={}: {}", matchId, memberId, e.getMessage());
+		}
+		log.info("[live-activity] 재발행 위해 이전 카드 닫음 matchId={} memberId={} 토큰={}건",
+				matchId, memberId, previousTokens.size());
 	}
 
 	/** 대상 산정만 다르고 발송·죽은 토큰 정리는 같다. */

--- a/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
+++ b/src/main/java/com/toy/nar/domain/member/repository/LiveActivityTokenRepository.java
@@ -17,6 +17,18 @@ public interface LiveActivityTokenRepository extends JpaRepository<LiveActivityT
 	@Query("select t.pushToken from LiveActivityToken t where t.matchId = :matchId and t.active = true")
 	List<String> findActivePushTokensByMatchId(@Param("matchId") String matchId);
 
+	/**
+	 * 회원 한 명이 이 경기에 대해 들고 있는 살아있는 카드 토큰.
+	 *
+	 * <p>구독 액션으로 카드를 다시 띄울 때 이전 카드를 먼저 닫기 위해 쓴다. 사용자가 잠금화면에서
+	 * 카드를 지워도 서버는 모르므로(앱에 해제 호출 경로가 없다) 이 토큰이 유령으로 남아
+	 * 재생성을 막는다.</p>
+	 */
+	@Query("select t.pushToken from LiveActivityToken t "
+			+ "where t.member.id = :memberId and t.matchId = :matchId and t.active = true")
+	List<String> findActivePushTokensByMemberIdAndMatchId(
+			@Param("memberId") Long memberId, @Param("matchId") String matchId);
+
 	/** 살아있는 카드가 있는 매치 목록. 스윕이 "끝난 매치의 카드"를 찾는 출발점이다. */
 	@Query("select distinct t.matchId from LiveActivityToken t where t.active = true")
 	List<String> findDistinctActiveMatchIds();

--- a/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceRecreateTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/LiveActivityPushServiceRecreateTest.java
@@ -1,0 +1,163 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.domain.member.repository.LiveActivityStartTokenRepository;
+import com.toy.nar.domain.member.repository.LiveActivityTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 구독 액션으로 카드를 다시 띄울 때는 그 회원의 이전 카드를 먼저 닫는다.
+ *
+ * <p>사용자가 잠금화면에서 카드를 지워도 서버는 그걸 모른다(앱에 해제 API 호출 경로가 없다).
+ * 갱신 토큰이 active 로 남아 {@code findStartTargetsForMember} 의 중복 방지 조건에 걸려,
+ * 구독을 취소하고 다시 신청해도 카드가 영원히 안 떴다 — 실측 2026-08-12 DK vs KT:
+ * 20:03 카드 생성 뒤 삭제, 20:52 구독 해제·재신청에도 push-to-start 발송 0건.</p>
+ *
+ * <p>이전 카드를 닫고(이미 없으면 무해) 토큰을 비활성화한 뒤 새로 발행하면, 지운 경우는
+ * 다시 뜨고 살아있는 경우도 카드가 두 장 되지 않는다.</p>
+ */
+class LiveActivityPushServiceRecreateTest {
+
+	private LiveActivityTokenRepository tokenRepository;
+	private LiveActivityStartTokenRepository startTokenRepository;
+	private ApnsLiveActivityClient apnsClient;
+	private LiveActivityPushService service;
+
+	@BeforeEach
+	void setUp() {
+		tokenRepository = mock(LiveActivityTokenRepository.class);
+		startTokenRepository = mock(LiveActivityStartTokenRepository.class);
+		apnsClient = mock(ApnsLiveActivityClient.class);
+		service = new LiveActivityPushService(tokenRepository, startTokenRepository, apnsClient);
+		when(apnsClient.isAvailable()).thenReturn(true);
+		org.springframework.test.util.ReflectionTestUtils.setField(service, "pushToStartEnabled", true);
+		when(apnsClient.sendStartAsync(anyString(), anyString(), any(), any(), anyString(), anyString()))
+				.thenReturn(CompletableFuture.completedFuture(true));
+		when(apnsClient.sendEndAsync(anyString(), any(), any()))
+				.thenReturn(CompletableFuture.completedFuture(true));
+	}
+
+	@Test
+	@DisplayName("이전 카드를 즉시 닫고 토큰을 비활성화한 뒤 새 카드를 발행한다")
+	void closesPreviousCardThenStartsNew() {
+		when(tokenRepository.findActivePushTokensByMemberIdAndMatchId(7L, "match-1"))
+				.thenReturn(List.of("old-tok"));
+		when(startTokenRepository.findStartTargetsForMember("match-1", 7L))
+				.thenReturn(List.of(startTarget("start-tok", 7L, "HLE")));
+
+		service.startCardForMember("match-1", 7L, 2, 1, 0, attributes());
+
+		// 닫기 → 토큰 정리 → 발송 순서. 정리가 발송보다 늦으면 중복 방지 조건이 새 카드를 막는다.
+		InOrder order = inOrder(apnsClient, tokenRepository, startTokenRepository);
+		order.verify(apnsClient).sendEndAsync(eq("old-tok"), any(), eq(Duration.ZERO));
+		order.verify(tokenRepository).deactivateByPushTokenIn(List.of("old-tok"));
+		order.verify(startTokenRepository).findStartTargetsForMember("match-1", 7L);
+		order.verify(apnsClient).sendStartAsync(eq("start-tok"), anyString(), any(), any(),
+				anyString(), anyString());
+	}
+
+	@Test
+	@DisplayName("이전 카드가 없으면 닫기 없이 바로 발행한다")
+	void startsDirectlyWhenNoPreviousCard() {
+		when(tokenRepository.findActivePushTokensByMemberIdAndMatchId(7L, "match-1"))
+				.thenReturn(List.of());
+		when(startTokenRepository.findStartTargetsForMember("match-1", 7L))
+				.thenReturn(List.of(startTarget("start-tok", 7L, "HLE")));
+
+		service.startCardForMember("match-1", 7L, 1, 0, 0, attributes());
+
+		verify(apnsClient, never()).sendEndAsync(anyString(), any(), any());
+		verify(tokenRepository, never()).deactivateByPushTokenIn(any());
+		verify(apnsClient).sendStartAsync(eq("start-tok"), anyString(), any(), any(),
+				anyString(), anyString());
+	}
+
+	@Test
+	@DisplayName("닫기 푸시가 실패해도 새 카드 발행은 진행한다")
+	void startsEvenWhenCloseFails() {
+		when(tokenRepository.findActivePushTokensByMemberIdAndMatchId(7L, "match-1"))
+				.thenReturn(List.of("old-tok"));
+		when(apnsClient.sendEndAsync(anyString(), any(), any()))
+				.thenReturn(CompletableFuture.failedFuture(new RuntimeException("apns down")));
+		when(startTokenRepository.findStartTargetsForMember("match-1", 7L))
+				.thenReturn(List.of(startTarget("start-tok", 7L, "HLE")));
+
+		service.startCardForMember("match-1", 7L, 2, 1, 0, attributes());
+
+		// 유령 토큰이 남아 재생성을 막는 편이 카드 두 장보다 나쁘다 — 정리는 발송 성공과 무관하게 한다.
+		verify(tokenRepository).deactivateByPushTokenIn(List.of("old-tok"));
+		verify(apnsClient).sendStartAsync(eq("start-tok"), anyString(), any(), any(),
+				anyString(), anyString());
+	}
+
+	@Test
+	@DisplayName("닫기 상태는 진행 중 스코어를 그대로 실어 카드가 잘못된 값으로 남지 않게 한다")
+	void closePayloadCarriesCurrentScore() {
+		when(tokenRepository.findActivePushTokensByMemberIdAndMatchId(7L, "match-1"))
+				.thenReturn(List.of("old-tok"));
+		when(startTokenRepository.findStartTargetsForMember("match-1", 7L))
+				.thenReturn(List.of(startTarget("start-tok", 7L, "HLE")));
+
+		service.startCardForMember("match-1", 7L, 2, 1, 0, attributes());
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Map<String, Object>> state = ArgumentCaptor.forClass(Map.class);
+		verify(apnsClient).sendEndAsync(eq("old-tok"), state.capture(), any());
+		assertThat(state.getValue()).containsEntry("scoreA", 1).containsEntry("scoreB", 0);
+	}
+
+	@Test
+	@DisplayName("전체 대상 발행(startCards)은 이전 카드를 닫지 않는다 — 세트 시작 경로는 그대로")
+	void startCardsDoesNotCloseAnything() {
+		when(startTokenRepository.findStartTargets("match-1", 10L, 20L))
+				.thenReturn(List.of(startTarget("start-tok", 7L, "HLE")));
+
+		service.startCards("match-1", 1, 0, 0, 10L, 20L, attributes());
+
+		verify(apnsClient, never()).sendEndAsync(anyString(), any(), any());
+		verify(tokenRepository, never()).findActivePushTokensByMemberIdAndMatchId(any(), anyString());
+	}
+
+	private LiveActivityPushService.MatchCardAttributes attributes() {
+		return new LiveActivityPushService.MatchCardAttributes(
+				"match-1", "T1", "T1", "Hanwha Life Esports", "HLE", "LCK");
+	}
+
+	private LiveActivityStartTokenRepository.StartTargetRow startTarget(
+			String pushToken, Long memberId, String favoriteTeamCode) {
+		return new LiveActivityStartTokenRepository.StartTargetRow() {
+			@Override
+			public String getPushToken() {
+				return pushToken;
+			}
+
+			@Override
+			public Long getMemberId() {
+				return memberId;
+			}
+
+			@Override
+			public String getFavoriteTeamCode() {
+				return favoriteTeamCode;
+			}
+		};
+	}
+}


### PR DESCRIPTION
## 문제

잠금화면에서 라이브위젯 카드를 실수로 지우면, **구독을 취소하고 다시 신청해도 경기 내내 다시 뜨지 않는다.**

카드를 지운 사실을 서버가 알 방법이 없다 — 앱에는 등록 경로만 있고(`live_activity_push_token_repository.dart` 는 `register`/`registerStartToken` 뿐, 주석도 "여기서는 등록만 한다") delete·unregister·reconcile 이 **최신 1.0.15+27 에도 없다**. 그래서 갱신 토큰이 `active=1` 로 남고, #368 이 카드 두 장을 막기 위해 둔 `NOT EXISTS(active LiveActivityToken)` 조건에 걸려 재발행이 전부 스킵된다.

**실측 2026-08-12 DK vs KT (member 10):**

| 시각(KST) | 사건 |
|---|---|
| 20:03:09 | 세트1 push-to-start 발송 8건 → 카드 생성 |
| 20:03:10 | 앱이 갱신 토큰 등록 (`live_activity_token` id=59, active=1) |
| — | 카드 삭제 (서버는 모름, 토큰 그대로) |
| 20:52:37 | 구독 해제 (`DELETE /match-subscriptions/{id}`) |
| 20:52:48 | 재신청 (`POST /match-subscriptions`) → #368 catch-up 진입 |
| — | **push-to-start 로그 0건** — 중복 방지 조건에서 대상 0명 |

## 변경

구독 액션 발행 경로(`startCardForMember`)에서 **그 회원의 이전 카드를 먼저 닫고 토큰을 비활성화한 뒤** 새로 발행한다.

- 카드가 이미 없으면(유령 토큰) APNs 가 200 을 주고 아무 일도 없다 — 무해
- 실제로 살아있었다면 닫히므로 **카드가 두 장 되지 않는다** (#368 의 중복 방지 의도 유지)
- `dismissal-date` 를 지금으로 둬 이전 카드는 즉시 사라진다 (매치 종료의 30분 유지와 다름)
- 닫기 발송 실패와 무관하게 토큰은 정리 — 유령 토큰이 남아 재발행을 계속 막는 쪽이 카드가 잠깐 두 장 보이는 것보다 나쁘다
- 정리는 대상 조회보다 반드시 먼저 (조회 조건이 이 토큰을 보고 제외하므로) — 순서를 테스트로 고정

**구독 해제 시점에 정리하지 않은 이유:** 팀 구독 등 다른 근거로 카드를 계속 받아야 하는 회원의 갱신이 끊긴다. 세트 시작 전체 발행(`startCards`)은 손대지 않았다.

## 테스트

`LiveActivityPushServiceRecreateTest` 5건 — 닫기→정리→발행 순서(InOrder), 이전 카드 없을 때 닫기 생략, 닫기 실패해도 발행 진행, 닫기 payload 스코어, `startCards` 경로 불변. 전체 `./gradlew test` green.

## 사용법 (머지 후)

카드를 지웠으면 **경기 알림 구독 취소 → 재신청** 하면 즉시 뜬다. 세트 시작 알림 토글 off→on 도 동일. 단 지금 세트가 진행 중이어야 한다(세트 사이면 다음 세트 시작 때 정상 경로로 뜬다).

## 남은 것 (이 PR 범위 아님)

구독을 건드리지 않고 카드만 지운 경우는 여전히 다음 세트까지 기다려야 한다. 앱 포그라운드 reconcile(`Activity.activities` vs 서버 토큰 diff → 유령 unregister)이 들어오면 자동 복구된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)