### PR TITLE
feat: 스케줄러 잡 지표 노출

### DIFF
--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -191,6 +191,27 @@ jvm_memory_used_bytes{area="heap"}
 hikaricp_connections_active
 ```
 
+```promql
+# 잡이 멎었나 — 마지막 성공 이후 경과 시간
+time() - nar_scheduler_last_success_epoch_seconds
+
+# 30분 주기인 MATCH_SYNC 가 한 시간 넘게 성공 못 함
+time() - nar_scheduler_last_success_epoch_seconds{job="MATCH_SYNC"} > 3600
+
+# 재시작 후 한 번도 못 돈 잡 (시리즈 자체가 없으므로 absent 로 잡는다)
+absent(nar_scheduler_last_success_epoch_seconds{job="MATCH_SYNC"})
+
+# 상류 CSV 정체 — 신규 게임 0건 연속
+nar_scheduler_zero_new_games_streak > 3
+
+# 잡별 실패율
+sum by (job) (rate(nar_scheduler_runs_total{outcome="failure"}[30m]))
+  / sum by (job) (rate(nar_scheduler_runs_total[30m]))
+
+# 잡 소요 시간 p95
+histogram_quantile(0.95, sum by (le, job) (rate(nar_scheduler_duration_seconds_bucket[30m])))
+```
+
 ```logql
 {container="nar-gg-blue"} | detected_level="error"
 

--- a/src/main/java/com/toy/nar/app/monitor/SchedulerAlertService.java
+++ b/src/main/java/com/toy/nar/app/monitor/SchedulerAlertService.java
@@ -1,6 +1,8 @@
 package com.toy.nar.app.monitor;
 
 import com.toy.nar.app.data.source.NotificationService;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +17,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 @Service
