### PR TITLE
feat: NAR 서비스 개요 대시보드 + 응답시간 히스토그램

### DIFF
--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -83,19 +83,15 @@ Tailscale 안에서만 닿는다.
 
 2026-08-15 실측 비율은 Warding 91%, 인증 나머지 대부분, 웹 7%, 백오피스 0 이다.
 
-응답시간 패널은 **평균**이다. Spring Boot 가 기본으로 히스토그램 버킷을 내보내지 않아
-`histogram_quantile` 을 쓸 수 없다. p95/p99 로 바꾸려면 앱에 아래 설정이 필요하다.
+응답시간은 **p50/p95/p99** 로 본다. 평균은 꼬리를 감춘다 — 요청 1%가 5초 걸려도 평균은 거의
+안 움직인다.
 
-```yaml
-management:
-  metrics:
-    distribution:
-      percentiles-histogram:
-        http.server.requests: true
-      # 버킷 수를 줄여 카디널리티를 억제한다
-      minimum-expected-value: { http.server.requests: 10ms }
-      maximum-expected-value: { http.server.requests: 10s }
-```
+이게 되려면 앱이 히스토그램 버킷(`_bucket` 시리즈)을 내보내야 한다. Spring Boot 기본값은
+`_count` 와 `_sum` 뿐이라 평균밖에 못 구한다. `application.yml` 의
+`management.metrics.distribution` 블록이 그 설정이고, **이 설정 없이는 응답시간 패널이 전부 빈다.**
+
+버킷은 시리즈 수를 곱하므로 기대 범위를 10ms~10s 로 좁혀 카디널리티를 억제했다.
+10ms 미만은 구분할 실익이 없고 10s 를 넘으면 어차피 다 같은 장애다.
 
 ## 재구축
 

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -51,6 +51,52 @@ Tailscale 안에서만 닿는다.
 
 **앞단 nginx가 없는 환경으로 앱을 옮기면 이 전제가 깨진다.** 그때는 접근 제어를 앱으로 가져와야 한다.
 
+## 대시보드
+
+`macmini/grafana/provisioning/dashboards/` 아래 JSON 이 진실의 원천이다. `allowUiUpdates: false`
+라서 GUI 에서 고쳐도 30초 뒤 파일 내용으로 덮인다. **바꿀 때는 GUI 에서 실험한 뒤
+`Export > Save to file` 로 JSON 을 뽑아 이 파일을 갱신하고 커밋한다.**
+
+데이터소스 `uid` 는 `prometheus`, `loki` 로 고정한다. 대시보드 JSON 이 이 값을 참조하기 때문이다.
+`uid` 없이 먼저 프로비저닝하면 Grafana 가 랜덤 값을 붙이고, 나중에 `uid` 를 지정하는 순간
+`data source not found` 로 부팅이 실패한다(재시작 루프에 빠진다). `deleteDatasources` 로
+먼저 지우고 다시 만들게 해두었다.
+
+### NAR 서비스 개요 (`nar-overview.json`)
+
+"지금 정상인가"를 30초 안에 판단하는 1층 대시보드다. 벤더 임포트 대시보드(4701 JVM,
+12900 SpringBoot APM, 14057 MySQL)는 컴포넌트를 파고들 때 쓰는 참조용이고, 평소에 여는 건 이쪽이다.
+
+**백엔드는 단일 배포지만 URI 로 서비스를 나눠서 본다.** 배포를 쪼개지 않고도 트래픽·에러율·응답시간을
+서비스별로 분리할 수 있다.
+
+| 분류 | URI |
+|---|---|
+| Warding 앱 | `/api/mobile/**` |
+| 인증 (앱·웹 공통) | `/api/auth/**` |
+| 백오피스 | `/api/admin/**` |
+| 웹 | 위 셋과 `/actuator/**`, 노이즈를 제외한 나머지 |
+| 노이즈 | `UNKNOWN`, `REDIRECTION`, `/**` (크롤러·스캐너) |
+
+**인증을 웹에 넣으면 안 된다.** `/api/auth/**` 는 앱 사용자가 대부분이라, 웹으로 세면 웹 트래픽이
+4배로 부풀려진다(실측: 웹 0.12/s 인데 인증 포함 시 0.62/s). 그래서 별도 분류로 뺐다.
+
+2026-08-15 실측 비율은 Warding 91%, 인증 나머지 대부분, 웹 7%, 백오피스 0 이다.
+
+응답시간 패널은 **평균**이다. Spring Boot 가 기본으로 히스토그램 버킷을 내보내지 않아
+`histogram_quantile` 을 쓸 수 없다. p95/p99 로 바꾸려면 앱에 아래 설정이 필요하다.
+
+```yaml
+management:
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      # 버킷 수를 줄여 카디널리티를 억제한다
+      minimum-expected-value: { http.server.requests: 10ms }
+      maximum-expected-value: { http.server.requests: 10s }
+```
+
 ## 재구축
 
 ### 맥미니

