### PR TITLE
fix: 세트 종료 카드 스코어가 한 세트 뒤처지던 문제 — 재조회 스코어를 DB 에 선반영

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -190,6 +190,21 @@ public class LeagueMatchService {
 	 * state 는 건드리지 않는다 — 되돌림 클래스(#354/#355)와 무관하게 유지.
 	 * 실패해도 종료 확정 흐름을 깨면 안 되므로 흡수한다.
 	 */
+	/**
+	 * 세트 종료 푸시가 재조회로 얻은 신선 스코어를 DB 에 선반영한다.
+	 *
+	 * <p>SET_END 푸시는 스코어를 직접 재조회하지만 그 결과를 문구에만 썼다. 잠금화면 카드는 그
+	 * 직후 DB 를 읽으므로(LivePollingScheduler.pushLiveActivitySetEnd) 아직 폴링 선반영이 닿지
+	 * 않은 옛 스코어가 카드에 실렸다 — 실측 2026-08-13 KRX vs BFX 세트2: 카드 18:29:16(1:0),
+	 * 선반영 18:29:28(1:1). 여기서 먼저 써두면 같은 값을 카드도 읽는다.</p>
+	 */
+	public void applyFreshScore(String matchId, int[] score) {
+		if (matchId == null || score == null) {
+			return;
+		}
+		overlayScoreOnlyIfAhead(leagueMatchRepository.findById(matchId).orElse(null), score);
+	}
+
 	private void overlayScoreOnlyIfAhead(LeagueMatch existing, int[] naverScore) {
 		try {
 			int[] ahead = scoreOnlyOverlay(existing, naverScore);

--- a/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
+++ b/src/main/java/com/toy/nar/app/mobile/push/TeamLiveEventPushService.java
@@ -58,6 +58,7 @@ public class TeamLiveEventPushService {
 	private final com.toy.nar.app.lolesports.WorldsService worldsService;
 	private final com.toy.nar.app.lolesports.NaverEsportsScoreClient naverEsportsScoreClient;
 	private final QuietAwarePushSender quietAwarePushSender;
+	private final com.toy.nar.app.lolesports.LeagueMatchService leagueMatchService;
 
 	@Value("${live.notification.fcm.enabled:false}")
 	private boolean fcmNotificationEnabled;
@@ -220,12 +221,12 @@ public class TeamLiveEventPushService {
 					naverUsable = naver != null;
 					int[] fresh = freshOrNull(naver, endedSetNumber);
 					if (fresh != null) {
-						return new ResolvedMatchScore(match, fresh);
+						return new ResolvedMatchScore(match, writeBack(matchId, fresh));
 					}
 				}
 				int[] fresh = freshOrNull(worldsService.fetchMatchGameWins(matchId), endedSetNumber);
 				if (fresh != null) {
-					return new ResolvedMatchScore(match, fresh);
+					return new ResolvedMatchScore(match, writeBack(matchId, fresh));
 				}
 			}
 			log.warn("Set-end score still stale after retries. matchId={} endedSet={} dbScore={}:{}",
@@ -238,6 +239,25 @@ public class TeamLiveEventPushService {
 			log.warn("Failed to load match score for set-end push matchId={}", matchId, e);
 			return ResolvedMatchScore.EMPTY;
 		}
+	}
+
+	/**
+	 * 재조회로 얻은 신선 스코어를 DB 에 선반영하고 그 스코어를 그대로 돌려준다.
+	 *
+	 * <p>이 값이 여기서 끝나면 잠금화면 카드가 곤란해진다 — 카드는 이 푸시 직후 DB 를 그대로
+	 * 읽어(LivePollingScheduler.pushLiveActivitySetEnd) 폴링 선반영이 닿기 전 옛 스코어를
+	 * 싣는다(실측 2026-08-13 KRX vs BFX 세트2: 카드 18:29:16 에 1:0, 선반영 18:29:28 에 1:1).
+	 * 카드 라벨은 프레임 신호라 맞고 숫자만 한 세트 뒤처져 다음 세트 시작까지 남았다.</p>
+	 *
+	 * <p>선반영 실패가 푸시를 막으면 안 된다 — 문구는 이미 정확한 값을 들고 있으므로 흡수한다.</p>
+	 */
+	private int[] writeBack(String matchId, int[] fresh) {
+		try {
+			leagueMatchService.applyFreshScore(matchId, fresh);
+		} catch (Exception e) {
+			log.warn("세트 종료 신선 스코어 선반영 실패. matchId={}: {}", matchId, e.getMessage());
+		}
+		return fresh;
 	}
 
 	/** 스코어 합이 방금 끝난 세트 수 이상(=신선)일 때만 그 스코어, 아니면 null. */

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushFanOutBatchTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushFanOutBatchTest.java
@@ -64,7 +64,8 @@ class TeamLiveEventPushFanOutBatchTest {
 				notificationService,
 				mock(WorldsService.class),
 				mock(NaverEsportsScoreClient.class),
-				quietAwarePushSender);
+				quietAwarePushSender,
+				mock(com.toy.nar.app.lolesports.LeagueMatchService.class));
 		ReflectionTestUtils.setField(service, "fcmNotificationEnabled", true);
 		when(pushGateway.isAvailable()).thenReturn(true);
 	}

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceBestOfTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceBestOfTest.java
@@ -66,7 +66,8 @@ class TeamLiveEventPushServiceBestOfTest {
 		service = new TeamLiveEventPushService(
 				deviceRepository, deliveryRepository, teamExternalIdentityRepository,
 				leagueMatchRepository, pushGateway, notificationService, worldsService,
-				naverEsportsScoreClient, quietAwarePushSender);
+				naverEsportsScoreClient, quietAwarePushSender,
+				org.mockito.Mockito.mock(com.toy.nar.app.lolesports.LeagueMatchService.class));
 		ReflectionTestUtils.setField(service, "fcmNotificationEnabled", true);
 		ReflectionTestUtils.setField(service, "scoreRetryAttempts", 1);
 		ReflectionTestUtils.setField(service, "scoreRetryDelayMs", 0L);

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceFreshScoreWriteBackTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceFreshScoreWriteBackTest.java
@@ -1,0 +1,145 @@
+package com.toy.nar.app.mobile.push;
+
+import com.toy.nar.app.lolesports.LeagueMatchService;
+import com.toy.nar.app.lolesports.NaverEsportsScoreClient;
+import com.toy.nar.app.lolesports.WorldsService;
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import com.toy.nar.app.lolesports.repository.LeagueMatchRepository;
+import com.toy.nar.app.mobile.notification.MemberNotificationService;
+import com.toy.nar.domain.member.repository.MemberDeviceRepository;
+import com.toy.nar.domain.member.repository.MemberTeamEventPushDeliveryRepository;
+import com.toy.nar.domain.participant.repository.TeamExternalIdentityRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * SET_END 가 재조회로 얻은 신선 스코어를 DB 에 선반영하는지.
+ *
+ * <p>지금까지 재조회 결과는 푸시 문구에만 쓰였다. 잠금화면 카드는 그 직후 DB 를 그대로 읽으므로
+ * (LivePollingScheduler.pushLiveActivitySetEnd) 아직 갱신 안 된 스코어가 카드에 실렸다 —
+ * 실측 2026-08-13 KRX vs BFX 세트2: 카드 발송 18:29:16(DB 1:0), 선반영 18:29:28(1:1).
+ * 카드에는 라벨만 "3세트 준비 중"으로 맞고 숫자는 1:0 으로 남았고, 세트3 시작까지 그대로였다.
+ * 알림 문구는 정확했다 — 두 경로가 서로 다른 스코어를 본 셈이다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class TeamLiveEventPushServiceFreshScoreWriteBackTest {
+
+	@Mock
+	private MemberDeviceRepository deviceRepository;
+	@Mock
+	private MemberTeamEventPushDeliveryRepository deliveryRepository;
+	@Mock
+	private TeamExternalIdentityRepository teamExternalIdentityRepository;
+	@Mock
+	private LeagueMatchRepository leagueMatchRepository;
+	@Mock
+	private MobilePushGateway pushGateway;
+	@Mock
+	private MemberNotificationService notificationService;
+	@Mock
+	private WorldsService worldsService;
+	@Mock
+	private NaverEsportsScoreClient naverEsportsScoreClient;
+	@Mock
+	private LeagueMatchService leagueMatchService;
+
+	private TeamLiveEventPushService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new TeamLiveEventPushService(
+				deviceRepository, deliveryRepository, teamExternalIdentityRepository,
+				leagueMatchRepository, pushGateway, notificationService, worldsService,
+				naverEsportsScoreClient, mock(QuietAwarePushSender.class), leagueMatchService);
+		ReflectionTestUtils.setField(service, "scoreRetryAttempts", 3);
+		ReflectionTestUtils.setField(service, "scoreRetryDelayMs", 0L);
+	}
+
+	@Test
+	@DisplayName("네이버 재조회로 얻은 스코어는 DB 에 선반영한다 — 직후 카드가 같은 값을 읽는다")
+	void writesBackNaverScore() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(1, 0)));
+		when(naverEsportsScoreClient.fetchScore(eq("KC"), eq("T1"), any()))
+				.thenReturn(new int[] { 1, 1 });
+
+		service.buildMatchScoreLine("m1", 2);
+
+		verify(leagueMatchService).applyFreshScore("m1", new int[] { 1, 1 });
+	}
+
+	@Test
+	@DisplayName("업스트림(Riot) 재조회로 얻은 스코어도 선반영한다")
+	void writesBackUpstreamScore() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(1, 0)));
+		when(naverEsportsScoreClient.fetchScore(eq("KC"), eq("T1"), any())).thenReturn(null);
+		when(worldsService.fetchMatchGameWins("m1")).thenReturn(new int[] { 2, 0 });
+
+		service.buildMatchScoreLine("m1", 2);
+
+		verify(leagueMatchService).applyFreshScore("m1", new int[] { 2, 0 });
+	}
+
+	@Test
+	@DisplayName("DB 가 이미 신선하면 선반영하지 않는다 — 쓸 것이 없다")
+	void skipsWriteBackWhenDbAlreadyFresh() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(1, 1)));
+
+		service.buildMatchScoreLine("m1", 2);
+
+		verify(leagueMatchService, never()).applyFreshScore(any(), any());
+	}
+
+	@Test
+	@DisplayName("재조회가 끝까지 stale 이면 선반영하지 않는다 — 틀린 값을 쓰면 카드까지 오염된다")
+	void skipsWriteBackWhenStillStale() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(1, 0)));
+		when(naverEsportsScoreClient.fetchScore(eq("KC"), eq("T1"), any()))
+				.thenReturn(new int[] { 1, 0 });
+		when(worldsService.fetchMatchGameWins("m1")).thenReturn(new int[] { 1, 0 });
+
+		service.buildMatchScoreLine("m1", 2);
+
+		verify(leagueMatchService, never()).applyFreshScore(any(), any());
+	}
+
+	@Test
+	@DisplayName("선반영이 터져도 푸시 문구는 정상으로 만든다")
+	void pushLineSurvivesWriteBackFailure() {
+		when(leagueMatchRepository.findById("m1")).thenReturn(Optional.of(match(1, 0)));
+		when(naverEsportsScoreClient.fetchScore(eq("KC"), eq("T1"), any()))
+				.thenReturn(new int[] { 1, 1 });
+		org.mockito.Mockito.doThrow(new RuntimeException("db down"))
+				.when(leagueMatchService).applyFreshScore(any(), any());
+
+		org.assertj.core.api.Assertions.assertThat(service.buildMatchScoreLine("m1", 2))
+				.isEqualTo("Karmine Corp 1 vs 1 T1");
+	}
+
+	private LeagueMatch match(Integer blueScore, Integer redScore) {
+		return LeagueMatch.builder()
+				.id("m1")
+				.leagueName("LCK")
+				.blueTeamCode("KC")
+				.blueTeamName("Karmine Corp")
+				.redTeamCode("T1")
+				.redTeamName("T1")
+				.blueScore(blueScore)
+				.redScore(redScore)
+				.matchDate(java.time.LocalDateTime.of(2026, 8, 13, 8, 0))
+				.build();
+	}
+}