@@ -23,7 +27,11 @@ public class SchedulerAlertService {
 
 	private static final String DEFAULT_ZONE = "Asia/Seoul";
 
+	// 디스코드 알림·일일 요약과 별개로 Prometheus 지표를 같이 남긴다.
+	// 알림은 "터졌을 때 알려주는" 용도고 지표는 "언제부터 이상했는지" 를 되짚는 용도라 역할이 다르다.
+	// 잡마다 계측을 흩뿌리지 않고 모든 잡이 이미 거쳐가는 이 지점 한 곳에서만 기록한다.
 	private final NotificationService notificationService;
+	private final MeterRegistry meterRegistry;
 
 	@Value("${notification.scheduler.summary-enabled:true}")
 	private boolean summaryEnabled;
@@ -45,9 +53,17 @@ public class SchedulerAlertService {
 	private final Map<String, Instant> lastWarningAlertAt = new ConcurrentHashMap<>();
 	private final Map<String, Integer> zeroNewGamesStreakByJob = new ConcurrentHashMap<>();
 
+	// Gauge 는 값 소유자를 밖에 두고 참조만 넘기는 구조라, 잡별 홀더를 여기 붙잡아 둔다.
+	private final Map<String, AtomicLong> lastSuccessEpochByJob = new ConcurrentHashMap<>();
+	private final Map<String, AtomicLong> zeroNewGamesStreakGaugeByJob = new ConcurrentHashMap<>();
+
 	public void recordSuccess(String jobKey, String jobName, long durationMs) {
 		JobDailyStats stats = getStats(jobKey, jobName);
 		stats.recordSuccess(durationMs);
+
+		meterRegistry.counter("nar.scheduler.runs", "job", jobKey, "outcome", "success").increment();
+		meterRegistry.timer("nar.scheduler.duration", "job", jobKey).record(durationMs, TimeUnit.MILLISECONDS);
+		lastSuccessEpoch(jobKey).set(Instant.now().getEpochSecond());
 	}
 
 	public void recordFailure(String jobKey, String jobName, Exception e, String detail) {
@@ -58,6 +74,9 @@ public class SchedulerAlertService {
 	public void recordFailure(String jobKey, String jobName, String reason, String detail) {
 		JobDailyStats stats = getStats(jobKey, jobName);
 		stats.recordFailure(reason);
+
+		// reason 은 라벨로 쓰지 않는다. 예외 메시지가 그대로 들어와 카디널리티가 터진다.
+		meterRegistry.counter("nar.scheduler.runs", "job", jobKey, "outcome", "failure").increment();
 
 		String cooldownKey = jobKey + "|" + sanitize(reason);
 		if (!shouldSend(lastFailureAlertAt, cooldownKey, failureCooldownMinutes)) {
@@ -73,16 +92,21 @@ public class SchedulerAlertService {
 	public void trackZeroNewGames(String jobKey, String jobName, int newGamesAdded, long totalRowsProcessed) {
 		if (newGamesAdded > 0) {
 			zeroNewGamesStreakByJob.remove(jobKey);
+			zeroNewGamesStreak(jobKey).set(0);
 			return;
 		}
 
 		int streak = zeroNewGamesStreakByJob.merge(jobKey, 1, Integer::sum);
+		// 임계 도달 전에도 지표는 올린다. 디스코드 알림은 3회 연속부터지만,
+		// 상류 CSV 가 언제부터 밀리기 시작했는지는 1회째부터 그래프에 남아야 되짚을 수 있다.
+		zeroNewGamesStreak(jobKey).set(streak);
 		if (streak < zeroNewGamesThreshold) {
 			return;
 		}
 
 		JobDailyStats stats = getStats(jobKey, jobName);
 		stats.recordWarning("신규 게임 0건 연속");
+		meterRegistry.counter("nar.scheduler.runs", "job", jobKey, "outcome", "warning").increment();
 
 		String cooldownKey = jobKey + "|ZERO_NEW_GAMES";
 		if (!shouldSend(lastWarningAlertAt, cooldownKey, warningCooldownMinutes)) {
@@ -97,6 +121,8 @@ public class SchedulerAlertService {
 	public void recordWarning(String jobKey, String jobName, String detail) {
 		JobDailyStats stats = getStats(jobKey, jobName);
 		stats.recordWarning(detail);
+
+		meterRegistry.counter("nar.scheduler.runs", "job", jobKey, "outcome", "warning").increment();
 
 		String cooldownKey = jobKey + "|" + sanitize(detail);
 		if (!shouldSend(lastWarningAlertAt, cooldownKey, warningCooldownMinutes)) {
@@ -128,6 +154,38 @@ public class SchedulerAlertService {
 
 		String summary = buildSummaryMessage(snapshots);
 		notificationService.sendSchedulerSummaryNotification(targetDate.toString(), summary);
+	}
+
+	/**
+	 * 잡이 마지막으로 성공한 시각(epoch seconds).
+	 * <p>
+	 * 실행 횟수 카운터보다 이 값이 중요하다. 잡이 죽으면 카운터는 그냥 안 늘어서 눈에 띄지 않지만,
+	 * 이 게이지는 {@code time() - 값} 이 계속 커져서 임계치를 자동으로 넘긴다.
+	 * <p>
+	 * 첫 성공 전에는 시리즈 자체가 없다. 재시작 후 한 번도 못 돈 잡은 {@code absent()} 로 잡아야 한다.
+	 */
+	private AtomicLong lastSuccessEpoch(String jobKey) {
+		return lastSuccessEpochByJob.computeIfAbsent(jobKey, key -> {
+			AtomicLong holder = new AtomicLong();
+			Gauge.builder("nar.scheduler.last.success.epoch", holder, AtomicLong::get)
+					.tag("job", key)
+					.description("잡이 마지막으로 성공한 시각")
+					.baseUnit("seconds")
+					.register(meterRegistry);
+			return holder;
+		});
+	}
+
+	/** 신규 게임 0건이 연속으로 몇 번 나왔는지. 상류 CSV 정체를 그래프로 되짚기 위한 값이다. */
+	private AtomicLong zeroNewGamesStreak(String jobKey) {
+		return zeroNewGamesStreakGaugeByJob.computeIfAbsent(jobKey, key -> {
+			AtomicLong holder = new AtomicLong();
+			Gauge.builder("nar.scheduler.zero.new.games.streak", holder, AtomicLong::get)
+					.tag("job", key)
+					.description("신규 게임 0건 연속 횟수")
+					.register(meterRegistry);
+			return holder;
+		});
 	}
 
 	private JobDailyStats getStats(String jobKey, String jobName) {

--- a/src/test/java/com/toy/nar/app/monitor/SchedulerAlertServiceMetricsTest.java
+++ b/src/test/java/com/toy/nar/app/monitor/SchedulerAlertServiceMetricsTest.java
@@ -1,0 +1,98 @@
+package com.toy.nar.app.monitor;
+
+import com.toy.nar.app.data.source.NotificationService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 스케줄러 지표가 Prometheus 로 나가는지 검증한다.
+ * <p>
+ * 디스코드 알림 쪽 동작(쿨다운·요약)은 기존대로 두고, 여기서는 지표만 본다.
+ */
+class SchedulerAlertServiceMetricsTest {
+
+	private static final String JOB_KEY = "MATCH_SYNC";
+	private static final String JOB_NAME = "리그 경기 동기화";
+
+	private MeterRegistry registry;
+	private SchedulerAlertService service;
+
+	@BeforeEach
+	void setUp() {
+		registry = new SimpleMeterRegistry();
+		service = new SchedulerAlertService(Mockito.mock(NotificationService.class), registry);
+		// @Value 는 순수 단위 테스트에서 주입되지 않아 기본값이 0 이 된다.
+		// 0 이면 신규 게임 0건 경고가 첫 회부터 발사되므로 운영 기본값(3)을 넣어준다.
+		ReflectionTestUtils.setField(service, "zeroNewGamesThreshold", 3);
+	}
+
+	@Test
+	@DisplayName("성공하면 카운터·타이머·마지막 성공 시각이 모두 남는다")
+	void recordSuccess_publishesMetrics() {
+		long before = Instant.now().getEpochSecond();
+
+		service.recordSuccess(JOB_KEY, JOB_NAME, 1_500L);
+
+		assertThat(runs("success")).isEqualTo(1.0);
+		assertThat(registry.timer("nar.scheduler.duration", "job", JOB_KEY).count()).isEqualTo(1L);
+		assertThat(lastSuccessEpoch()).isGreaterThanOrEqualTo(before);
+	}
+
+	@Test
+	@DisplayName("실패는 outcome=failure 로만 집계되고 마지막 성공 시각은 건드리지 않는다")
+	void recordFailure_doesNotTouchLastSuccess() {
+		service.recordSuccess(JOB_KEY, JOB_NAME, 100L);
+		double successEpoch = lastSuccessEpoch();
+
+		service.recordFailure(JOB_KEY, JOB_NAME, "CONNECT_TIMEOUT", "상세");
+
+		assertThat(runs("failure")).isEqualTo(1.0);
+		assertThat(runs("success")).isEqualTo(1.0);
+		assertThat(lastSuccessEpoch()).isEqualTo(successEpoch);
+	}
+
+	@Test
+	@DisplayName("신규 게임 0건 연속 횟수는 임계 도달 전에도 올라가고, 게임이 들어오면 0으로 돌아간다")
+	void zeroNewGamesStreak_tracksBeforeThresholdAndResets() {
+		service.trackZeroNewGames(JOB_KEY, JOB_NAME, 0, 120L);
+		assertThat(zeroNewGamesStreak()).isEqualTo(1.0);
+
+		service.trackZeroNewGames(JOB_KEY, JOB_NAME, 0, 120L);
+		assertThat(zeroNewGamesStreak()).isEqualTo(2.0);
+
+		service.trackZeroNewGames(JOB_KEY, JOB_NAME, 5, 120L);
+		assertThat(zeroNewGamesStreak()).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("실패 사유는 라벨에 들어가지 않는다 — 예외 메시지가 라벨이 되면 카디널리티가 터진다")
+	void failureReason_isNotUsedAsLabel() {
+		service.recordFailure(JOB_KEY, JOB_NAME, "reason-A", "상세");
+		service.recordFailure(JOB_KEY, JOB_NAME, "reason-B", "상세");
+
+		long seriesCount = registry.find("nar.scheduler.runs").counters().size();
+		assertThat(seriesCount).isEqualTo(1L);
+		assertThat(runs("failure")).isEqualTo(2.0);
+	}
+
+	private double runs(String outcome) {
+		return registry.counter("nar.scheduler.runs", "job", JOB_KEY, "outcome", outcome).count();
+	}
+
+	private double lastSuccessEpoch() {
+		return registry.get("nar.scheduler.last.success.epoch").tag("job", JOB_KEY).gauge().value();
+	}
+
+	private double zeroNewGamesStreak() {
+		return registry.get("nar.scheduler.zero.new.games.streak").tag("job", JOB_KEY).gauge().value();
+	}
+}


### PR DESCRIPTION
## 배경

방금 만든 개요 대시보드는 "서버가 살아있나"에는 답하지만 **"잡이 돌고 있나"에는 답하지 못한다.**

힙도 CPU도 멀쩡하고 HTTP 에러율도 0인데 CSV 인제스트가 30분째 멎어 있는 상황 — 지금 지표로는
아무것도 안 보인다. 인프라 지표만으로는 못 잡는 종류의 장애다.

## 왜 이 파일 한 곳인가

`SchedulerAlertService` 는 **모든 잡이 이미 거쳐가는 지점**이다. `recordSuccess` /
`recordFailure` / `recordWarning` / `trackZeroNewGames` 넷으로 다 모인다.

그래서 잡마다 계측을 흩뿌리지 않고 여기에만 Micrometer 를 붙였다.
**스케줄러 클래스는 하나도 안 건드렸다.**

## 지표

| 이름 | 용도 |
|---|---|
| `nar_scheduler_last_success_epoch_seconds{job}` | 마지막 성공 시각 |
| `nar_scheduler_runs_total{job,outcome}` | 성공·실패·경고 횟수 |
| `nar_scheduler_duration_seconds{job}` | 소요 시간 |
| `nar_scheduler_zero_new_games_streak{job}` | 신규 게임 0건 연속 |

`job` 값은 기존 `jobKey` 를 그대로 쓴다 — `MATCH_SYNC`, `TEAM_METADATA_SYNC`,
`YOUTUBE_SUBSCRIPTION_REFRESH`, `PLAYER_RANKED_SOLO_MONITOR` 등 10개 안쪽이라 카디널리티는 안전하다.

## 설계 판단 세 개

**1. 카운터보다 "마지막 성공 시각" 이 중요하다.**
잡이 죽으면 실행 횟수 카운터는 그냥 안 늘어서 눈에 띄지 않는다. 반면 이 게이지는
`time() - 값` 이 계속 커져서 임계치를 자동으로 넘긴다. 침묵하는 실패를 잡는 방식이 다르다.

**2. 신규 게임 0건 연속은 1회째부터 기록한다.**
디스코드 알림은 3회 연속부터 발사되지만, 상류 CSV 가 **언제부터** 밀리기 시작했는지는
그래프로 되짚어야 한다. 알림 임계와 지표 임계는 다른 문제다.

**3. 실패 사유는 라벨에 넣지 않았다.**
예외 메시지가 그대로 라벨이 되면 카디널리티가 터진다. 사유는 기존 디스코드 알림과
일일 요약이 이미 전달하므로 지표는 횟수만 센다. 이 판단을 테스트로 고정했다.

## 알림 쿼리

```promql
# 30분 주기 잡이 한 시간 넘게 성공 못 함
time() - nar_scheduler_last_success_epoch_seconds{job="MATCH_SYNC"} > 3600

# 재시작 후 한 번도 못 돈 잡 (첫 성공 전에는 시리즈가 없다)
absent(nar_scheduler_last_success_epoch_seconds{job="MATCH_SYNC"})

# 상류 CSV 정체
nar_scheduler_zero_new_games_streak > 3
```

⚠️ 첫 성공 전에는 시리즈 자체가 없다. 재시작 후 한 번도 못 돈 잡은 `time() - gauge` 로는
안 잡히고 `absent()` 로 잡아야 한다. README 에 적어뒀다.

## 검증

```
tests=4 failures=0 errors=0 skipped=0
  성공하면 카운터·타이머·마지막 성공 시각이 모두 남는다
  실패는 outcome=failure 로만 집계되고 마지막 성공 시각은 건드리지 않는다
  신규 게임 0건 연속 횟수는 임계 도달 전에도 올라가고, 게임이 들어오면 0으로 돌아간다
  실패 사유는 라벨에 들어가지 않는다 — 예외 메시지가 라벨이 되면 카디널리티가 터진다
```

## 남은 것

푸시 발송 지연(감지 → 발송)은 이 PR 범위 밖이다. 발송 경로가 스케줄러가 아니라 별도라
훅 포인트를 따로 찾아야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)