--- a/infra/monitoring/macmini/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/monitoring/macmini/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+providers:
+  - name: nar
+    orgId: 1
+    folder: NAR
+    type: file
+    disableDeletion: false
+    # 파일이 진실의 원천이다. GUI 에서 고쳐도 다음 스캔에 덮인다.
+    # 바꿀 때는 GUI 에서 실험한 뒤 Export JSON 해서 이 파일을 갱신한다.
+    allowUiUpdates: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/infra/monitoring/macmini/grafana/provisioning/dashboards/nar-overview.json
+++ b/infra/monitoring/macmini/grafana/provisioning/dashboards/nar-overview.json
@@ -1,0 +1,332 @@
+{
+  "uid": "nar-overview",
+  "title": "NAR 서비스 개요",
+  "description": "지금 정상인가를 30초 안에 판단하는 대시보드. 백엔드는 단일 배포지만 URI 로 Warding 앱 / 웹 / 백오피스를 나눠서 본다.",
+  "tags": ["nar", "overview"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Warding 앱 요청/s",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "decimals": 2, "color": { "mode": "fixed", "fixedColor": "blue" } },
+        "overrides": []
+      },
+      "options": { "graphMode": "area", "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "웹 요청/s",
+      "description": "mobile·admin·auth·actuator 와 매칭 실패 노이즈(UNKNOWN, REDIRECTION, /**)를 뺀 나머지. 인증(/api/auth)은 앱 사용자가 대부분이라 웹으로 세면 웹 트래픽이 4배로 부풀려진다. 그래서 별도 분류로 뺐다.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "decimals": 3, "color": { "mode": "fixed", "fixedColor": "green" } },
+        "overrides": []
+      },
+      "options": { "graphMode": "area", "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "백오피스 요청/s",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 10, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/admin/.*\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "decimals": 3, "color": { "mode": "fixed", "fixedColor": "purple" } },
+        "overrides": []
+      },
+      "options": { "graphMode": "area", "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "5xx 에러율",
+      "description": "노이즈 경로를 제외한 전체 기준. 0.5% 넘으면 주황, 2% 넘으면 빨강.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\",uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])), 0.001)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.005 },
+              { "color": "red", "value": 0.02 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "graphMode": "area", "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "커넥션 대기",
+      "description": "HikariCP 에서 커넥션을 못 얻고 기다리는 스레드 수. 0 이 아니면 이미 병목이다. 과거 이 값이 쌓여 세트 종료 푸시가 6분 밀린 적이 있다.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 0 },
+      "targets": [{ "refId": "A", "expr": "sum(hikaricp_connections_pending)" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "graphMode": "area", "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "서비스별 요청량",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "Warding 앱",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\"}[5m]))"
+        },
+        {
+          "refId": "B",
+          "legendFormat": "웹",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m]))"
+        },
+        {
+          "refId": "C",
+          "legendFormat": "인증(앱·웹 공통)",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/auth/.*\"}[5m]))"
+        },
+        {
+          "refId": "D",
+          "legendFormat": "백오피스",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/admin/.*\"}[5m]))"
+        },
+        {
+          "refId": "E",
+          "legendFormat": "노이즈(크롤러·미매칭)",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "서비스별 평균 응답시간",
+      "description": "평균이라 꼬리를 못 본다. 히스토그램을 켜면 p95/p99 로 바꾼다(management.metrics.distribution.percentiles-histogram).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "Warding 앱",
+          "expr": "sum(rate(http_server_requests_seconds_sum{uri=~\"/api/mobile/.*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\"}[5m])), 0.001)"
+        },
+        {
+          "refId": "B",
+          "legendFormat": "웹",
+          "expr": "sum(rate(http_server_requests_seconds_sum{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])), 0.001)"
+        },
+        {
+          "refId": "C",
+          "legendFormat": "백오피스",
+          "expr": "sum(rate(http_server_requests_seconds_sum{uri=~\"/api/admin/.*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=~\"/api/admin/.*\"}[5m])), 0.001)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+    },
+
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "서비스별 에러율 (4xx / 5xx)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "앱 5xx",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\"}[5m])), 0.001)"
+        },
+        {
+          "refId": "B",
+          "legendFormat": "앱 4xx",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\",status=~\"4..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\"}[5m])), 0.001)"
+        },
+        {
+          "refId": "C",
+          "legendFormat": "웹 5xx",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])), 0.001)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "custom": { "lineWidth": 2, "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "느린 엔드포인트 TOP 5 (평균)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "{{uri}}",
+          "expr": "topk(5, sum by (uri) (rate(http_server_requests_seconds_sum{uri!~\"/actuator/.*\"}[5m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{uri!~\"/actuator/.*\"}[5m])), 0.001))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+    },
+
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "JVM 힙",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 20 },
+      "targets": [
+        { "refId": "A", "legendFormat": "사용", "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})" },
+        { "refId": "B", "legendFormat": "최대", "expr": "sum(jvm_memory_max_bytes{area=\"heap\"})" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "HikariCP 커넥션",
+      "description": "pending 이 0 을 벗어나면 풀이 부족하다는 뜻이다.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 20 },
+      "targets": [
+        { "refId": "A", "legendFormat": "active", "expr": "sum(hikaricp_connections_active)" },
+        { "refId": "B", "legendFormat": "idle", "expr": "sum(hikaricp_connections_idle)" },
+        { "refId": "C", "legendFormat": "pending", "expr": "sum(hikaricp_connections_pending)" },
+        { "refId": "D", "legendFormat": "max", "expr": "sum(hikaricp_connections_max)" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" } },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "MySQL 버퍼풀 히트율",
+      "description": "누적값이 아니라 5분 구간 기준. 버퍼풀이 128MB 뿐이라 이 값이 떨어지는 시간대를 찾는 게 목적이다.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 20 },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "히트율",
+          "expr": "1 - (rate(mysql_global_status_innodb_buffer_pool_reads[5m]) / clamp_min(rate(mysql_global_status_innodb_buffer_pool_read_requests[5m]), 0.001))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0.9,
+          "max": 1,
+          "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.98 },
+              { "color": "green", "value": 0.995 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+
+    {
+      "id": 40,
+      "type": "logs",
+      "title": "최근 ERROR 로그",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 27 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{host=\"nar-app\", container=~\"nar-gg-.*\"} | detected_level=\"error\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    }
+  ]
+}

--- a/infra/monitoring/macmini/grafana/provisioning/dashboards/nar-overview.json
+++ b/infra/monitoring/macmini/grafana/provisioning/dashboards/nar-overview.json
@@ -2,20 +2,36 @@
   "uid": "nar-overview",
   "title": "NAR 서비스 개요",
   "description": "지금 정상인가를 30초 안에 판단하는 대시보드. 백엔드는 단일 배포지만 URI 로 Warding 앱 / 웹 / 백오피스를 나눠서 본다.",
-  "tags": ["nar", "overview"],
+  "tags": [
+    "nar",
+    "overview"
+  ],
   "timezone": "browser",
   "editable": true,
   "schemaVersion": 39,
   "refresh": "30s",
-  "time": { "from": "now-6h", "to": "now" },
-  "templating": { "list": [] },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
   "panels": [
     {
       "id": 1,
       "type": "stat",
       "title": "Warding 앱 요청/s",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
       "targets": [
         {
           "refId": "A",
@@ -23,18 +39,41 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "decimals": 2, "color": { "mode": "fixed", "fixedColor": "blue" } },
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        },
         "overrides": []
       },
-      "options": { "graphMode": "area", "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "id": 2,
       "type": "stat",
       "title": "웹 요청/s",
       "description": "mobile·admin·auth·actuator 와 매칭 실패 노이즈(UNKNOWN, REDIRECTION, /**)를 뺀 나머지. 인증(/api/auth)은 앱 사용자가 대부분이라 웹으로 세면 웹 트래픽이 4배로 부풀려진다. 그래서 별도 분류로 뺐다.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
       "targets": [
         {
           "refId": "A",
@@ -42,17 +81,40 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "decimals": 3, "color": { "mode": "fixed", "fixedColor": "green" } },
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 3,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        },
         "overrides": []
       },
-      "options": { "graphMode": "area", "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "id": 3,
       "type": "stat",
       "title": "백오피스 요청/s",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 4, "x": 10, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
       "targets": [
         {
           "refId": "A",
@@ -60,18 +122,41 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "decimals": 3, "color": { "mode": "fixed", "fixedColor": "purple" } },
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 3,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        },
         "overrides": []
       },
-      "options": { "graphMode": "area", "colorMode": "value", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "id": 4,
       "type": "stat",
       "title": "5xx 에러율",
       "description": "노이즈 경로를 제외한 전체 기준. 0.5% 넘으면 주황, 2% 넘으면 빨강.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
       "targets": [
         {
           "refId": "A",
@@ -85,24 +170,54 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 0.005 },
-              { "color": "red", "value": 0.02 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.005
+              },
+              {
+                "color": "red",
+                "value": 0.02
+              }
             ]
           }
         },
         "overrides": []
       },
-      "options": { "graphMode": "area", "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
     {
       "id": 5,
       "type": "stat",
       "title": "커넥션 대기",
       "description": "HikariCP 에서 커넥션을 못 얻고 기다리는 스레드 수. 0 이 아니면 이미 병목이다. 과거 이 값이 쌓여 세트 종료 푸시가 6분 밀린 적이 있다.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 0 },
-      "targets": [{ "refId": "A", "expr": "sum(hikaricp_connections_pending)" }],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(hikaricp_connections_pending)"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -110,23 +225,102 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 },
-              { "color": "red", "value": 5 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
             ]
           }
         },
         "overrides": []
       },
-      "options": { "graphMode": "area", "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
     },
-
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "p95 응답시간",
+      "description": "노이즈·actuator 를 제외한 전체 기준. 평균이 아니라 상위 5% 요청이 얼마나 걸리는지를 본다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
     {
       "id": 10,
       "type": "timeseries",
       "title": "서비스별 요청량",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "targets": [
         {
           "refId": "A",
@@ -155,48 +349,103 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" } },
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
       "id": 11,
       "type": "timeseries",
-      "title": "서비스별 평균 응답시간",
-      "description": "평균이라 꼬리를 못 본다. 히스토그램을 켜면 p95/p99 로 바꾼다(management.metrics.distribution.percentiles-histogram).",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "title": "응답시간 분포 (p50 / p95 / p99)",
+      "description": "노이즈·actuator 제외 전체. Warding 앱이 트래픽의 90% 이상이라 사실상 앱 지연이다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "targets": [
         {
           "refId": "A",
-          "legendFormat": "Warding 앱",
-          "expr": "sum(rate(http_server_requests_seconds_sum{uri=~\"/api/mobile/.*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=~\"/api/mobile/.*\"}[5m])), 0.001)"
+          "legendFormat": "p50",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])))"
         },
         {
           "refId": "B",
-          "legendFormat": "웹",
-          "expr": "sum(rate(http_server_requests_seconds_sum{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri!~\"/api/mobile/.*|/api/admin/.*|/api/auth/.*|/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])), 0.001)"
+          "legendFormat": "p95",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])))"
         },
         {
           "refId": "C",
-          "legendFormat": "백오피스",
-          "expr": "sum(rate(http_server_requests_seconds_sum{uri=~\"/api/admin/.*\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=~\"/api/admin/.*\"}[5m])), 0.001)"
+          "legendFormat": "p99",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m])))"
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" } },
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never"
+          }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
-
     {
       "id": 20,
       "type": "timeseries",
       "title": "서비스별 에러율 (4xx / 5xx)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "targets": [
         {
           "refId": "A",
@@ -215,73 +464,197 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "custom": { "lineWidth": 2, "fillOpacity": 10, "showPoints": "never" } },
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
     {
       "id": 21,
       "type": "timeseries",
-      "title": "느린 엔드포인트 TOP 5 (평균)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "title": "느린 엔드포인트 TOP 5 (p95)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "targets": [
         {
           "refId": "A",
           "legendFormat": "{{uri}}",
-          "expr": "topk(5, sum by (uri) (rate(http_server_requests_seconds_sum{uri!~\"/actuator/.*\"}[5m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{uri!~\"/actuator/.*\"}[5m])), 0.001))"
+          "expr": "topk(5, histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator/.*|UNKNOWN|REDIRECTION|/\\\\*\\\\*\"}[5m]))))"
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" } },
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never"
+          }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max"] }, "tooltip": { "mode": "multi", "sort": "desc" } }
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
     },
-
     {
       "id": 30,
       "type": "timeseries",
       "title": "JVM 힙",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 20 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
       "targets": [
-        { "refId": "A", "legendFormat": "사용", "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})" },
-        { "refId": "B", "legendFormat": "최대", "expr": "sum(jvm_memory_max_bytes{area=\"heap\"})" }
+        {
+          "refId": "A",
+          "legendFormat": "사용",
+          "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})"
+        },
+        {
+          "refId": "B",
+          "legendFormat": "최대",
+          "expr": "sum(jvm_memory_max_bytes{area=\"heap\"})"
+        }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "bytes", "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" } },
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
     },
     {
       "id": 31,
       "type": "timeseries",
       "title": "HikariCP 커넥션",
       "description": "pending 이 0 을 벗어나면 풀이 부족하다는 뜻이다.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 20 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 20
+      },
       "targets": [
-        { "refId": "A", "legendFormat": "active", "expr": "sum(hikaricp_connections_active)" },
-        { "refId": "B", "legendFormat": "idle", "expr": "sum(hikaricp_connections_idle)" },
-        { "refId": "C", "legendFormat": "pending", "expr": "sum(hikaricp_connections_pending)" },
-        { "refId": "D", "legendFormat": "max", "expr": "sum(hikaricp_connections_max)" }
+        {
+          "refId": "A",
+          "legendFormat": "active",
+          "expr": "sum(hikaricp_connections_active)"
+        },
+        {
+          "refId": "B",
+          "legendFormat": "idle",
+          "expr": "sum(hikaricp_connections_idle)"
+        },
+        {
+          "refId": "C",
+          "legendFormat": "pending",
+          "expr": "sum(hikaricp_connections_pending)"
+        },
+        {
+          "refId": "D",
+          "legendFormat": "max",
+          "expr": "sum(hikaricp_connections_max)"
+        }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" } },
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never"
+          }
+        },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
     },
     {
       "id": 32,
       "type": "timeseries",
       "title": "MySQL 버퍼풀 히트율",
       "description": "누적값이 아니라 5분 구간 기준. 버퍼풀이 128MB 뿐이라 이 값이 떨어지는 시간대를 찾는 게 목적이다.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 20 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 20
+      },
       "targets": [
         {
           "refId": "A",
@@ -294,27 +667,55 @@
           "unit": "percentunit",
           "min": 0.9,
           "max": 1,
-          "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "orange", "value": 0.98 },
-              { "color": "green", "value": 0.995 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.98
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
             ]
           }
         },
         "overrides": []
       },