--- a/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceScoreLineTest.java
+++ b/src/test/java/com/toy/nar/app/mobile/push/TeamLiveEventPushServiceScoreLineTest.java
@@ -56,7 +56,7 @@ class TeamLiveEventPushServiceScoreLineTest {
 		service = new TeamLiveEventPushService(
 				deviceRepository, deliveryRepository, teamExternalIdentityRepository,
 				leagueMatchRepository, pushGateway, notificationService, worldsService,
-				naverEsportsScoreClient, mock(QuietAwarePushSender.class));
+				naverEsportsScoreClient, mock(QuietAwarePushSender.class), mock(com.toy.nar.app.lolesports.LeagueMatchService.class));
 		// 테스트에서 재시도 대기 없이 즉시 진행
 		ReflectionTestUtils.setField(service, "scoreRetryAttempts", 3);
 		ReflectionTestUtils.setField(service, "scoreRetryDelayMs", 0L);


### PR DESCRIPTION
## 문제

세트가 끝나면 잠금화면 카드는 "다음 세트 준비 중"으로 **라벨은 맞게** 바뀌는데 **스코어 숫자만 한 세트 뒤처진다.** 앱 경기 상세 화면은 정상 값이라 차이가 드러난다.

같은 세트 종료를 두 경로가 서로 다른 스코어로 본다:

