### PR TITLE
fix: 알림 미읽음 카운트 커버링 인덱스 추가 — 2,130ms → 5ms

### DIFF
--- a/src/main/resources/db/migration/V67__Add_member_notification_unread_index.sql
+++ b/src/main/resources/db/migration/V67__Add_member_notification_unread_index.sql
@@ -1,0 +1,21 @@
+-- 알림 리스트 조회(MemberNotificationService.getNotifications)는 요청마다 미읽음 건수를
+-- countByMember_IdAndReadAtIsNull 로 센다. 기존 인덱스는 (member_id, created_at)/(member_id, type)
+-- 뿐이라 read_at 을 확인하려고 member 의 전체 행마다 클러스터드 인덱스를 랜덤 액세스했다.
+--
+-- 실측 2026-08-12 23:53 (LPL 라이브 유입, 27 req/s): 이 엔드포인트가 241건 중 평균 294ms,
+-- 최대 7,297ms 이고 그 시간의 88%가 SQL 대기였다. 프로덕션 DB 에서 미읽음 5,793건 회원으로
+-- 직접 재보니 미읽음 카운트만 2,130ms — 전체 카운트(4.5ms)·페이지 20건(2.4ms)과 비교해 500배.
+-- member_notification 이 125만 행 632MB 인데 innodb_buffer_pool_size 가 128MB 라
+-- 랜덤 액세스가 그대로 디스크 I/O 로 나간다.
+--
+-- (member_id, read_at) 을 추가하면 커버링 인덱스가 되어 2,130ms → 5.2ms (EXPLAIN: Using index).
+--
+-- 프로덕션에는 2026-08-13 00:21 에 온라인 DDL 로 선반영했다(34.6초, ALGORITHM=INPLACE LOCK=NONE).
+-- 배포 시 중복 생성으로 실패하지 않도록 V50 과 같은 멱등 패턴으로 둔다.
+SET @stmt := IF(
+    (SELECT COUNT(1) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'member_notification'
+       AND INDEX_NAME = 'idx_member_notification_member_read') = 0,
+    'CREATE INDEX idx_member_notification_member_read ON member_notification (member_id, read_at)',
+    'SELECT 1');
+PREPARE s FROM @stmt; EXECUTE s; DEALLOCATE PREPARE s;


### PR DESCRIPTION
## 문제

2026-08-12 23:52~23:53 프로덕션 CPU 100% 스파이크를 조사하다 나온 실제 병목. WhaTap 프로파일(1,561 트랜잭션) 기준:

| 트랜잭션 | 건수 | 평균 | SQL 비중 | max |
|---|---|---|---|---|
| `/api/mobile/me/notifications` | 241 | 294ms | **88%** | **7,297ms** |
| `/api/mobile/me/player-subscriptions` | 118 | 249ms | 86% | 2,271ms |

`DB 연결 시간`은 한 자리 ms → 커넥션 풀 대기 아님. 쿼리 자체가 느렸다.

## 원인

`MemberNotificationService.getNotifications()` 가 요청마다 부르는 `countByMember_IdAndReadAtIsNull`. 기존 인덱스는 `(member_id, created_at)`, `(member_id, type)` 뿐이라 `read_at` 을 확인하려고 그 회원의 전체 행을 클러스터드 인덱스로 랜덤 액세스한다.

프로덕션 DB 실측 (미읽음 5,793건 회원):

```
COUNT(*) WHERE member_id=? AND read_at IS NULL  →  2,130 ms   (Using where, filtered 10%)
COUNT(*) WHERE member_id=?                      →      4.5 ms  (Using index)
페이지 20건 (member_id + created_at DESC)        →      2.4 ms  (Backward index scan)
```

`member_notification` 이 **125만 행 / 632MB** 인데 `innodb_buffer_pool_size` 는 **128MB(기본값)** 라, 랜덤 액세스가 그대로 디스크 I/O 로 나간다. 알림 리스트는 유입 피크에 분당 121회 호출됐다.

## 수정

`(member_id, read_at)` 인덱스 하나. 코드 변경 없음.

```
2,130 ms → 5.2 ms   (EXPLAIN: Using where → Using where; Using index)
```

## 프로덕션 반영 상태

이미 온라인 DDL 로 **선반영 완료** (2026-08-13 00:21, `ALGORITHM=INPLACE LOCK=NONE`, 34.6초). 그래서 이 마이그레이션은 V50 과 같은 멱등 패턴이고 배포 시엔 `SELECT 1` 로 지나간다.

롤백은 `DROP INDEX idx_member_notification_member_read ON member_notification`.

## 남은 것 (이 PR 범위 밖)

- `LoggingFilter` 가 debug 꺼진 prod 에서도 요청·응답 바디를 매번 String 으로 복사
- `member_notification` 125만 행 중 30일 초과가 277건뿐 → 최근 30일에만 125만 행이 쌓였다. 보관정책 필요
- `/api/mobile/live/games/{id}/events` SQL 70건/요청 (N+1)
- `/api/auth/me` 호출 212건 중 89건이 401 Access Denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)