### PR TITLE
docs: 관측 스택 설정 파일과 재구축 절차 기록

### DIFF
--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,163 @@
+# 관측 스택 (Prometheus · Loki · Grafana)
+
+맥미니 홈서버를 관측 허브로 두고 프로덕션 앱(EC2)과 DB(Oracle VM)의 메트릭·로그를 한 곳에서 본다.
+
+이 디렉토리는 **원본 보관용이다. 자동 배포가 아니다.** 서버 설정을 바꿨으면 여기에도 반영하고,
+기기를 새로 세울 때는 여기서 복사한다.
+
+## 토폴로지
+
+```
+EC2 nar-app (100.88.94.95)
+  ├ nginx :9105        ──pull──>  Prometheus ─┐
+  └ Grafana Alloy      ──push──>  Loki ───────┼─> Grafana :3000
+                                              │
+Oracle VM nargg-vnic (100.101.232.109)        │
+  └ mysqld_exporter :9104  ──pull─────────────┘
+
+                          맥미니 (100.111.167.92)
+```
+
+**방향이 서로 반대다.** Prometheus는 맥미니가 긁어가고(pull), Loki는 EC2가 밀어넣는다(push).
+
+전 구간이 Tailscale 위다. 공인 IP도 포트 개방도 없다. 그래서 **EC2 보안그룹에 9105를 열면 안 된다** —
+Tailscale 트래픽은 이미 성립된 아웃바운드 WireGuard 세션에 실려 오므로 보안그룹을 거치지 않는다.
+열면 인터넷에도 노출된다.
+
+Colima VM 안 컨테이너에서 `100.x` 대역은 도달하지만 **MagicDNS 이름은 해석하지 못한다.**
+그래서 스크랩 타깃과 push URL은 이름이 아니라 IP로 적는다.
+
+## 접속
+
+| | 주소 |
+|---|---|
+| Grafana | `http://macmini:3000` |
+| Prometheus | `http://macmini:9090` |
+| Loki | `http://macmini:3100` (직접 볼 일은 없다) |
+
+Tailscale 안에서만 닿는다.
+
+## 앱 메트릭이 9105를 거치는 이유
+
+앱 컨테이너는 `127.0.0.1:8080|8083`에만 바인딩되고(블루-그린), `SecurityConfig`는
+`/actuator/**`를 `permitAll`로 둔다. 즉 앱 자체에는 인증이 없다. 접근 제어를 전부 nginx가 한다.
+
+- `sites-enabled/api.nar.kr` 443 블록에 `location /actuator/ { return 404; }` — 공개 도메인 차단
+- `conf.d/nar-metrics.conf`(이 디렉토리의 `ec2/nginx-nar-metrics.conf`) — 9105 포트를
+  Tailscale 대역(`100.64.0.0/10`)에만 열어 스크랩을 받는다
+
+`upstream nar_backend`를 참조하므로 블루-그린 포트 전환(8080↔8083)을 자동으로 따라간다.
+배포 스크립트가 재작성하는 파일은 `conf.d/nar-upstream.conf` 뿐이라 이 설정은 배포에 덮이지 않는다.
+
+**앞단 nginx가 없는 환경으로 앱을 옮기면 이 전제가 깨진다.** 그때는 접근 제어를 앱으로 가져와야 한다.
+
+## 재구축
+
+### 맥미니
+
+```bash
+brew install colima docker docker-compose
+colima start --cpu 6 --memory 10 --disk 100 --vm-type vz --mount-type virtiofs
+brew services start colima
+
+mkdir -p ~/monitoring && cp -r macmini/* ~/monitoring/
+cd ~/monitoring && docker compose up -d
+```
+
+대시보드는 Grafana API로 넣는다. 4701(JVM Micrometer), 12900(SpringBoot APM)은 import API로
+그대로 들어가지만, **14057(MySQL)은 `__inputs`가 비어 있고 `id`가 박혀 있어 import API가 거부한다.**
+`id`를 `null`로 바꿔 `/api/dashboards/db`에 POST해야 들어간다.
+
+### EC2
+
+```bash
+sudo mkdir -p /etc/apt/keyrings/
+wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | sudo tee /etc/apt/sources.list.d/grafana.list
+sudo apt-get update && sudo apt-get install -y alloy
+
+sudo cp alloy-config.alloy /etc/alloy/config.alloy
+sudo usermod -aG docker alloy          # 도커 소켓을 읽어야 한다
+sudo systemctl restart alloy
+
+sudo cp nginx-nar-metrics.conf /etc/nginx/conf.d/
+sudo nginx -t && sudo nginx -s reload
+```
+
+### Oracle VM
+
+```bash
+V=0.20.0
+curl -sSL -O https://github.com/prometheus/mysqld_exporter/releases/download/v${V}/mysqld_exporter-${V}.linux-amd64.tar.gz
+tar xzf mysqld_exporter-${V}.linux-amd64.tar.gz
+sudo install -m 0755 mysqld_exporter-${V}.linux-amd64/mysqld_exporter /usr/local/bin/
+
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin mysqld_exporter
+sudo mkdir -p /etc/mysqld_exporter
+# .my.cnf 작성: [client] user=exporter / password=... / socket=/var/run/mysqld/mysqld.sock
+sudo chown -R mysqld_exporter:mysqld_exporter /etc/mysqld_exporter
+sudo chmod 600 /etc/mysqld_exporter/.my.cnf
+
+sudo cp mysqld_exporter.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now mysqld_exporter
+```
+
+exporter 계정은 읽기 전용으로 만든다.
+
+```sql
+CREATE USER 'exporter'@'localhost' IDENTIFIED BY '<비번>' WITH MAX_USER_CONNECTIONS 3;
+GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+```
+
+TCP 대신 유닉스 소켓을 쓴다. MySQL 8 기본 인증(`caching_sha2_password`)이 평문 TCP에서
+RSA 키 교환을 요구하는데, 소켓은 그 과정을 건너뛴다.
+
+## 시크릿
+
+이 디렉토리에는 시크릿이 없다.
+
+- Grafana 관리자 비밀번호 — 맥미니 `grafana-data` 볼륨 안
+- mysqld_exporter 비밀번호 — EC2가 아닌 Oracle VM의 `/etc/mysqld_exporter/.my.cnf` (0600)
+
+Tailscale IP가 들어가지만 사설망 주소라 공개돼도 접근되지 않는다.
+
+## 밟았던 함정
+
+1. **`proxy_set_header Host $host;`를 빼면 400 Bad Request가 난다.** nginx 기본값은 Host 헤더에
+   `$proxy_host`(=`nar_backend`)를 넣는데, 호스트명에 언더스코어는 RFC상 무효라 Tomcat이 거부한다.
+
+2. **`sites-available`과 `sites-enabled`가 심볼릭 링크가 아니다.** `sites-available` 쪽은
+   `proxy_pass localhost:8080`이 하드코딩된 옛 사본이다. 활성 설정은 `nginx -T`(머지된 최종 설정)로 확인한다.
+
+3. **`sites-enabled/`에 `.bak` 파일을 두면 안 된다.** nginx가 그 디렉토리의 모든 파일을 include해서
+   server 블록이 중복된다. 백업은 다른 경로에 둔다.
+
+4. **Promtail은 2026년 3월 2일 EOL이다.** 인터넷 문서 대부분이 Promtail 기준이라 그대로 따라하면
+   지원이 끝난 스택을 깐다. Grafana Alloy를 쓴다.
+
+5. **Loki는 컨테이너가 `Up`이어도 `/ready`가 한동안 503을 낸다**(ingester 워밍업 15초).
+   부팅 후 전체가 준비되기까지 약 60초 걸린다. 알림 규칙을 걸 때 이 구간을 오탐으로 잡지 않게 한다.
+
+## 자주 쓰는 쿼리
+
+```promql
+# 버퍼풀 히트율 (구간별) — 누적값만 보면 최근 상태를 놓친다
+1 - rate(mysql_global_status_innodb_buffer_pool_reads[5m])
+  / rate(mysql_global_status_innodb_buffer_pool_read_requests[5m])
+
+jvm_memory_used_bytes{area="heap"}
+hikaricp_connections_active
+```
+
+```logql
+{container="nar-gg-blue"} | detected_level="error"
+
+# 1초 넘는 요청. LoggingFilter 가 요청마다 Duration 을 남긴다
+{container="nar-gg-blue"} |= "[END]" | pattern "<_>Duration: <dur>ms" | dur > 1000
+
+# 에러 발생률 — 알림 규칙에 쓸 식
+sum(rate({container="nar-gg-blue"} | detected_level="error" [5m]))
+```
+
+블루-그린 배포라 컨테이너 이름이 `nar-gg-blue`와 `nar-gg-green`을 오간다. 현재 어느 쪽인지는
+`container` 라벨 값으로 확인한다.