| 경로 | 스코어 출처 |
|---|---|
| SET_END FCM 알림 | `resolveMatchScore()` — 네이버·업스트림 재조회로 신선한 값을 구함 |
| Live Activity 카드 | `leagueMatchRepository.findById()` — **DB 를 그대로 읽음** |

`pushLiveActivitySetEnd` 의 주석은 "SET_END 푸시가 재조회로 최대 60초 블로킹되니 그 뒤에 부른다 — 그때쯤이면 DB 도 갱신돼 있다"고 기대하지만, **재조회 결과가 DB 에 써지지 않는다.** DB 갱신은 별도 폴링 tick 의 선반영(#362)이 하고 그게 더 늦게 온다.

**실측 2026-08-13 KRX vs BFX (CloudWatch)**

```
세트1  17:40:19 set-end 감지
      17:41:12 카드 update 발송      ← DB 0:0
      17:41:28 DB 선반영 1:0          ← 16초 늦음

세트2  18:28:24 set-end 감지
      18:29:16 카드 update 발송      ← DB 1:0
      18:29:28 DB 선반영 1:1          ← 12초 늦음
```

`"still stale"` 경고는 0건 — FCM 쪽은 스코어를 제때 구했다. **알림 배너는 정확한데 카드만 틀린** 상태다.

스스로 복구되지도 않는다. `retryMatchEndCard`(#354)는 **매치 종료일 때만** 돌고, 세트 종료는 복구 경로가 없으며 `progressKey` 워터마크가 같은 phase 재발송을 막는다. 그래서 다음 세트 시작(`notifySetStart`)이 값을 덮을 때까지 남는다 — 세트1은 21분간 0:0 이었다.

## 변경

재조회가 신선 스코어를 얻은 두 지점(네이버·업스트림)에서 **#362 의 선반영 경로로 DB 에 먼저 쓴다.** 카드는 바로 다음 단계에서 그 값을 읽는다 — 호출 순서는 이미 FCM → 카드이므로 순서 변경이 없다.

- `LeagueMatchService.applyFreshScore(matchId, score)` — #362 의 `overlayScoreOnlyIfAhead` 재사용 (스코어만 write, state 불변, 캐시 evict)
- 검증 통과분만 쓴다: `freshOrNull`(합 ≥ 세트번호) → `scoreOnlyOverlay`(completed 제외, 앞선 값만)
- 선반영 실패는 흡수 — 푸시 문구는 이미 정확한 값을 들고 있다
- **외부 API 호출 증가 0** (이미 받아온 응답을 쓴다)

부수 효과로 앱 상세 화면 스코어도 12~16초 빨라진다.

## 의존 방향

`TeamLiveEventPushService` → `LeagueMatchService` 를 새로 추가했다. `LeagueMatchService` 의 의존(repository·`LeagueSeasonResolver`·`WorldsService`·`NaverEsportsScoreClient`·`CacheEvictionService`) 중 push service 로 되돌아오는 것이 없어 순환은 생기지 않는다. (`LiveObjectEventRecorder` 가 push service 를 참조하지만 `LeagueMatchService` 의 의존이 아니다.)

## 확인한 것 / 아닌 것

- 위젯 SwiftUI 코드는 잠금화면·다이나믹 아일랜드(compactLeading/Trailing/minimal/expanded) **전부 `context.state.scoreA/B`** 를 읽는다. 정적 `attributes` 를 스코어로 쓰는 곳은 없어 뷰 버그가 아니다.
- 따라서 다이나믹 아일랜드만의 문제가 아니라 카드 전체(같은 activity·같은 state)의 문제다.

## 테스트

`TeamLiveEventPushServiceFreshScoreWriteBackTest` 5건 — 네이버 재조회분 선반영 / 업스트림 재조회분 선반영 / DB 가 이미 신선하면 미호출 / 끝까지 stale 이면 미호출(틀린 값이 카드까지 오염되지 않도록) / 선반영이 터져도 푸시 문구 정상. 전체 `./gradlew test` green.

## 남은 것

재조회마저 실패해 stale 인 경우(어제 네이버 16분 지연 같은 상황)는 여전히 다음 세트 시작까지 뒤처진다. 세트 종료 카드의 늦은 스코어 복구(`retryMatchEndCard` 의 세트판, 워터마크에 "스코어가 바뀌면 통과" 예외 필요)가 그걸 덮지만 이 PR 범위는 아니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
