### PR TITLE
feat: Prometheus 메트릭 엔드포인트 노출

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,21 @@ server:
     enabled: true
     min-response-size: 1KB
 
+# Prometheus 스크랩용 메트릭 노출. actuator 와 micrometer-registry-prometheus 는 이미
+# 의존성에 있었고 노출 목록만 기본값(health)이라 /actuator/prometheus 가 404 였다.
+#
+# 접근 제어는 앱이 아니라 nginx 가 한다 — SecurityConfig 는 /actuator/** 를 permitAll 로 둔다.
+# api.nar.kr 은 /actuator/ 를 404 로 막고, 9105 포트(conf.d/nar-metrics.conf)만
+# Tailscale 대역(100.64.0.0/10)에 열어 스크랩을 받는다. 메트릭에는 내부 엔드포인트 경로와
+# 커넥션 풀·스케줄러 상태가 그대로 드러나므로 공개 도메인으로 새면 안 된다.
+#
+# 앞단 nginx 가 없는 환경(예: k8s)으로 옮기면 이 전제가 깨진다. 그때는 접근 제어를 앱으로 가져와야 한다.
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}


### PR DESCRIPTION
## 배경

맥미니에 Prometheus + Grafana 를 세워 앱을 관측하려는데 `/actuator/prometheus` 가 404 였다.

원인은 의존성이 아니라 설정이었다. `spring-boot-starter-actuator`(build.gradle:28)와
`micrometer-registry-prometheus`(build.gradle:34)는 이미 들어 있고,
`management` 블록이 없어 노출 목록이 기본값(`health`)으로만 잡혀 있었다.

## 변경

`application.yml` 에 `management.endpoints.web.exposure.include: health,prometheus` 추가. 그게 전부다.

## 접근 제어 — 앱이 아니라 nginx 가 한다

`SecurityConfig:72` 가 `/actuator/**` 를 `permitAll` 로 두고 있어, 노출만 켜면 메트릭이
`api.nar.kr` 로 그대로 공개된다. 메트릭에는 내부 엔드포인트 경로, HikariCP 풀 상태,
스케줄러 잡 이름이 들어 있다.

그래서 서버 쪽에서 먼저 막아뒀다(레포 밖, EC2 nginx 설정).

- `sites-enabled/api.nar.kr` 의 443 블록에 `location /actuator/ { return 404; }` 추가
- `conf.d/nar-metrics.conf` 신규 — 9105 포트에서 `allow 100.64.0.0/10; deny all;` 로
  Tailscale 대역만 허용하고 `upstream nar_backend` 로 프록시

`nar_backend` 를 참조하므로 블루-그린 전환(8080↔8083)을 자동으로 따라간다.
`conf.d/` 는 배포 스크립트가 재작성하는 `nar-upstream.conf` 와 별개 파일이라 배포에 덮이지 않는다.

적용 전후:

```
https://api.nar.kr/actuator/health   200 → 404
http://nar-app:9105/actuator/health  (Tailscale) 200
```

## 검증

머지·배포 후:

```bash
curl -s http://nar-app:9105/actuator/prometheus | head          # 메트릭 출력
curl -s -o /dev/null -w '%{http_code}\n' \
  https://api.nar.kr/actuator/prometheus                        # 404
```

## 남는 것

앞단 nginx 가 없는 환경으로 앱을 옮기면 이 전제가 깨진다. 그때는 접근 제어를 앱으로
가져와야 한다. yml 주석에 남겨뒀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)