-      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
     },
-
     {
       "id": 40,
       "type": "logs",
       "title": "최근 ERROR 로그",
-      "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 27 },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
       "targets": [
         {
           "refId": "A",

--- a/infra/monitoring/macmini/grafana/provisioning/datasources/datasource.yml
+++ b/infra/monitoring/macmini/grafana/provisioning/datasources/datasource.yml
@@ -1,8 +1,18 @@
 apiVersion: 1
 
+# uid 를 고정해야 대시보드 JSON 이 데이터소스를 안정적으로 참조한다.
+# 처음 프로비저닝 때 uid 없이 만들면 Grafana 가 랜덤 uid 를 붙이고, 나중에 uid 를 지정하면
+# "data source not found" 로 부팅이 실패한다. 그래서 먼저 지우고 다시 만든다.
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+  - name: Loki
+    orgId: 1
+
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
@@ -10,6 +20,7 @@ datasources:
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://loki:3100
     editable: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,22 @@ management:
       exposure:
         include: health,prometheus
 
+  # 응답시간 히스토그램. 기본값은 _count 와 _sum 만 내보내서 평균밖에 못 구하는데,
+  # 평균은 꼬리를 감춘다 — 요청 1%가 5초 걸려도 평균은 거의 안 움직인다.
+  # _bucket 시리즈가 생겨야 PromQL 의 histogram_quantile 로 p95/p99 를 뽑을 수 있고,
+  # 여러 엔드포인트를 합산한 서비스 단위 p95 도 그때 비로소 계산이 맞는다.
+  #
+  # 버킷은 시리즈 수를 그대로 곱하므로 기대 범위를 좁혀 카디널리티를 억제한다.
+  # 10ms 미만은 구분할 실익이 없고, 10s 를 넘으면 어차피 다 같은 장애다.
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 10ms
+      maximum-expected-value:
+        http.server.requests: 10s
+
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}


### PR DESCRIPTION
## 배경

벤더 임포트 대시보드 3개(4701 JVM, 12900 SpringBoot APM, 14057 MySQL)만 있어서
"지금 정상인가"를 판단하려면 매번 대시보드 세 개를 뒤져야 했다.

실무에서 쓰는 계층 구조로 보면 **1층(서비스 개요)이 비어 있었다.** 그걸 채운다.

| 층 | 목적 |
|---|---|
| 1. 서비스 개요 | "지금 정상인가" — 한 화면, 30초 |
| 2. 컴포넌트 상세 | "어디가 문제인가" — 파고들 때 |
| 3. 벤더 임포트 | 참조용 |

## 1. 단일 배포에서 서비스를 나눠 본다

백엔드는 단일 레포·단일 배포지만 프론트는 NAR 웹과 Warding 앱 둘이다.
**배포를 쪼개지 않고 URI 라벨만으로 분리했다.** 앱 코드 변경이 없다.

| 분류 | URI | 실측 (2026-08-15) |
|---|---|---|
| Warding 앱 | `/api/mobile/**` | 1.744 req/s |
| 인증 (앱·웹 공통) | `/api/auth/**` | 0.526 req/s |
| 웹 | 나머지 | 0.119 req/s |
| 백오피스 | `/api/admin/**` | 0 |
| 노이즈 | `UNKNOWN`, `REDIRECTION`, `/**` | 0.035 req/s |

**인증을 웹에 넣으면 안 된다는 걸 실측에서 발견했다.** `/api/auth/**` 는 앱 사용자가
대부분인데 처음엔 웹으로 잡혀서 웹 트래픽이 0.62/s 로 나왔다. 별도 분류로 빼니 실제 웹은
0.12/s — 앱의 7% 수준이다. 합산해서 보면 웹이 통째로 죽어도 전체 그래프는 거의 안 움직인다.

## 2. 응답시간 히스토그램 (`application.yml`)

대시보드를 만들다 보니 **`_bucket` 시리즈가 0개**였다. Spring Boot 기본값은 `_count` 와
`_sum` 만 내보내서 평균밖에 못 구한다. 평균은 꼬리를 감춘다 — 요청 1%가 5초 걸려도
평균은 거의 움직이지 않는다.

```yaml
management:
  metrics:
    distribution:
      percentiles-histogram: { http.server.requests: true }
      minimum-expected-value: { http.server.requests: 10ms }
      maximum-expected-value: { http.server.requests: 10s }
```

버킷은 시리즈 수를 그대로 곱하므로 기대 범위를 좁혀 카디널리티를 억제했다.
10ms 미만은 구분할 실익이 없고, 10s 를 넘으면 어차피 다 같은 장애다.

이 설정이 있어야 `histogram_quantile` 로 p95/p99 를 뽑을 수 있고, 여러 엔드포인트를
합산한 **서비스 단위 p95** 도 그때 비로소 계산이 맞는다.

## 패널

```
[Warding req/s] [웹] [백오피스] [p95 응답시간] [5xx 에러율] [커넥션 대기]
[서비스별 요청량]                [응답시간 분포 p50/p95/p99]
[서비스별 에러율 4xx/5xx]        [느린 엔드포인트 TOP 5 (p95)]
[JVM 힙]        [HikariCP]       [MySQL 버퍼풀 히트율]
[최근 ERROR 로그 (Loki)]
```

"커넥션 대기"(`hikaricp_connections_pending`)를 상단 스탯에 올렸다. 과거 이 값이 쌓여
세트 종료 푸시가 6분 밀린 적이 있어서, 0 을 벗어나는 순간 눈에 띄어야 한다.

버퍼풀 히트율은 **구간별**이다. 누적값은 99.947% 로 항상 좋아 보이지만, 버퍼풀이 128MB 뿐이라
특정 시간대에 떨어지는지를 봐야 한다.

## 데이터소스 uid 고정

대시보드 JSON 이 데이터소스를 참조하려면 `uid` 가 안정적이어야 한다.

⚠️ `uid` 없이 먼저 프로비저닝하면 Grafana 가 랜덤 값을 붙인다. 나중에 `uid` 를 지정하는 순간
`data source not found` 로 **부팅이 실패하고 재시작 루프에 빠진다**(이번에 실제로 겪었다).
`deleteDatasources` 로 먼저 지우고 다시 만들게 했다.

## 대시보드 as code

`allowUiUpdates: false` 라 GUI 에서 고쳐도 30초 뒤 파일 내용으로 덮인다.
바꿀 때는 GUI 에서 실험한 뒤 `Export > Save to file` 로 JSON 을 뽑아 파일을 갱신하고 커밋한다.

## 배포 순서

앱 설정과 대시보드가 한 PR 에 있지만 반영 경로가 다르다.

1. 머지 → CI 가 앱 배포 → `_bucket` 시리즈 생성
2. 그 뒤 대시보드 JSON 을 맥미니에 복사 (`~/monitoring/grafana/provisioning/dashboards/`)

순서를 뒤집으면 응답시간 패널이 잠시 빈다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)