--- a/infra/monitoring/ec2/alloy-config.alloy
+++ b/infra/monitoring/ec2/alloy-config.alloy
@@ -1,0 +1,38 @@
+// EC2 의 도커 컨테이너 로그를 맥미니 Loki 로 밀어넣는다.
+// Prometheus 는 맥미니가 긁어가는 pull 이지만 Loki 는 push 라 방향이 반대다.
+// 경로는 Tailscale — 공인 IP·포트 개방 없이 100.x 로 직접 보낸다.
+
+discovery.docker "containers" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "15s"
+}
+
+discovery.relabel "containers" {
+  targets = discovery.docker.containers.targets
+
+  // 컨테이너 이름 앞의 슬래시를 떼어 nar-gg-blue / nar-gg-green / dozzle 로 라벨링한다.
+  // 블루-그린 배포라 이름이 번갈아 바뀌므로, 배포 전후를 구분해서 볼 때 이 라벨을 쓴다.
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_log_stream"]
+    target_label  = "stream"
+  }
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.containers.output
+  labels     = { host = "nar-app", env = "prod" }
+  forward_to = [loki.write.macmini.receiver]
+}
+
+loki.write "macmini" {
+  endpoint {
+    url = "http://100.111.167.92:3100/loki/api/v1/push"
+  }
+}

