### PR TITLE
fix: 30분 크론이 진행 중 매치를 되돌리던 구멍 — 스코어·상태 후퇴 차단

### DIFF
--- a/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
+++ b/src/main/java/com/toy/nar/app/lolesports/LeagueMatchService.java
@@ -348,6 +348,53 @@ public class LeagueMatchService {
 		return !isCompleted(incoming);
 	}
 
+	/**
+	 * 진행 중 경기의 스코어·상태 후퇴를 막는다 — 각각 앞선 값으로 {@code incoming} 을 고쳐 놓는다.
+	 *
+	 * <p>{@link #isResultRegression} 은 completed 결과만 지켜서, 아직 진행 중인 경기는 30분 주기
+	 * 전체 동기화가 업스트림 stale 값으로 조건 없이 덮어썼다 — 실측 2026-08-12 DNS vs GEN:
+	 * 19:04 에 1:0 inProgress 였던 매치가 19:30 크론에 unstarted 0:0 으로 되돌아가고 19:30:33
+	 * 네이버 선반영이 스코어만 복구했다. 매시 :00/:30 마다 리스트·상세가 0:0 으로 깜빡이고
+	 * state 는 세트 사이 unstarted 로 고착했다.</p>
+	 *
+	 * <p>업스트림 gameWins 는 다음 세트 픽밴에야 뒤집혀 몇 분간 뒤처지고(네이버 오버레이가 항상
+	 * 앞선다), 세트가 끝난 뒤 스코어가 줄어들 이유는 없다. 정정은 completed 갱신이 담당한다 —
+	 * 그 경로를 막지 않으므로 네이버 wrong-high 도 최종값으로 self-heal 된다.</p>
+	 */
+	static void preserveLiveProgress(LeagueMatch existing, LeagueMatch incoming) {
+		if (isCompleted(existing) || isCompleted(incoming)) {
+			return;
+		}
+		boolean scoreBehind = scoreSum(incoming) < scoreSum(existing);
+		boolean stateBehind = stateRank(incoming) < stateRank(existing);
+		if (!scoreBehind && !stateBehind) {
+			return;
+		}
+		log.info("업스트림이 진행 중 매치를 되돌려 앞선 값을 유지한다. matchId={} 유지={}:{}({}) 수신={}:{}({})",
+				existing.getId(),
+				scoreBehind ? existing.getBlueScore() : incoming.getBlueScore(),
+				scoreBehind ? existing.getRedScore() : incoming.getRedScore(),
+				stateBehind ? existing.getState() : incoming.getState(),
+				incoming.getBlueScore(), incoming.getRedScore(), incoming.getState());
+		incoming.restoreResult(
+				stateBehind ? existing.getState() : incoming.getState(),
+				scoreBehind ? existing.getBlueScore() : incoming.getBlueScore(),
+				scoreBehind ? existing.getRedScore() : incoming.getRedScore());
+	}
+
+	/** 경기 진행 단계. 뒤로 가는 갱신을 판정하는 데만 쓴다 — 미상 상태는 최하위로 본다. */
+	private static int stateRank(LeagueMatch match) {
+		String state = match.getState();
+		if (state == null) {
+			return 0;
+		}
+		return switch (state.toLowerCase()) {
+			case "completed" -> 2;
+			case "inprogress" -> 1;
+			default -> 0;
+		};
+	}
+
 	private static int scoreSum(LeagueMatch match) {
 		int blue = match.getBlueScore() == null ? 0 : match.getBlueScore();
 		int red = match.getRedScore() == null ? 0 : match.getRedScore();
@@ -1040,6 +1087,9 @@ public class LeagueMatchService {
 							existing.getId(), existing.getBlueScore(), existing.getRedScore(), existing.getState(),
 							incoming.getBlueScore(), incoming.getRedScore(), incoming.getState());
 					incoming.restoreResult(existing.getState(), existing.getBlueScore(), existing.getRedScore());
+				} else {
+					// 진행 중 매치도 되돌림을 막는다 — 위 가드는 completed 결과만 지킨다.
+					preserveLiveProgress(existing, incoming);
 				}
 
 				if (!hasRealtimeRelevantChange(existing, incoming)) {

--- a/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceLiveRegressionTest.java
+++ b/src/test/java/com/toy/nar/app/lolesports/LeagueMatchServiceLiveRegressionTest.java
@@ -1,0 +1,137 @@
+package com.toy.nar.app.lolesports;
+
+import com.toy.nar.app.lolesports.repository.LeagueMatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 진행 중 경기의 스코어·상태 후퇴를 막는다.
+ *
+ * <p>{@link LeagueMatchService#isResultRegression}은 completed 결과만 지킨다. 그래서 아직 진행 중인
+ * 경기는 30분 주기 전체 동기화가 업스트림 stale 값으로 조건 없이 덮어썼다 — 실측 2026-08-12
+ * DNS vs GEN: 19:04 에 1:0 inProgress 였던 매치가 19:30 크론에 unstarted 0:0 으로 되돌아가고
+ * 19:30:33 네이버 선반영이 스코어만 복구했다. 매시 :00/:30 마다 리스트·상세가 0:0 으로 깜빡이고,
+ * state 는 세트 사이 unstarted 로 고착했다.</p>
+ *
+ * <p>업스트림 gameWins 는 다음 세트 픽밴에야 뒤집혀 몇 분간 뒤처지고(네이버 오버레이가 항상
+ * 앞선다), 세트가 끝난 뒤 스코어가 줄어들 이유는 없다. 그래서 비완료 갱신은 스코어·상태를
+ * 각각 앞선 값으로 유지한다. 최종 정정은 completed 갱신이 담당한다(self-heal).</p>
+ */
+class LeagueMatchServiceLiveRegressionTest {
+
+	@Test
+	@DisplayName("진행 중 1:0 을 미시작 0:0 으로 되돌리면 스코어·상태 모두 지킨다")
+	void keepsScoreAndStateWhenCronRevertsToUnstarted() {
+		LeagueMatch existing = match("inProgress", 1, 0);
+		LeagueMatch incoming = match("unstarted", 0, 0);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("inProgress");
+		assertThat(incoming.getBlueScore()).isEqualTo(1);
+		assertThat(incoming.getRedScore()).isZero();
+	}
+
+	@Test
+	@DisplayName("스코어만 후퇴하면 스코어만 지키고 상태는 수신값을 쓴다")
+	void keepsOnlyScoreWhenStateIsNotBehind() {
+		LeagueMatch existing = match("inProgress", 1, 1);
+		LeagueMatch incoming = match("inProgress", 1, 0);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("inProgress");
+		assertThat(incoming.getBlueScore()).isEqualTo(1);
+		assertThat(incoming.getRedScore()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("상태만 후퇴하면 상태만 지키고 전진한 스코어는 수신값을 쓴다")
+	void keepsOnlyStateWhenScoreMovedForward() {
+		LeagueMatch existing = match("inProgress", 1, 0);
+		LeagueMatch incoming = match("unstarted", 1, 1);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("inProgress");
+		assertThat(incoming.getBlueScore()).isEqualTo(1);
+		assertThat(incoming.getRedScore()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("전진하는 갱신은 그대로 통과시킨다")
+	void passesForwardUpdate() {
+		LeagueMatch existing = match("inProgress", 1, 0);
+		LeagueMatch incoming = match("inProgress", 1, 1);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getBlueScore()).isEqualTo(1);
+		assertThat(incoming.getRedScore()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("수신이 completed 면 손대지 않는다 — 최종 스코어 정정과 self-heal 경로다")
+	void doesNotTouchCompletedIncoming() {
+		LeagueMatch existing = match("inProgress", 1, 1);
+		LeagueMatch incoming = match("completed", 2, 1);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("completed");
+		assertThat(incoming.getBlueScore()).isEqualTo(2);
+		assertThat(incoming.getRedScore()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("기존이 completed 면 대상이 아니다 — isResultRegression 이 담당한다")
+	void doesNotTouchCompletedExisting() {
+		LeagueMatch existing = match("completed", 2, 0);
+		LeagueMatch incoming = match("inProgress", 1, 0);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("inProgress");
+		assertThat(incoming.getBlueScore()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("시작 전 경기에 0:0 이 오는 것은 정상이다")
+	void unstartedZeroIsNotRegression() {
+		LeagueMatch existing = match("unstarted", 0, 0);
+		LeagueMatch incoming = match("unstarted", 0, 0);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("unstarted");
+		assertThat(incoming.getBlueScore()).isZero();
+	}
+
+	@Test
+	@DisplayName("스코어가 null 이어도 터지지 않는다")
+	void nullScoresAreSafe() {
+		LeagueMatch existing = match("inProgress", 1, 0);
+		LeagueMatch incoming = match("unstarted", null, null);
+
+		LeagueMatchService.preserveLiveProgress(existing, incoming);
+
+		assertThat(incoming.getState()).isEqualTo("inProgress");
+		assertThat(incoming.getBlueScore()).isEqualTo(1);
+		assertThat(incoming.getRedScore()).isZero();
+	}
+
+	private LeagueMatch match(String state, Integer blueScore, Integer redScore) {
+		return LeagueMatch.builder()
+				.id("116929376557102192")
+				.leagueName("LCK")
+				.state(state)
+				.blueTeamCode("DNS")
+				.blueScore(blueScore)
+				.redTeamCode("GEN")
+				.redScore(redScore)
+				.bestOf(3)
+				.build();
+	}
+}


### PR DESCRIPTION
## 문제

`isResultRegression` 은 **completed 결과만** 지킨다. 그래서 아직 진행 중인 경기는 30분 주기 전체 동기화가 업스트림 stale 값으로 조건 없이 덮어쓴다.

**실측 2026-08-12 DNS vs GEN (CloudWatch)**

```
19:04:06  Realtime match status synced  state=inProgress score=1:0   ← 정상
19:30:04  30분 크론 → unstarted 0:0 으로 되돌림                      ← 여기
19:30:33  세트 사이 네이버 스코어 선반영 1:0                          ← 스코어만 복구
```

증상 두 개:
- **매시 :00/:30 마다 리스트·상세 스코어가 0:0 으로 깜빡인다.** 선반영이 다음 폴링 tick 에 복구하지만 그 사이 사용자에게 보인다.
- **state 가 unstarted 로 고착한다.** 선반영은 스코어만 복구하고 상태는 되돌린 채 남는다 — 세트 사이엔 프로브가 라이브 게임을 못 찾아 다시 올려주지도 못해서, 진행 중 경기가 "시작 전" 으로 보인다.

카드는 #373 에서 후퇴를 무시하도록 막았지만, 그건 카드만 가린 것이고 원인은 여기다.

## 변경

비완료 갱신은 스코어·상태를 **각각** 앞선 값으로 유지한다(`preserveLiveProgress`).

- 스코어 합이 후퇴하면 기존 스코어 유지, 상태 단계(`unstarted` 0 < `inProgress` 1 < `completed` 2)가 후퇴하면 기존 상태 유지 — 한쪽만 후퇴한 경우 다른 쪽은 수신값을 그대로 쓴다
- `isResultRegression` 이 걸리지 않은 경우에만 돈다(completed 결과는 기존 가드가 담당)
- **completed 갱신은 손대지 않는다** — 리메이크·오기 정정이 그 경로로 들어오고, 네이버 wrong-high 가 최종 스코어로 덮여 self-heal 되는 것도 거기에 의존한다

근거: 업스트림 `gameWins` 는 다음 세트 픽밴에야 뒤집혀 몇 분간 뒤처지고(네이버 오버레이가 항상 앞선다 — `overlayNaverScoreIfAhead` 주석의 실측), 세트가 끝난 뒤 스코어가 줄어들 이유가 없다.

되돌림이 막히면 `hasRealtimeRelevantChange` 가 무변경으로 판정해 write 자체가 생략된다 — 크론이 헛돌지 않는다.

## 테스트

`LeagueMatchServiceLiveRegressionTest` 8건
- 진행 중 1:0 → 미시작 0:0: 스코어·상태 모두 유지
- 스코어만 후퇴: 스코어만 유지, 상태는 수신값
- 상태만 후퇴: 상태만 유지, 전진한 스코어는 수신값
- 전진 갱신은 통과 / 수신 completed 는 무개입 / 기존 completed 는 대상 아님 / 시작 전 0:0 정상 / null 스코어 안전

기존 `LeagueMatchServiceResultRegressionTest` 는 수정 없이 통과 — completed 가드 계약이 그대로라는 뜻이다. 전체 `./gradlew test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
