### PR TITLE
fix: 세트 종료 카드를 감지 즉시 보내고 스코어를 뒤따르게

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -90,10 +90,11 @@ public class LivePollingScheduler {
 	private final java.util.Set<String> startNotifiedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
 	/**
-	 * 세트 종료 카드로 마지막에 보낸 스코어("blue:red"). 폴링 tick 마다 같은 값을 다시 쏘지 않게 한다.
+	 * 세트 종료 카드로 마지막에 보낸 스코어 {blue, red}. 폴링 tick 마다 같은 값을 다시 쏘거나
+	 * 후퇴한 값을 쏘지 않게 한다.
 	 * ponytail: {@link #naverFinalizedMatchIds} 와 같은 이유로 프로세스 생애 동안 누적된다 — 하루 수십 건이라 무해.
 	 */
-	private final java.util.Map<String, String> lastSetEndCardScoreByGame =
+	private final java.util.Map<String, int[]> lastSetEndCardScoreByGame =
 			new java.util.concurrent.ConcurrentHashMap<>();
 
 	// 매치 종료 카드 발송 여부는 LiveActivityPushService 가 공유 상태로 관리한다
@@ -563,11 +564,23 @@ public class LivePollingScheduler {
 				return;
 			}
 
-			// 스코어가 그대로면 tick 마다 같은 카드를 다시 쏘게 되므로 변화가 있을 때만 보낸다.
-			String scoreKey = blue + ":" + red;
-			if (scoreKey.equals(lastSetEndCardScoreByGame.put(activeGame.gameId(), scoreKey))) {
-				return;
+			// 매 tick 도는 자리라 발송 조건을 좁힌다(폴링은 단일 스레드라 get→put 사이 경합이 없다).
+			int[] previous = lastSetEndCardScoreByGame.get(activeGame.gameId());
+			if (previous != null) {
+				// 같은 스코어를 다시 쏘면 APNs 왕복만 늘어난다.
+				if (previous[0] == blue && previous[1] == red) {
+					return;
+				}
+				// 후퇴는 무시한다. 세트가 끝난 뒤 스코어가 줄어들 이유가 없고, 30분 전체 sync 가
+				// 진행 중 경기를 업스트림 stale 값으로 되돌리는 구간이 있다(isResultRegression 은
+				// completed 만 지킨다). 그걸 카드에 반영하면 잠금화면 숫자가 왕복한다.
+				if (blue + red < previous[0] + previous[1]) {
+					log.info("[live-activity] 세트 종료 카드 스코어 후퇴 무시 matchId={} {}:{} -> {}:{}",
+							activeGame.matchId(), previous[0], previous[1], blue, red);
+					return;
+				}
 			}
+			lastSetEndCardScoreByGame.put(activeGame.gameId(), new int[] { blue, red });
 			log.info("[live-activity] 세트 종료 카드 matchId={} set={} score={}:{}",
 					activeGame.matchId(), setNumber, blue, red);
 			applicationTaskExecutor.execute(() -> liveActivityPushService.notifySetEnd(

--- a/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
+++ b/src/main/java/com/toy/nar/app/lolesports/live/LivePollingScheduler.java
@@ -89,6 +89,13 @@ public class LivePollingScheduler {
 	 */
 	private final java.util.Set<String> startNotifiedGameIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
+	/**
+	 * 세트 종료 카드로 마지막에 보낸 스코어("blue:red"). 폴링 tick 마다 같은 값을 다시 쏘지 않게 한다.
+	 * ponytail: {@link #naverFinalizedMatchIds} 와 같은 이유로 프로세스 생애 동안 누적된다 — 하루 수십 건이라 무해.
+	 */
+	private final java.util.Map<String, String> lastSetEndCardScoreByGame =
+			new java.util.concurrent.ConcurrentHashMap<>();
+
 	// 매치 종료 카드 발송 여부는 LiveActivityPushService 가 공유 상태로 관리한다
 	// (matchEndPushed/claimMatchEndPush) — 스윕까지 발송자가 셋이라 여기 두면 스윕 발송이 안 보인다.
 
@@ -505,63 +512,28 @@ public class LivePollingScheduler {
 				log.warn("[live-notify] set-end FCM failed gameId={} matchId={}: {}",
 						activeGame.gameId(), activeGame.matchId(), e.getMessage());
 			}
-			pushLiveActivitySetEnd(activeGame);
 		});
 	}
 
-	/**
-	 * iOS Live Activity 카드를 세트 종료(또는 매치 종료)로 바꾼다.
-	 *
-	 * <p>SET_END 푸시가 스코어 재조회로 최대 60초 블로킹될 수 있어 그 뒤에 부른다 —
-	 * 그때쯤이면 DB 스코어도 갱신돼 카드와 알림이 같은 값을 보게 된다.</p>
-	 */
-	private void pushLiveActivitySetEnd(ActiveLiveGame activeGame) {
-		if (!liveActivityPushService.isEnabled()) {
-			return;
-		}
-		// 복구 경로(retryMatchEndCard)나 스윕이 먼저 매치 종료를 보냈으면 setEnded 를 뒤에 쏘면 안 된다 —
-		// 매치 종료 발송이 워터마크를 지우므로 뒤늦은 setEnded 가 통과해 카드가 되돌아간다.
-		if (liveActivityPushService.matchEndPushed(activeGame.matchId())) {
-			return;
-		}
-		try {
-			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
-			Integer blue = match == null ? null : match.getBlueScore();
-			Integer red = match == null ? null : match.getRedScore();
-			Integer bestOf = match == null ? null : match.getBestOf();
-			boolean matchEnded = isMatchEnded(bestOf, blue, red);
-			String winner = null;
-			if (matchEnded && match != null) {
-				winner = (blue == null ? 0 : blue) > (red == null ? 0 : red)
-						? match.getBlueTeamCode()
-						: match.getRedTeamCode();
-			}
-			if (matchEnded) {
-				liveActivityPushService.claimMatchEndPush(activeGame.matchId());
-			}
-			liveActivityPushService.notifySetEnd(
-					activeGame.matchId(),
-					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
-					blue, red, matchEnded, winner);
-		} catch (Exception e) {
-			log.warn("[live-activity] set-end 실패 matchId={}: {}", activeGame.matchId(), e.getMessage());
-		}
-	}
 
 	/**
-	 * 늦게 도착한 스코어로 매치 종료 카드를 복구한다.
+	 * 종료된 세트의 카드를 현재 스코어로 유지한다 — 발송은 스코어가 바뀔 때만.
 	 *
-	 * <p>매치 종료 카드는 세트 종료 이벤트에 편승하는데(그 경로가 {@code PHASE_MATCH_ENDED} 유일 진입점),
-	 * 그 시점 DB 스코어가 아직 직전 세트 값이면 setEnded 로 나가 카드가 "다음 세트 준비 중" 으로 고착한다.
-	 * 세트 종료 이벤트는 gameId 단위로 dedup 돼 재발화가 없어서, 스코어가 뒤늦게 맞아도 카드가
-	 * iOS 한도(8시간)까지 잘못된 상태로 잠금화면에 남는다.
-	 * 실측 2026-08-08 DNS vs NS: 카드 21:46:46 발송(스코어 1:0) / 2:0 도착 21:47:03 — 17초 차이로 고착.</p>
+	 * <p>예전엔 세트 종료 카드를 SET_END FCM 뒤에 한 번만 보냈다. 그 FCM 은 스코어 재조회(네이버·
+	 * 업스트림)를 최대 6회×10초 기다리므로 카드까지 그 대기에 묶였고, 발송된 뒤에는 갱신 경로가
+	 * 없어 값이 고착했다 — 실측 2026-08-14 DK vs T1 세트1: 프레임 종료 감지 17:39:47,
+	 * 카드 17:41:51(124초). 앱 상세 화면은 DB 를 폴링해 17:41:36 에 이미 맞은 값을 보여
+	 * 카드만 뒤처져 보였다.</p>
 	 *
-	 * <p>그래서 프레임 finished 로 확정된 세트에 대해 폴링 tick 마다 스코어를 다시 보고,
-	 * 다전제 승리 조건에 도달했으면 매치 종료를 한 번 더 보낸다. 카드 진행도 워터마크가
-	 * setEnded(1) → matchEnded(2) 상승만 허용하므로 순서가 뒤집히는 발송은 없다.</p>
+	 * <p>대신 프레임 finished 로 확정된 세트를 폴링 tick 마다 훑는다. 감지된 tick 에서 바로 한 번
+	 * 나가고(스코어가 아직 직전 세트 값이어도 "다음 세트 준비 중" 은 즉시 맞다), 이후 스코어가
+	 * 도착하면 그 tick 에서 카드가 따라간다. 재조회 대기가 카드를 붙잡지 않는다.</p>
+	 *
+	 * <p>다전제 승리 조건에 닿으면 매치 종료로 한 번 더 보낸다(claim 으로 1회 보장). 카드 진행도
+	 * 워터마크가 setEnded(1) → matchEnded(2) 상승만 허용하므로 순서가 뒤집히는 발송은 없고,
+	 * 같은 단계 재발송은 스코어 갱신을 위해 통과시킨다.</p>
 	 */
-	private void retryMatchEndCard(ActiveLiveGame activeGame) {
+	private void refreshEndedSetCard(ActiveLiveGame activeGame) {
 		if (!liveActivityPushService.isEnabled()
 				|| activeGame.matchId() == null
 				|| liveActivityPushService.matchEndPushed(activeGame.matchId())) {
@@ -569,26 +541,39 @@ public class LivePollingScheduler {
 		}
 		try {
 			var match = leagueMatchRepository.findById(activeGame.matchId()).orElse(null);
-			if (match == null
-					|| !isMatchEnded(match.getBestOf(), match.getBlueScore(), match.getRedScore())) {
-				return;
-			}
-			// claim 으로 검사와 등록을 한 번에 한다 — 세트 종료 편승 경로·스윕과 동시에 들어올 수 있다.
-			if (!liveActivityPushService.claimMatchEndPush(activeGame.matchId())) {
+			if (match == null) {
 				return;
 			}
 			int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
 			int red = match.getRedScore() == null ? 0 : match.getRedScore();
-			String winner = blue > red ? match.getBlueTeamCode() : match.getRedTeamCode();
-			log.info("[live-activity] 매치 종료 카드 복구 matchId={} set={} score={}:{}",
-					activeGame.matchId(), activeGame.setNumber(), blue, red);
-			// 폴링 스레드에서 APNs 팬아웃을 태우면 다음 프레임 수집이 밀린다.
+			int setNumber = activeGame.setNumber() != null ? activeGame.setNumber() : 0;
+			boolean matchEnded = isMatchEnded(match.getBestOf(), blue, red);
+
+			if (matchEnded) {
+				// claim 으로 검사와 등록을 한 번에 한다 — 스윕과 동시에 들어올 수 있다.
+				if (!liveActivityPushService.claimMatchEndPush(activeGame.matchId())) {
+					return;
+				}
+				String winner = blue > red ? match.getBlueTeamCode() : match.getRedTeamCode();
+				log.info("[live-activity] 매치 종료 카드 matchId={} set={} score={}:{}",
+						activeGame.matchId(), setNumber, blue, red);
+				// 폴링 스레드에서 APNs 팬아웃을 태우면 다음 프레임 수집이 밀린다.
+				applicationTaskExecutor.execute(() -> liveActivityPushService.notifySetEnd(
+						activeGame.matchId(), setNumber, blue, red, true, winner));
+				return;
+			}
+
+			// 스코어가 그대로면 tick 마다 같은 카드를 다시 쏘게 되므로 변화가 있을 때만 보낸다.
+			String scoreKey = blue + ":" + red;
+			if (scoreKey.equals(lastSetEndCardScoreByGame.put(activeGame.gameId(), scoreKey))) {
+				return;
+			}
+			log.info("[live-activity] 세트 종료 카드 matchId={} set={} score={}:{}",
+					activeGame.matchId(), setNumber, blue, red);
 			applicationTaskExecutor.execute(() -> liveActivityPushService.notifySetEnd(
-					activeGame.matchId(),
-					activeGame.setNumber() != null ? activeGame.setNumber() : 0,
-					blue, red, true, winner));
+					activeGame.matchId(), setNumber, blue, red, false, null));
 		} catch (Exception e) {
-			log.warn("[live-activity] 매치 종료 카드 복구 실패 matchId={}: {}",
+			log.warn("[live-activity] 세트 종료 카드 갱신 실패 matchId={}: {}",
 					activeGame.matchId(), e.getMessage());
 		}
 	}
@@ -721,7 +706,7 @@ public class LivePollingScheduler {
 				// 종료된 세트는 stale 제거(기본 3분) 전까지 매 tick 여기를 지난다. 그동안 스코어가
 				// 늦게 도착하면 매치 종료 카드를 복구한다.
 				if (frameFinishedGameIds.contains(activeGame.gameId())) {
-					retryMatchEndCard(activeGame);
+					refreshEndedSetCard(activeGame);
 				}
 
 				liveFrameProcessor.process(activeGame, window, details);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -735,6 +735,55 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void lateScoreRefreshesSetEndCard() {
+		// 매치가 안 끝난 세트 종료에도 늦게 온 스코어를 카드에 반영해야 한다.
+		// 지금까지는 매치 종료(retryMatchEndCard)만 복구 대상이라, 세트 종료 카드는 발송 시점
+		// 스코어로 고착해 다음 세트 시작까지 한 세트 뒤처졌다 — 실측 2026-08-14 DK vs T1 세트1:
+		// 감지 17:39:47, 스코어 확정 17:41:36. 카드는 감지 즉시 나가고 스코어를 뒤따라야 한다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		// bo5 로 둬 1:0 → 1:1 이 매치 종료 조건에 닿지 않게 한다(세트 종료만 검증).
+		java.util.concurrent.atomic.AtomicInteger redScore = new java.util.concurrent.atomic.AtomicInteger(0);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(180_000L), matchRepositoryWithMutableRedScore(redScore));
+		var activityPush = liveActivityPushService(scheduler);
+		when(activityPush.isEnabled()).thenReturn(true);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();   // 감지 즉시 — DB 는 아직 1:0 (직전 세트 값)
+		redScore.set(1);               // 네이버 선반영으로 1:1 도착
+		scheduler.pollActiveGames();
+
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 1, 0, false, null);
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 1, 1, false, null);
+	}
+
+	@Test
+	void setEndCardIsNotResentWhileScoreIsUnchanged() {
+		// 폴링 tick 마다 같은 스코어를 다시 쏘면 APNs 왕복만 늘어난다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		java.util.concurrent.atomic.AtomicInteger redScore = new java.util.concurrent.atomic.AtomicInteger(0);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(180_000L), matchRepositoryWithMutableRedScore(redScore));
+		var activityPush = liveActivityPushService(scheduler);
+		when(activityPush.isEnabled()).thenReturn(true);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();
+		scheduler.pollActiveGames();
+		scheduler.pollActiveGames();
+
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 1, 0, false, null);
+	}
+
+	@Test
 	void matchEndCardIsNotSentTwiceWhenScoreWasAlreadyFresh() {
 		// 세트 종료 시점에 이미 스코어가 맞으면 편승 경로가 매치 종료를 보내고,
 		// 복구 경로는 같은 매치에 두 번 쏘지 않아야 한다.
@@ -802,6 +851,20 @@ class LivePollingSchedulerTest {
 		when(match.getBlueScore()).thenAnswer(invocation -> blueScore.get());
 		when(match.getRedScore()).thenReturn(0);
 		when(match.getBestOf()).thenReturn(3);
+		when(match.getBlueTeamCode()).thenReturn("KT");
+		when(match.getRedTeamCode()).thenReturn("HLE");
+		var repository = mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class);
+		when(repository.findById("match-1")).thenReturn(java.util.Optional.of(match));
+		return repository;
+	}
+
+	/** blue 1 고정, red 만 움직인다 — bo5 라 1:1 까지는 매치 종료에 닿지 않는다. */
+	private com.toy.nar.app.lolesports.repository.LeagueMatchRepository matchRepositoryWithMutableRedScore(
+			java.util.concurrent.atomic.AtomicInteger redScore) {
+		var match = mock(com.toy.nar.app.lolesports.repository.LeagueMatch.class);
+		when(match.getBlueScore()).thenReturn(1);
+		when(match.getRedScore()).thenAnswer(invocation -> redScore.get());
+		when(match.getBestOf()).thenReturn(5);
 		when(match.getBlueTeamCode()).thenReturn("KT");
 		when(match.getRedTeamCode()).thenReturn("HLE");
 		var repository = mock(com.toy.nar.app.lolesports.repository.LeagueMatchRepository.class);

--- a/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/live/LivePollingSchedulerTest.java
@@ -784,6 +784,30 @@ class LivePollingSchedulerTest {
 	}
 
 	@Test
+	void setEndCardIgnoresScoreRegression() {
+		// 30분 전체 sync 가 진행 중 경기를 업스트림 stale 값으로 되돌리는 구간이 있다
+		// (isResultRegression 은 completed 만 지킨다). 그걸 카드에 반영하면 잠금화면 숫자가 왕복한다.
+		LiveStateStore liveStateStore = new LiveStateStore();
+		TeamLiveEventPushService pushService = mock(TeamLiveEventPushService.class);
+		when(pushService.isEnabled()).thenReturn(true);
+		java.util.concurrent.atomic.AtomicInteger redScore = new java.util.concurrent.atomic.AtomicInteger(1);
+		LivePollingScheduler scheduler = schedulerWith(liveStateStore, pushService,
+				new LiveFrameStallTracker(180_000L), matchRepositoryWithMutableRedScore(redScore));
+		var activityPush = liveActivityPushService(scheduler);
+		when(activityPush.isEnabled()).thenReturn(true);
+		liveStateStore.getActiveGames().put("game-1", lckGame("game-1"));
+		when(liveStatsClient(scheduler).getWindow(anyString(), anyString()))
+				.thenReturn(windowWithGameState("finished"));
+
+		scheduler.pollActiveGames();   // 1:1 발송
+		redScore.set(0);               // 크론이 1:0 으로 되돌림
+		scheduler.pollActiveGames();
+
+		verify(activityPush, times(1)).notifySetEnd("match-1", 2, 1, 1, false, null);
+		verify(activityPush, never()).notifySetEnd("match-1", 2, 1, 0, false, null);
+	}
+
+	@Test
 	void matchEndCardIsNotSentTwiceWhenScoreWasAlreadyFresh() {
 		// 세트 종료 시점에 이미 스코어가 맞으면 편승 경로가 매치 종료를 보내고,
 		// 복구 경로는 같은 매치에 두 번 쏘지 않아야 한다.


### PR DESCRIPTION
## 문제

#372 로 카드에 실리는 스코어 **값**은 맞게 됐지만, 카드가 **2분 늦게** 갱신되는 건 그대로였다.

**실측 2026-08-14 DK vs T1 세트1 (CloudWatch)**

```
17:39:47  프레임 finished 감지                     (0초)
          │
          │  ← resolveMatchScore 재조회 루프가 네이버를 기다림 (109초)
          │
17:41:36  DB 선반영 0:1   ← 앱 상세 화면은 여기서 갱신
17:41:37  FCM SET_END 팬아웃 시작 (2,824명)
17:41:50  팬아웃 완료
17:41:51  라이브위젯 카드 갱신                     (감지 후 124초)
```

세트가 끝난 걸 **17:39:47 에 이미 알고 있었는데** 카드가 2분간 붙잡혔다. 원인은 카드 발송이 SET_END FCM 뒤에 매달려 있고, 그 FCM 이 스코어 재조회를 **최대 6회 × 10초** 기다리기 때문이다. 게다가 한 번 나간 뒤에는 갱신 경로가 없어(`retryMatchEndCard` 는 매치 종료 전용) 값이 고착했다.

대기 시간은 네이버가 언제 반영해주느냐에 달려 매번 다르다 — 8/13 은 53초, 8/11 은 16분을 넘겨 스코어 없이 나갔다.

## 변경

카드 발송을 FCM 흐름에서 떼어내 **폴링 tick** 으로 옮긴다.

- 프레임 finished 로 확정된 세트를 매 tick 훑는다. **감지된 그 tick 에서 바로 한 번** 나가고(스코어가 아직 직전 세트 값이어도 "다음 세트 준비 중" 은 즉시 맞다), 이후 스코어가 도착하면 그 tick 에서 카드가 따라간다.
- `retryMatchEndCard` → `refreshEndedSetCard` 로 일반화. 매치 종료 복구는 기존 그대로 `claim` 으로 1회 보장.
- tick 마다 같은 값을 다시 쏘지 않도록 마지막 발송 스코어를 게임별로 기억한다.
- `pushLiveActivitySetEnd`(FCM 뒤 카드 발송) 제거.

**워터마크는 손대지 않았다.** `accept()` 는 같은 단계 재발송을 이미 통과시킨다 — 주석에 그대로 적혀 있다: *"같은 값이 다시 오는 것은 통과시킨다 … 그 사이 스코어가 갱신됐을 수 있다."* 순서 역전(setEnded → playing)은 여전히 막힌다.

**FCM 알림은 손대지 않았다.** 1회성이라 스코어를 기다리는 편이 맞다. 알림이 늦는 건 네이버 반영 속도 문제로 남는다.

## 효과

| | 이전 | 이후 |
|---|---|---|
| 카드가 "다음 세트 준비 중" 으로 바뀌는 시점 | 감지 + 최대 2분 | **감지 즉시 (같은 tick)** |
| 스코어가 카드에 반영되는 시점 | 발송 시점 값으로 고착 | 스코어 도착 후 다음 tick (≤10초) |
| 재조회가 끝내 실패한 경우 | 스코어 없이 고착 | 나중에 스코어가 와도 따라감 |

## 테스트

`LivePollingSchedulerTest` 신규 2건
- `lateScoreRefreshesSetEndCard` — 감지 tick 에 1:0 으로 나가고, 스코어가 1:1 로 바뀐 tick 에 다시 나간다
- `setEndCardIsNotResentWhileScoreIsUnchanged` — 스코어가 그대로면 tick 3번에 발송 1회

기존 `lateScoreRecoversMatchEndCard` / `matchEndCardIsNotSentTwiceWhenScoreWasAlreadyFresh` 도 수정 없이 통과 — 매치 종료 경로 계약이 그대로라는 뜻이다. 전체 `./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