--- a/infra/monitoring/ec2/nginx-nar-metrics.conf
+++ b/infra/monitoring/ec2/nginx-nar-metrics.conf
@@ -1,0 +1,16 @@
+server {
+    listen 9105;
+
+    location /actuator/ {
+        allow 100.64.0.0/10;
+        deny all;
+
+        proxy_pass http://nar_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / { return 404; }
+}

--- a/infra/monitoring/macmini/docker-compose.yml
+++ b/infra/monitoring/macmini/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prom-data:/prometheus
+    ports:
+      - "9090:9090"
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    ports:
+      - "3100:3100"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3000:3000"
+
+volumes:
+  prom-data:
+  loki-data:
+  grafana-data:

--- a/infra/monitoring/macmini/grafana/provisioning/datasources/datasource.yml
+++ b/infra/monitoring/macmini/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/infra/monitoring/macmini/loki-config.yml
+++ b/infra/monitoring/macmini/loki-config.yml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2026-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  # 보관 14일. 맥미니 디스크는 여유가 있으나 사고 조사는 대개 며칠 안에 끝난다.
+  retention_period: 336h
+  # EC2 Alloy 가 재시작 후 밀린 로그를 밀어넣을 때 거부당하지 않게 한다.
+  reject_old_samples: false
+  volume_enabled: true
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem

--- a/infra/monitoring/macmini/prometheus.yml
+++ b/infra/monitoring/macmini/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: nar-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['100.88.94.95:9105']
+        labels:
+          instance: nar-app
+
+  - job_name: mysql
+    static_configs:
+      - targets: ['100.101.232.109:9104']
+        labels:
+          instance: nargg-vnic

--- a/infra/monitoring/oracle-vm/mysqld_exporter.service
+++ b/infra/monitoring/oracle-vm/mysqld_exporter.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Prometheus MySQL Exporter
+After=network-online.target mysql.service
+Wants=network-online.target
+
+[Service]
+User=mysqld_exporter
+Group=mysqld_exporter
+Type=simple
+ExecStart=/usr/local/bin/mysqld_exporter   --config.my-cnf=/etc/mysqld_exporter/.my.cnf   --web.listen-address=:9104
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## 배경

맥미니를 관측 허브로 세워 프로덕션 앱(EC2)과 DB(Oracle VM)를 Prometheus·Loki·Grafana 로 보고 있다.
그런데 그 설정이 세 기기 안에만 존재해서, 기기가 죽으면 기억으로 재구축해야 하는 상태였다.

원본을 레포로 옮긴다. **자동 배포가 아니라 원본 보관이다.** 서버 설정을 바꾸면 여기에도 반영한다.

## 구성

```
infra/monitoring/
├── README.md                      토폴로지 · 재구축 절차 · 함정
├── macmini/                       docker compose (Prometheus · Loki · Grafana)
├── ec2/                           nginx 9105 · Alloy
└── oracle-vm/                     mysqld_exporter systemd 유닛
```

## 토폴로지 — pull 과 push 방향이 반대다

```
EC2 nar-app        nginx :9105          ──pull──>  Prometheus ─┐
                   Grafana Alloy        ──push──>  Loki ───────┼─> Grafana :3000
Oracle nargg-vnic  mysqld_exporter :9104 ──pull───────────────┘
```

전 구간이 Tailscale 위라 공인 IP 도 포트 개방도 없다.
그래서 **EC2 보안그룹에 9105 를 열면 안 된다** — Tailscale 트래픽은 이미 성립된 아웃바운드
WireGuard 세션에 실려 오므로 보안그룹을 거치지 않는다. 열면 인터넷에도 노출된다.

## 앱 메트릭이 9105 를 거치는 이유

앱 컨테이너는 `127.0.0.1:8080|8083` 에만 바인딩되고(블루-그린), `SecurityConfig` 는
`/actuator/**` 를 permitAll 로 둔다. 즉 앱 자체에는 인증이 없어서 접근 제어를 nginx 가 전담한다.

- `sites-enabled/api.nar.kr` 443 블록: `location /actuator/ { return 404; }`
- `conf.d/nar-metrics.conf`: 9105 를 `100.64.0.0/10` 에만 열고 `upstream nar_backend` 로 프록시

`nar_backend` 를 참조하므로 블루-그린 전환을 자동으로 따라가고, 배포 스크립트가 재작성하는
`conf.d/nar-upstream.conf` 와는 별개 파일이라 배포에 덮이지 않는다.

## 시크릿은 들어있지 않다

- Grafana 관리자 비밀번호 — 맥미니 `grafana-data` 볼륨 안
- mysqld_exporter 비밀번호 — Oracle VM `/etc/mysqld_exporter/.my.cnf` (0600)

Tailscale IP 가 들어가지만 사설망 주소라 공개돼도 접근되지 않는다.

## 참고

`infra/monitoring/macmini/docker-compose.yml` 은 `.gitignore:39` 의 `docker-compose.yml`
패턴에 걸려서 `git add -f` 로 넣었다. 루트의 로컬 개발용 compose 를 무시하려던 패턴이
하위 디렉토리까지 잡은 것이다. `.gitignore` 를 고치면 다른 사람 로컬 compose 가 딸려
들어갈 수 있어 파일 하나만 예외 처리했다.

## 검증

재부팅 후 전부 자동 복구되는 것을 확인했다.

```
uptime 43초    prometheus / loki / grafana 자동 기동
Prometheus     nar-app UP, mysql UP
Loki           6초 전 로그까지 수집 (Alloy 자동 재연결)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)